### PR TITLE
chore(schemas): refresh committed copy from promptarena

### DIFF
--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -17,53 +17,64 @@
           "type": "array"
         },
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "URL of a remote A2A server. When set, Card and Responses are ignored\nand the agent is discovered from the remote /.well-known/agent.json."
         },
         "auth": {
-          "$ref": "#/$defs/A2AAuthConfig"
+          "$ref": "#/$defs/A2AAuthConfig",
+          "description": "Auth configures authentication for remote A2A servers."
         },
         "headers": {
           "additionalProperties": {
             "type": "string"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Headers are static headers sent on every request to the remote server."
         },
         "headers_from_env": {
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "description": "HeadersFromEnv injects headers from environment variables.\nFormat: \"Header-Name=ENV_VAR_NAME\"."
         },
         "timeout_ms": {
-          "type": "integer"
+          "type": "integer",
+          "description": "TimeoutMs sets the per-request timeout in milliseconds."
         },
         "skill_filter": {
-          "$ref": "#/$defs/A2ASkillFilter"
+          "$ref": "#/$defs/A2ASkillFilter",
+          "description": "SkillFilter controls which skills from this agent are exposed."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "name"
-      ]
+      ],
+      "description": "A2AAgentConfig defines an A2A agent for Arena testing."
     },
     "A2AAuthConfig": {
       "properties": {
         "scheme": {
-          "type": "string"
+          "type": "string",
+          "description": "Scheme is the auth scheme (e.g. \"Bearer\")."
         },
         "token": {
-          "type": "string"
+          "type": "string",
+          "description": "Token is the literal token value."
         },
         "token_env": {
-          "type": "string"
+          "type": "string",
+          "description": "TokenEnv is the name of an environment variable containing the token."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "scheme"
-      ]
+      ],
+      "description": "A2AAuthConfig configures authentication for a remote A2A agent."
     },
     "A2ACardConfig": {
       "properties": {
@@ -86,7 +97,8 @@
         "name",
         "description",
         "skills"
-      ]
+      ],
+      "description": "A2ACardConfig defines the agent card for a mock A2A agent."
     },
     "A2AMatchConfig": {
       "properties": {
@@ -98,7 +110,8 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "A2AMatchConfig defines how to match incoming messages for a mock A2A agent."
     },
     "A2APartConfig": {
       "properties": {
@@ -110,7 +123,8 @@
       "type": "object",
       "required": [
         "text"
-      ]
+      ],
+      "description": "A2APartConfig defines a single response part for a mock A2A agent."
     },
     "A2AResponseConfig": {
       "properties": {
@@ -125,7 +139,8 @@
       "type": "object",
       "required": [
         "parts"
-      ]
+      ],
+      "description": "A2AResponseConfig defines the response parts for a mock A2A agent."
     },
     "A2AResponseRule": {
       "properties": {
@@ -146,7 +161,8 @@
       "type": "object",
       "required": [
         "skill"
-      ]
+      ],
+      "description": "A2AResponseRule defines a response rule for a mock A2A agent."
     },
     "A2ASkillConfig": {
       "properties": {
@@ -172,7 +188,8 @@
         "id",
         "name",
         "description"
-      ]
+      ],
+      "description": "A2ASkillConfig defines a single skill in a mock A2A agent card."
     },
     "A2ASkillFilter": {
       "properties": {
@@ -190,7 +207,8 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "A2ASkillFilter controls which skills from an A2A agent are exposed."
     },
     "AssertionConfig": {
       "properties": {
@@ -302,7 +320,8 @@
           "description": "Handler type. PromptKit-known types are suggested, but values are not restricted to this list — a different runtime may define additional types."
         },
         "params": {
-          "type": "object"
+          "type": "object",
+          "description": "Params is optional: many assertion types take no parameters, so an\nentry with only `type:` is valid and must not require an empty\n`params: {}` stub. omitempty also drops it from the schema's required set."
         },
         "message": {
           "type": "string"
@@ -311,32 +330,39 @@
           "$ref": "#/$defs/AssertionWhen"
         },
         "pass_threshold": {
-          "type": "number"
+          "type": "number",
+          "description": "PassThreshold is the minimum pass rate (0.0-1.0) required across trials.\nOnly meaningful when the parent scenario has Trials \u003e 1.\nIf unset, defaults to 1.0 (must pass every trial)."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "type"
-      ]
+      ],
+      "description": "AssertionConfig represents an assertion configuration used in arena scenarios."
     },
     "AssertionWhen": {
       "properties": {
         "tool_called": {
-          "type": "string"
+          "type": "string",
+          "description": "ToolCalled requires an exact tool name to have been called."
         },
         "tool_called_pattern": {
-          "type": "string"
+          "type": "string",
+          "description": "ToolCalledPattern is a regex that must match at least one tool name."
         },
         "any_tool_called": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "AnyToolCalled requires at least one tool to have been called."
         },
         "min_tool_calls": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MinToolCalls is the minimum number of tool calls required."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "AssertionWhen specifies preconditions that must be met for an assertion to run."
     },
     "AudioConfig": {
       "properties": {
@@ -362,14 +388,17 @@
     "AudioMonitorSection": {
       "properties": {
         "enabled": {
-          "type": "string"
+          "type": "string",
+          "description": "Enabled controls when monitoring is active. One of \"auto\", \"on\", \"off\".\nDefaults to \"auto\" when unset."
         },
         "rate": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Rate is the canonical sample rate inside the router. Must be one of\n16000, 24000, or 48000. Defaults to 24000 when unset."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "AudioMonitorSection configures real-time audio monitoring for duplex scenarios."
     },
     "ChangelogEntry": {
       "properties": {
@@ -400,25 +429,31 @@
           "items": {
             "$ref": "#/$defs/ChaosToolFailure"
           },
-          "type": "array"
+          "type": "array",
+          "description": "ToolFailures injects failures into specific tool calls."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "ChaosConfig defines fault injection rules for a turn."
     },
     "ChaosToolFailure": {
       "properties": {
         "tool": {
-          "type": "string"
+          "type": "string",
+          "description": "Tool is the name of the tool to inject failures for."
         },
         "mode": {
-          "type": "string"
+          "type": "string",
+          "description": "Mode is the type of failure: \"error\", \"timeout\", or \"slow\"."
         },
         "probability": {
-          "type": "number"
+          "type": "number",
+          "description": "Probability is the chance of failure (0.0 to 1.0, default 1.0)."
         },
         "message": {
-          "type": "string"
+          "type": "string",
+          "description": "Message is an optional custom error message."
         }
       },
       "additionalProperties": false,
@@ -426,7 +461,8 @@
       "required": [
         "tool",
         "mode"
-      ]
+      ],
+      "description": "ChaosToolFailure defines a failure injection rule for a specific tool."
     },
     "CompilationInfo": {
       "properties": {
@@ -453,95 +489,122 @@
           "items": {
             "$ref": "#/$defs/PromptConfigRef"
           },
-          "type": "array"
+          "type": "array",
+          "description": "PromptConfigs references prompt configuration files, each binding an id to a\nPromptConfig file (with optional per-file variable overrides)."
         },
         "providers": {
           "items": {
             "$ref": "#/$defs/ProviderRef"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Providers lists the LLM provider configurations (file references); the loader\nroutes each into the right role slot based on its role."
         },
         "judges": {
           "items": {
             "$ref": "#/$defs/JudgeRef"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Judges maps a judge name to a provider for LLM-as-judge assertions."
         },
         "judge_defaults": {
-          "$ref": "#/$defs/JudgeDefaults"
+          "$ref": "#/$defs/JudgeDefaults",
+          "description": "JudgeDefaults sets the default judge prompt and prompt registry used by\nLLM-as-judge assertions."
         },
         "scenarios": {
           "items": {
             "$ref": "#/$defs/ScenarioRef"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Scenarios references the test scenario files to run."
         },
         "evals": {
           "items": {
             "$ref": "#/$defs/EvalRef"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Evals references saved-conversation evaluation files."
         },
         "tools": {
           "items": {
             "$ref": "#/$defs/ToolRef"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Tools references tool (function) definition files the LLM may call."
         },
         "skills": {
           "items": {
             "$ref": "#/$defs/SkillSourceConfig"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Skills lists skill sources made available to the run."
         },
         "pack_evals": {
           "items": {
             "$ref": "#/$defs/EvalDef"
           },
-          "type": "array"
+          "type": "array",
+          "description": "PackEvals lists pack-level eval definitions."
         },
         "globals": {
-          "$ref": "#/$defs/Globals"
+          "$ref": "#/$defs/Globals",
+          "description": "Globals holds arena-level cross-cutting config that applies to\nevery scenario in addition to its own definitions. Distinct from\nDefaults (which are \"values when unspecified\") — Globals is for\n\"always-additive\" entries."
         },
         "runtime": {
-          "$ref": "#/$defs/RuntimeConfigSpec"
+          "$ref": "#/$defs/RuntimeConfigSpec",
+          "description": "Runtime carries a runtime configuration spec passed straight through to the\nruntime layer (hooks, sandboxes, …). Arena wraps the runtime, so anything\nthe runtime config supports is available here under `runtime:` without\nArena needing a bespoke field for each."
         },
-        "workflow": true,
-        "compositions": true,
-        "memory": true,
-        "agents": true,
+        "workflow": {
+          "description": "Workflow configures a workflow state machine (auto-registers the workflow tool)."
+        },
+        "compositions": {
+          "description": "Compositions configures composed multi-agent pipelines."
+        },
+        "memory": {
+          "description": "Memory configures the memory capability (auto-registers the memory tools)."
+        },
+        "agents": {
+          "description": "Agents configures named agents."
+        },
         "deploy": {
-          "$ref": "#/$defs/DeployConfig"
+          "$ref": "#/$defs/DeployConfig",
+          "description": "Deploy configures `promptarena deploy`: the target provider plus base and\nper-environment adapter config."
         },
         "mcp_servers": {
           "items": {
             "$ref": "#/$defs/MCPServerConfig"
           },
-          "type": "array"
+          "type": "array",
+          "description": "MCPServers configures MCP (Model Context Protocol) servers whose tools the\nLLM can call."
         },
         "a2a_agents": {
           "items": {
             "$ref": "#/$defs/A2AAgentConfig"
           },
-          "type": "array"
+          "type": "array",
+          "description": "A2AAgents configures agent-to-agent (A2A) endpoints."
         },
         "state_store": {
-          "$ref": "#/$defs/StateStoreConfig"
+          "$ref": "#/$defs/StateStoreConfig",
+          "description": "StateStore configures conversation state persistence (memory, redis, or file)."
         },
         "defaults": {
-          "$ref": "#/$defs/Defaults"
+          "$ref": "#/$defs/Defaults",
+          "description": "Defaults holds global defaults applied when a scenario does not specify its\nown (temperature, max_tokens, concurrency, output, fail_on, …)."
         },
         "self_play": {
-          "$ref": "#/$defs/SelfPlayConfig"
+          "$ref": "#/$defs/SelfPlayConfig",
+          "description": "SelfPlay configures self-play: personas and roles that drive the user side\nof a conversation."
         },
         "pack_file": {
-          "type": "string"
+          "type": "string",
+          "description": "PackFile is the path to a pre-compiled pack (*.pack.json) to deploy instead\nof compiling from this config."
         },
         "provider_specs": {
           "additionalProperties": {
             "$ref": "#/$defs/Provider"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Inline resource specs (alternative to file refs, merged into LoadedX during load)"
         },
         "scenario_specs": {
           "additionalProperties": {
@@ -577,7 +640,8 @@
           "items": {
             "$ref": "#/$defs/ProviderRef"
           },
-          "type": "array"
+          "type": "array",
+          "description": "TTSProviders / STTProviders / EmbeddingProviders / ImageProviders are\nthe legacy role-specific slots. They still load correctly — every\nentry's `role:` is validated against the slot — but the preferred\nshape is a single unified `providers:` list where the loader routes\neach provider into the right Loaded* map based on its `role:` value.\nMixing the legacy slots and the unified list is supported during\nmigration; both populate the same Loaded* maps."
         },
         "stt_providers": {
           "items": {
@@ -601,7 +665,8 @@
           "items": {
             "$ref": "#/$defs/VoiceBinding"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Voices binds voice IDs to loaded TTS provider IDs. Personas reference\nvoice IDs (not provider IDs) so the same persona can run against a\nreal Cartesia voice in recording mode and a mock TTS provider in CI\njust by editing this list."
         }
       },
       "additionalProperties": false,
@@ -609,7 +674,8 @@
       "required": [
         "providers",
         "defaults"
-      ]
+      ],
+      "description": "Config represents the main configuration structure"
     },
     "ContextMetadata": {
       "properties": {
@@ -624,28 +690,35 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "ContextMetadata provides structured context information for scenarios"
     },
     "ContextPolicy": {
       "properties": {
         "token_budget": {
-          "type": "integer"
+          "type": "integer",
+          "description": "TokenBudget is the maximum tokens for context (0 = unlimited)"
         },
         "reserve_for_output": {
-          "type": "integer"
+          "type": "integer",
+          "description": "ReserveForOutput reserves tokens for the response (default 4000)"
         },
         "strategy": {
-          "type": "string"
+          "type": "string",
+          "description": "Strategy is the truncation strategy: \"oldest\", \"summarize\", \"relevance\", \"fail\""
         },
         "cache_breakpoints": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "CacheBreakpoints enables Anthropic caching"
         },
         "relevance": {
-          "$ref": "#/$defs/RelevanceConfig"
+          "$ref": "#/$defs/RelevanceConfig",
+          "description": "Relevance configures embedding-based truncation when Strategy is \"relevance\""
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "ContextPolicy defines context management for a scenario"
     },
     "CostEstimate": {
       "properties": {
@@ -697,13 +770,15 @@
           "type": "integer"
         },
         "run_timeout": {
-          "type": "string"
+          "type": "string",
+          "description": "RunTimeout is the per-run timeout duration (e.g. \"5m\", \"30s\"). Defaults to 5m."
         },
         "output": {
           "$ref": "#/$defs/OutputConfig"
         },
         "config_dir": {
-          "type": "string"
+          "type": "string",
+          "description": "ConfigDir is the base directory for all config files (prompts, providers, scenarios, tools).\nIf not set, defaults to the directory containing the main config file.\nIf the main config file path is not known, defaults to current working directory."
         },
         "fail_on": {
           "items": {
@@ -715,13 +790,16 @@
           "type": "boolean"
         },
         "monitor": {
-          "$ref": "#/$defs/MonitorSection"
+          "$ref": "#/$defs/MonitorSection",
+          "description": "Monitor groups runtime-monitor configuration (audio, future surfaces)."
         },
         "inference": {
-          "$ref": "#/$defs/InferenceDefaults"
+          "$ref": "#/$defs/InferenceDefaults",
+          "description": "Inference selects which configured inference client (under\nspec.inference) serves each task when an assertion or handler doesn't\npin one explicitly. IDs reference entries in cfg.Inference."
         },
         "html_report": {
-          "type": "string"
+          "type": "string",
+          "description": "Deprecated fields for backward compatibility (will be removed)"
         },
         "out_dir": {
           "type": "string"
@@ -737,70 +815,86 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Defaults contains default configuration values"
     },
     "DeployConfig": {
       "properties": {
         "provider": {
-          "type": "string"
+          "type": "string",
+          "description": "Provider specifies the deployment provider (e.g., \"agentcore\", \"ecs\", \"k8s\")"
         },
         "config": {
-          "type": "object"
+          "type": "object",
+          "description": "Config holds provider-specific configuration (opaque to core)"
         },
         "environments": {
           "additionalProperties": {
             "$ref": "#/$defs/DeployEnvironment"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Environments defines per-environment configuration overrides"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "provider"
-      ]
+      ],
+      "description": "DeployConfig represents deployment configuration for the arena"
     },
     "DeployEnvironment": {
       "properties": {
         "config": {
-          "type": "object"
+          "type": "object",
+          "description": "Config holds environment-specific provider configuration (merged with top-level config)"
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "DeployEnvironment defines environment-specific deployment configuration"
     },
     "DuplexConfig": {
       "properties": {
         "timeout": {
-          "type": "string"
+          "type": "string",
+          "description": "Timeout is the maximum session duration (e.g., \"10m\", \"5m30s\")."
         },
         "turn_detection": {
-          "$ref": "#/$defs/TurnDetectionConfig"
+          "$ref": "#/$defs/TurnDetectionConfig",
+          "description": "TurnDetection configures how turn boundaries are detected."
         },
         "resilience": {
-          "$ref": "#/$defs/DuplexResilienceConfig"
+          "$ref": "#/$defs/DuplexResilienceConfig",
+          "description": "Resilience configures error handling and retry behavior."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "DuplexConfig enables duplex (bidirectional) streaming mode for a scenario."
     },
     "DuplexResilienceConfig": {
       "properties": {
         "max_retries": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MaxRetries is the number of retry attempts for failed turns (default: 0).\nEach retry creates a new session if the previous one ended."
         },
         "retry_delay_ms": {
-          "type": "integer"
+          "type": "integer",
+          "description": "RetryDelayMs is the delay in milliseconds between retries (default: 1000)."
         },
         "partial_success_min_turns": {
-          "type": "integer"
+          "type": "integer",
+          "description": "PartialSuccessMinTurns is the minimum completed turns to accept partial success (default: 1).\nIf the session ends unexpectedly but this many turns completed, treat as success."
         },
         "ignore_last_turn_session_end": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "IgnoreLastTurnSessionEnd treats session end on the final turn as success (default: true).\nUseful when providers may close sessions after completing the expected conversation."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "DuplexResilienceConfig configures error handling and retry behavior for duplex streaming."
     },
     "EmbeddingProviderConfig": {
       "properties": {
@@ -906,7 +1000,8 @@
       "required": [
         "description",
         "recording"
-      ]
+      ],
+      "description": "Eval describes an evaluation configuration for replaying and validating saved conversations"
     },
     "EvalAllTurnsConfig": {
       "properties": {
@@ -919,7 +1014,8 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "EvalAllTurnsConfig contains the assertions for all turns"
     },
     "EvalDef": {
       "properties": {
@@ -1086,7 +1182,8 @@
       "type": "object",
       "required": [
         "file"
-      ]
+      ],
+      "description": "EvalRef references an eval configuration file"
     },
     "EvalTurnConfig": {
       "properties": {
@@ -1096,7 +1193,8 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "EvalTurnConfig configures turn-level assertions for evaluations Uses a structure parallel to Scenario turns but with all_turns instead of role"
     },
     "EvalWhen": {
       "properties": {
@@ -1319,7 +1417,8 @@
           "type": "string"
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "Optional: relative path to fragment file"
         },
         "required": {
           "type": "boolean"
@@ -1330,7 +1429,8 @@
       "required": [
         "name",
         "required"
-      ]
+      ],
+      "description": "FragmentRef references a reusable prompt fragment Reuses the same structure as prompt.FragmentRef for consistency"
     },
     "Globals": {
       "properties": {
@@ -1338,20 +1438,24 @@
           "items": {
             "$ref": "#/$defs/AssertionConfig"
           },
-          "type": "array"
+          "type": "array",
+          "description": "ConversationAssertions are appended to every scenario's own\nconversation_assertions list at evaluation time. Useful for the\n\"DRY across scenarios\" case (e.g. capture a metric on every run).\nFor pass/fail gates that must apply to all scenarios — though if\na gate truly belongs everywhere, an eval (in pack_evals) is the\nmore honest expression."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Globals holds arena-level cross-cutting config that applies to every scenario in addition to its own definitions."
     },
     "HTMLOutputConfig": {
       "properties": {
         "file": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom HTML output file name"
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "HTMLOutputConfig contains configuration options for HTML output"
     },
     "HTTPConfig": {
       "properties": {
@@ -1505,16 +1609,19 @@
     "JSONOutputConfig": {
       "properties": {},
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "JSONOutputConfig contains configuration options for JSON output"
     },
     "JUnitOutputConfig": {
       "properties": {
         "file": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom JUnit output file name"
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "JUnitOutputConfig contains configuration options for JUnit XML output"
     },
     "JudgeDefaults": {
       "properties": {
@@ -1526,15 +1633,18 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "JudgeDefaults configures default judge prompt selection."
     },
     "JudgeRef": {
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Judge identifier used in assertions"
         },
         "provider": {
-          "type": "string"
+          "type": "string",
+          "description": "Provider ID reference (must exist in spec.providers)"
         }
       },
       "additionalProperties": false,
@@ -1542,19 +1652,22 @@
       "required": [
         "name",
         "provider"
-      ]
+      ],
+      "description": "JudgeRef references a judge configuration mapped to a provider."
     },
     "JudgeSpec": {
       "properties": {
         "provider": {
-          "type": "string"
+          "type": "string",
+          "description": "Provider ID reference"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "provider"
-      ]
+      ],
+      "description": "JudgeSpec defines an inline judge configuration."
     },
     "LoggingConfigSpec": {
       "properties": {
@@ -1698,19 +1811,24 @@
     "MarkdownConfig": {
       "properties": {
         "include_details": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Include detailed test information"
         },
         "show_overview": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Show executive overview section"
         },
         "show_results_matrix": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Show results matrix table"
         },
         "show_failed_tests": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Show failed tests section"
         },
         "show_cost_summary": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Show cost analysis section"
         }
       },
       "additionalProperties": false,
@@ -1721,27 +1839,34 @@
         "show_results_matrix",
         "show_failed_tests",
         "show_cost_summary"
-      ]
+      ],
+      "description": "Deprecated: Use MarkdownOutputConfig instead"
     },
     "MarkdownOutputConfig": {
       "properties": {
         "file": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom markdown output file name"
         },
         "include_details": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Include detailed test information"
         },
         "show_overview": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Show executive overview section"
         },
         "show_results_matrix": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Show results matrix table"
         },
         "show_failed_tests": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Show failed tests section"
         },
         "show_cost_summary": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Show cost analysis section"
         }
       },
       "additionalProperties": false,
@@ -1752,7 +1877,8 @@
         "show_results_matrix",
         "show_failed_tests",
         "show_cost_summary"
-      ]
+      ],
+      "description": "MarkdownOutputConfig contains configuration options for markdown output formatting"
     },
     "MediaConfig": {
       "properties": {
@@ -1974,7 +2100,8 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "MonitorSection groups runtime-monitor configuration."
     },
     "MultimodalConfig": {
       "properties": {
@@ -2084,7 +2211,8 @@
       "required": [
         "dir",
         "formats"
-      ]
+      ],
+      "description": "OutputConfig contains configuration for all output formats"
     },
     "ParametersPack": {
       "properties": {
@@ -2138,7 +2266,8 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "PersonaDefaults contains default LLM parameters for the persona."
     },
     "PersonaRef": {
       "properties": {
@@ -2150,27 +2279,33 @@
       "type": "object",
       "required": [
         "file"
-      ]
+      ],
+      "description": "PersonaRef references a persona file"
     },
     "PersonaStyle": {
       "properties": {
         "verbosity": {
-          "type": "string"
+          "type": "string",
+          "description": "\"short\", \"medium\", \"long\""
         },
         "challenge_level": {
-          "type": "string"
+          "type": "string",
+          "description": "\"low\", \"medium\", \"high\""
         },
         "friction_tags": {
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "description": "e.g., [\"skeptical\", \"impatient\", \"detail-oriented\"]"
         },
         "expressive": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Expressive opts the persona into TTS characterization markup. When\ntrue, [UserPersonaPack.BuildSystemPrompt] prepends a bracket-tag\nrubric (from the resolved TTS provider, or from\nCharacterizationRubric below) so the LLM emits \"[whispers]\" /\n\"[excited]\" / \"[laughs]\" etc. that downstream provider adapters\nlower into their native dialects. Default false — existing personas\nproduce byte-identical prompts."
         },
         "characterization_rubric": {
-          "type": "string"
+          "type": "string",
+          "description": "CharacterizationRubric is an optional override that replaces the\nprovider-default rubric verbatim. Only consulted when Expressive is\ntrue. Use this when a persona has unusual delivery requirements\n(custom tag examples, narrower vocabulary, alternative phrasing)."
         }
       },
       "additionalProperties": false,
@@ -2179,7 +2314,8 @@
         "verbosity",
         "challenge_level",
         "friction_tags"
-      ]
+      ],
+      "description": "PersonaStyle defines behavioral characteristics for the user persona"
     },
     "PlatformConfig": {
       "properties": {
@@ -2238,7 +2374,8 @@
       "required": [
         "id",
         "file"
-      ]
+      ],
+      "description": "PromptConfigRef references a prompt builder configuration"
     },
     "Provider": {
       "properties": {
@@ -2378,7 +2515,8 @@
       "type": "object",
       "required": [
         "file"
-      ]
+      ],
+      "description": "ProviderRef references a provider configuration file"
     },
     "Range": {
       "properties": {
@@ -2411,17 +2549,20 @@
     "RecordingConfig": {
       "properties": {
         "enabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Enable session recording"
         },
         "dir": {
-          "type": "string"
+          "type": "string",
+          "description": "Subdirectory within output.dir (default: \"recordings\")"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "enabled"
-      ]
+      ],
+      "description": "RecordingConfig contains configuration for session recording."
     },
     "RecordingSource": {
       "properties": {
@@ -2444,7 +2585,8 @@
       "type": "object",
       "required": [
         "path"
-      ]
+      ],
+      "description": "RecordingSource specifies where to load the saved conversation from"
     },
     "RedisConfig": {
       "properties": {
@@ -2473,38 +2615,48 @@
     "RelevanceConfig": {
       "properties": {
         "provider": {
-          "type": "string"
+          "type": "string",
+          "description": "Provider specifies the embedding provider: \"openai\" or \"gemini\""
         },
         "model": {
-          "type": "string"
+          "type": "string",
+          "description": "Model optionally overrides the default embedding model for the provider"
         },
         "min_recent_messages": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MinRecentMessages always keeps the N most recent messages regardless of relevance.\nDefault: 3"
         },
         "always_keep_system_role": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "AlwaysKeepSystemRole keeps all system role messages regardless of score.\nDefault: true"
         },
         "similarity_threshold": {
-          "type": "number"
+          "type": "number",
+          "description": "SimilarityThreshold is the minimum score (0.0-1.0) to consider a message relevant.\nMessages below this threshold are dropped first. Default: 0.0 (no threshold)"
         },
         "query_source": {
-          "type": "string"
+          "type": "string",
+          "description": "QuerySource determines what text to compare messages against.\nValues: \"last_user\" (default), \"last_n\", \"custom\""
         },
         "last_n_count": {
-          "type": "integer"
+          "type": "integer",
+          "description": "LastNCount is the number of messages to use when QuerySource is \"last_n\".\nDefault: 3"
         },
         "custom_query": {
-          "type": "string"
+          "type": "string",
+          "description": "CustomQuery is the query text when QuerySource is \"custom\"."
         },
         "cache_embeddings": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "CacheEmbeddings enables caching of embeddings across truncation calls.\nDefault: false"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "provider"
-      ]
+      ],
+      "description": "RelevanceConfig configures embedding-based relevance truncation."
     },
     "RequestMapping": {
       "properties": {
@@ -2745,7 +2897,8 @@
           "additionalProperties": {
             "type": "string"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Labels are key/value tags copied from the scenario manifest's metadata.labels\n(K8s-style). Used for stratified reporting in arena. Populated by LoadScenario;\nnot read from the spec body itself."
         },
         "context_metadata": {
           "$ref": "#/$defs/ContextMetadata"
@@ -2769,7 +2922,8 @@
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "description": "ProvidersOverride: If empty, uses all arena providers."
         },
         "provider_group": {
           "type": "string"
@@ -2778,25 +2932,31 @@
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "description": "RequiredCapabilities filters providers to only those supporting all listed capabilities.\nValid values: text, streaming, vision, tools, json, audio, video, documents"
         },
         "streaming": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Enable streaming for all turns by default."
         },
         "context_policy": {
-          "$ref": "#/$defs/ContextPolicy"
+          "$ref": "#/$defs/ContextPolicy",
+          "description": "Context management policy for long conversations."
         },
         "conversation_assertions": {
           "items": {
             "$ref": "#/$defs/AssertionConfig"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Assertions evaluated after the entire conversation completes."
         },
         "duplex": {
-          "$ref": "#/$defs/DuplexConfig"
+          "$ref": "#/$defs/DuplexConfig",
+          "description": "Duplex enables bidirectional streaming mode for voice/audio scenarios."
         },
         "voice": {
-          "type": "string"
+          "type": "string",
+          "description": "Voice references an arena-level voice id (see Config.Voices) used to\nsynthesize this scenario's scripted-text user turns. The duplex executor\nresolves the voice via Config.ResolveVoice.\n\nFor selfplay scenarios (turns with role: selfplay-user) the persona owns\nvoice choice; Scenario.Voice is ignored."
         },
         "variables": {
           "additionalProperties": {
@@ -2813,14 +2973,16 @@
           "items": {
             "$ref": "#/$defs/SeedMemoryEntry"
           },
-          "type": "array"
+          "type": "array",
+          "description": "SeedMemories pre-populates the memory store before the first turn.\nUses the same fields as memory__remember: content (required), type, confidence, metadata."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "description"
-      ]
+      ],
+      "description": "Scenario describes user turns, context, and validation constraints."
     },
     "ScenarioRef": {
       "properties": {
@@ -2832,7 +2994,8 @@
       "type": "object",
       "required": [
         "file"
-      ]
+      ],
+      "description": "ScenarioRef references a scenario file"
     },
     "SeedMemoryEntry": {
       "properties": {
@@ -2853,7 +3016,8 @@
       "type": "object",
       "required": [
         "content"
-      ]
+      ],
+      "description": "SeedMemoryEntry defines a memory to pre-populate before scenario execution."
     },
     "SelectorConfig": {
       "properties": {
@@ -2898,7 +3062,8 @@
     "SelfPlayConfig": {
       "properties": {
         "enabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Deprecated: Enabled is redundant — self-play is enabled whenever this section\nis present. The field is retained for backward compatibility and will be removed\nin a future release. To disable self-play, remove the self_play section entirely."
         },
         "personas": {
           "items": {
@@ -2924,7 +3089,8 @@
       "required": [
         "personas",
         "roles"
-      ]
+      ],
+      "description": "SelfPlayConfig configures self-play functionality."
     },
     "SelfPlayRoleGroup": {
       "properties": {
@@ -2932,7 +3098,8 @@
           "type": "string"
         },
         "provider": {
-          "type": "string"
+          "type": "string",
+          "description": "Provider ID reference (must exist in spec.providers)"
         }
       },
       "additionalProperties": false,
@@ -2940,7 +3107,8 @@
       "required": [
         "id",
         "provider"
-      ]
+      ],
+      "description": "SelfPlayRoleGroup defines user LLM configuration for self-play"
     },
     "SkillSourceConfig": {
       "properties": {
@@ -3238,7 +3406,8 @@
     "ToolPolicy": {
       "properties": {
         "tool_choice": {
-          "type": "string"
+          "type": "string",
+          "description": "\"auto\" | \"required\" | \"none\""
         },
         "max_tool_calls_per_turn": {
           "type": "integer"
@@ -3253,13 +3422,16 @@
           "type": "array"
         },
         "max_rounds": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MaxRounds is the maximum number of tool-call rounds per turn.\n0/unset means use the Arena default (50). Never unlimited."
         },
         "max_cost_usd": {
-          "type": "number"
+          "type": "number",
+          "description": "MaxCostUSD is the maximum cost in USD allowed per turn.\n0/unset means use the Arena default ($2.00). Never unlimited."
         },
         "max_identical_tool_calls": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MaxIdenticalToolCalls is the maximum number of times the same tool may be\ncalled with identical arguments before the loop is aborted.\n0/unset means use the Arena default (3). Never unlimited."
         }
       },
       "additionalProperties": false,
@@ -3268,7 +3440,8 @@
         "tool_choice",
         "max_tool_calls_per_turn",
         "max_total_tool_calls"
-      ]
+      ],
+      "description": "ToolPolicy defines constraints for tool usage in scenarios"
     },
     "ToolPolicyPack": {
       "properties": {
@@ -3301,7 +3474,8 @@
       "type": "object",
       "required": [
         "file"
-      ]
+      ],
+      "description": "ToolRef references a tool configuration file"
     },
     "ToolSpec": {
       "properties": {
@@ -3355,25 +3529,30 @@
     "TurnContentPart": {
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "\"text\", \"image\", \"audio\", \"video\""
         },
         "text": {
-          "type": "string"
+          "type": "string",
+          "description": "Text content (for type=text)"
         },
         "media": {
-          "$ref": "#/$defs/TurnMediaContent"
+          "$ref": "#/$defs/TurnMediaContent",
+          "description": "For media content"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "type"
-      ]
+      ],
+      "description": "TurnContentPart represents a content part in a scenario turn (simplified for YAML configuration)"
     },
     "TurnDefinition": {
       "properties": {
         "role": {
-          "type": "string"
+          "type": "string",
+          "description": "\"user\", \"assistant\", or provider selector like \"claude-user\" (only for self-play turns)"
         },
         "content": {
           "type": "string"
@@ -3382,34 +3561,43 @@
           "items": {
             "$ref": "#/$defs/TurnContentPart"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Multimodal content parts (text, images, audio, video)\nIf Parts is non-empty, it takes precedence over Content."
         },
         "persona": {
-          "type": "string"
+          "type": "string",
+          "description": "Self-play specific fields (when role is a provider selector like \"claude-user\")"
         },
         "turns": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Turns is the number of self-play exchanges. Exact count if MaxTurns absent."
         },
         "max_turns": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MaxTurns is the upper bound; enables natural termination when \u003e Turns."
         },
         "assistant_temp": {
-          "type": "number"
+          "type": "number",
+          "description": "Override assistant temperature"
         },
         "user_temp": {
-          "type": "number"
+          "type": "number",
+          "description": "Override user temperature"
         },
         "seed": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Override seed"
         },
         "streaming": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Streaming control - if nil, uses scenario-level streaming setting"
         },
         "consent_overrides": {
           "additionalProperties": {
             "type": "string"
           },
-          "type": "object"
+          "type": "object",
+          "description": "ConsentOverrides controls consent simulation for client-side tools.\nKeys are tool names, values are \"grant\", \"deny\", or \"timeout\"."
         },
         "perturbations": {
           "additionalProperties": {
@@ -3418,65 +3606,80 @@
             },
             "type": "array"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Perturbations define variable substitutions for behavioral testing.\nEach key is a placeholder name (e.g., \"city\") and the value is a list of variants.\nThe engine expands each variant into a separate trial, substituting {key} in Content."
         },
         "chaos": {
-          "$ref": "#/$defs/ChaosConfig"
+          "$ref": "#/$defs/ChaosConfig",
+          "description": "Chaos configures fault injection for resilience testing."
         },
         "assertions": {
           "items": {
             "$ref": "#/$defs/AssertionConfig"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Turn-level assertions (for testing only)"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "role"
-      ]
+      ],
+      "description": "TurnDefinition represents a single conversation turn definition"
     },
     "TurnDetectionConfig": {
       "properties": {
         "mode": {
-          "type": "string"
+          "type": "string",
+          "description": "Mode specifies the turn detection method: \"vad\" (voice activity detection) or \"asm\" (provider-native)."
         },
         "vad": {
-          "$ref": "#/$defs/VADConfig"
+          "$ref": "#/$defs/VADConfig",
+          "description": "VAD contains voice activity detection settings (used when Mode is \"vad\")."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "TurnDetectionConfig configures turn detection for duplex mode."
     },
     "TurnMediaContent": {
       "properties": {
         "file_path": {
-          "type": "string"
+          "type": "string",
+          "description": "Relative path to media file (resolved at test time)"
         },
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "External URL (http/https)"
         },
         "data": {
-          "type": "string"
+          "type": "string",
+          "description": "Base64-encoded data (for inline media)"
         },
         "storage_reference": {
-          "type": "string"
+          "type": "string",
+          "description": "Storage backend reference (for externalized media)"
         },
         "mime_type": {
-          "type": "string"
+          "type": "string",
+          "description": "MIME type (e.g., \"image/jpeg\")"
         },
         "detail": {
-          "type": "string"
+          "type": "string",
+          "description": "Detail level for images: \"low\", \"high\", \"auto\""
         },
         "caption": {
-          "type": "string"
+          "type": "string",
+          "description": "Optional caption/description"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "mime_type"
-      ]
+      ],
+      "description": "TurnMediaContent represents media content in a turn definition"
     },
     "UserPersonaPack": {
       "properties": {
@@ -3487,31 +3690,37 @@
           "type": "string"
         },
         "prompt_activity": {
-          "type": "string"
+          "type": "string",
+          "description": "DEPRECATED: Legacy prompt builder reference"
         },
         "fragments": {
           "items": {
             "$ref": "#/$defs/FragmentRef"
           },
-          "type": "array"
+          "type": "array",
+          "description": "NEW: Template system (preferred)"
         },
         "system_template": {
-          "type": "string"
+          "type": "string",
+          "description": "Template with {{variables}}"
         },
         "required_vars": {
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Variables that must be provided"
         },
         "optional_vars": {
           "additionalProperties": {
             "type": "string"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Variables with default values"
         },
         "system_prompt": {
-          "type": "string"
+          "type": "string",
+          "description": "LEGACY: Backward compatibility"
         },
         "goals": {
           "items": {
@@ -3529,7 +3738,8 @@
           "$ref": "#/$defs/PersonaStyle"
         },
         "voice": {
-          "type": "string"
+          "type": "string",
+          "description": "Voice references an arena-level voice id (see Config.Voices). When\nset, selfplay synthesis routes this persona's text through the bound\nTTS provider. Empty means the arena falls back to its default voice\nor fails fast if no default is configured."
         },
         "defaults": {
           "$ref": "#/$defs/PersonaDefaults"
@@ -3541,22 +3751,27 @@
         "description",
         "goals",
         "constraints"
-      ]
+      ],
+      "description": "UserPersonaPack defines how the User LLM behaves in self-play scenarios"
     },
     "VADConfig": {
       "properties": {
         "silence_threshold_ms": {
-          "type": "integer"
+          "type": "integer",
+          "description": "SilenceThresholdMs is the silence duration in milliseconds to trigger turn end (default: 500)."
         },
         "min_speech_ms": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MinSpeechMs is the minimum speech duration before silence counts (default: 1000)."
         },
         "max_turn_duration_s": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MaxTurnDurationS forces turn end after this duration in seconds (default: 60)."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "VADConfig configures voice activity detection for turn detection."
     },
     "ValidatorConfig": {
       "properties": {

--- a/schemas/v1alpha1/eval.json
+++ b/schemas/v1alpha1/eval.json
@@ -112,7 +112,8 @@
           "description": "Handler type. PromptKit-known types are suggested, but values are not restricted to this list — a different runtime may define additional types."
         },
         "params": {
-          "type": "object"
+          "type": "object",
+          "description": "Params is optional: many assertion types take no parameters, so an\nentry with only `type:` is valid and must not require an empty\n`params: {}` stub. omitempty also drops it from the schema's required set."
         },
         "message": {
           "type": "string"
@@ -121,32 +122,39 @@
           "$ref": "#/$defs/AssertionWhen"
         },
         "pass_threshold": {
-          "type": "number"
+          "type": "number",
+          "description": "PassThreshold is the minimum pass rate (0.0-1.0) required across trials.\nOnly meaningful when the parent scenario has Trials \u003e 1.\nIf unset, defaults to 1.0 (must pass every trial)."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "type"
-      ]
+      ],
+      "description": "AssertionConfig represents an assertion configuration used in arena scenarios."
     },
     "AssertionWhen": {
       "properties": {
         "tool_called": {
-          "type": "string"
+          "type": "string",
+          "description": "ToolCalled requires an exact tool name to have been called."
         },
         "tool_called_pattern": {
-          "type": "string"
+          "type": "string",
+          "description": "ToolCalledPattern is a regex that must match at least one tool name."
         },
         "any_tool_called": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "AnyToolCalled requires at least one tool to have been called."
         },
         "min_tool_calls": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MinToolCalls is the minimum number of tool calls required."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "AssertionWhen specifies preconditions that must be met for an assertion to run."
     },
     "Eval": {
       "properties": {
@@ -202,7 +210,8 @@
       "required": [
         "description",
         "recording"
-      ]
+      ],
+      "description": "Eval describes an evaluation configuration for replaying and validating saved conversations"
     },
     "EvalAllTurnsConfig": {
       "properties": {
@@ -215,7 +224,8 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "EvalAllTurnsConfig contains the assertions for all turns"
     },
     "EvalTurnConfig": {
       "properties": {
@@ -225,7 +235,8 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "EvalTurnConfig configures turn-level assertions for evaluations Uses a structure parallel to Scenario turns but with all_turns instead of role"
     },
     "ObjectMeta": {
       "properties": {
@@ -280,7 +291,8 @@
       "type": "object",
       "required": [
         "path"
-      ]
+      ],
+      "description": "RecordingSource specifies where to load the saved conversation from"
     }
   },
   "properties": {

--- a/schemas/v1alpha1/persona.json
+++ b/schemas/v1alpha1/persona.json
@@ -8,7 +8,8 @@
           "type": "string"
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "Optional: relative path to fragment file"
         },
         "required": {
           "type": "boolean"
@@ -19,7 +20,8 @@
       "required": [
         "name",
         "required"
-      ]
+      ],
+      "description": "FragmentRef references a reusable prompt fragment Reuses the same structure as prompt.FragmentRef for consistency"
     },
     "ObjectMeta": {
       "properties": {
@@ -63,27 +65,33 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "PersonaDefaults contains default LLM parameters for the persona."
     },
     "PersonaStyle": {
       "properties": {
         "verbosity": {
-          "type": "string"
+          "type": "string",
+          "description": "\"short\", \"medium\", \"long\""
         },
         "challenge_level": {
-          "type": "string"
+          "type": "string",
+          "description": "\"low\", \"medium\", \"high\""
         },
         "friction_tags": {
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "description": "e.g., [\"skeptical\", \"impatient\", \"detail-oriented\"]"
         },
         "expressive": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Expressive opts the persona into TTS characterization markup. When\ntrue, [UserPersonaPack.BuildSystemPrompt] prepends a bracket-tag\nrubric (from the resolved TTS provider, or from\nCharacterizationRubric below) so the LLM emits \"[whispers]\" /\n\"[excited]\" / \"[laughs]\" etc. that downstream provider adapters\nlower into their native dialects. Default false — existing personas\nproduce byte-identical prompts."
         },
         "characterization_rubric": {
-          "type": "string"
+          "type": "string",
+          "description": "CharacterizationRubric is an optional override that replaces the\nprovider-default rubric verbatim. Only consulted when Expressive is\ntrue. Use this when a persona has unusual delivery requirements\n(custom tag examples, narrower vocabulary, alternative phrasing)."
         }
       },
       "additionalProperties": false,
@@ -92,7 +100,8 @@
         "verbosity",
         "challenge_level",
         "friction_tags"
-      ]
+      ],
+      "description": "PersonaStyle defines behavioral characteristics for the user persona"
     },
     "UserPersonaPack": {
       "properties": {
@@ -103,31 +112,37 @@
           "type": "string"
         },
         "prompt_activity": {
-          "type": "string"
+          "type": "string",
+          "description": "DEPRECATED: Legacy prompt builder reference"
         },
         "fragments": {
           "items": {
             "$ref": "#/$defs/FragmentRef"
           },
-          "type": "array"
+          "type": "array",
+          "description": "NEW: Template system (preferred)"
         },
         "system_template": {
-          "type": "string"
+          "type": "string",
+          "description": "Template with {{variables}}"
         },
         "required_vars": {
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Variables that must be provided"
         },
         "optional_vars": {
           "additionalProperties": {
             "type": "string"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Variables with default values"
         },
         "system_prompt": {
-          "type": "string"
+          "type": "string",
+          "description": "LEGACY: Backward compatibility"
         },
         "goals": {
           "items": {
@@ -145,7 +160,8 @@
           "$ref": "#/$defs/PersonaStyle"
         },
         "voice": {
-          "type": "string"
+          "type": "string",
+          "description": "Voice references an arena-level voice id (see Config.Voices). When\nset, selfplay synthesis routes this persona's text through the bound\nTTS provider. Empty means the arena falls back to its default voice\nor fails fast if no default is configured."
         },
         "defaults": {
           "$ref": "#/$defs/PersonaDefaults"
@@ -157,7 +173,8 @@
         "description",
         "goals",
         "constraints"
-      ]
+      ],
+      "description": "UserPersonaPack defines how the User LLM behaves in self-play scenarios"
     }
   },
   "properties": {

--- a/schemas/v1alpha1/scenario.json
+++ b/schemas/v1alpha1/scenario.json
@@ -112,7 +112,8 @@
           "description": "Handler type. PromptKit-known types are suggested, but values are not restricted to this list — a different runtime may define additional types."
         },
         "params": {
-          "type": "object"
+          "type": "object",
+          "description": "Params is optional: many assertion types take no parameters, so an\nentry with only `type:` is valid and must not require an empty\n`params: {}` stub. omitempty also drops it from the schema's required set."
         },
         "message": {
           "type": "string"
@@ -121,32 +122,39 @@
           "$ref": "#/$defs/AssertionWhen"
         },
         "pass_threshold": {
-          "type": "number"
+          "type": "number",
+          "description": "PassThreshold is the minimum pass rate (0.0-1.0) required across trials.\nOnly meaningful when the parent scenario has Trials \u003e 1.\nIf unset, defaults to 1.0 (must pass every trial)."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "type"
-      ]
+      ],
+      "description": "AssertionConfig represents an assertion configuration used in arena scenarios."
     },
     "AssertionWhen": {
       "properties": {
         "tool_called": {
-          "type": "string"
+          "type": "string",
+          "description": "ToolCalled requires an exact tool name to have been called."
         },
         "tool_called_pattern": {
-          "type": "string"
+          "type": "string",
+          "description": "ToolCalledPattern is a regex that must match at least one tool name."
         },
         "any_tool_called": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "AnyToolCalled requires at least one tool to have been called."
         },
         "min_tool_calls": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MinToolCalls is the minimum number of tool calls required."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "AssertionWhen specifies preconditions that must be met for an assertion to run."
     },
     "ChaosConfig": {
       "properties": {
@@ -154,25 +162,31 @@
           "items": {
             "$ref": "#/$defs/ChaosToolFailure"
           },
-          "type": "array"
+          "type": "array",
+          "description": "ToolFailures injects failures into specific tool calls."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "ChaosConfig defines fault injection rules for a turn."
     },
     "ChaosToolFailure": {
       "properties": {
         "tool": {
-          "type": "string"
+          "type": "string",
+          "description": "Tool is the name of the tool to inject failures for."
         },
         "mode": {
-          "type": "string"
+          "type": "string",
+          "description": "Mode is the type of failure: \"error\", \"timeout\", or \"slow\"."
         },
         "probability": {
-          "type": "number"
+          "type": "number",
+          "description": "Probability is the chance of failure (0.0 to 1.0, default 1.0)."
         },
         "message": {
-          "type": "string"
+          "type": "string",
+          "description": "Message is an optional custom error message."
         }
       },
       "additionalProperties": false,
@@ -180,7 +194,8 @@
       "required": [
         "tool",
         "mode"
-      ]
+      ],
+      "description": "ChaosToolFailure defines a failure injection rule for a specific tool."
     },
     "ContextMetadata": {
       "properties": {
@@ -195,61 +210,77 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "ContextMetadata provides structured context information for scenarios"
     },
     "ContextPolicy": {
       "properties": {
         "token_budget": {
-          "type": "integer"
+          "type": "integer",
+          "description": "TokenBudget is the maximum tokens for context (0 = unlimited)"
         },
         "reserve_for_output": {
-          "type": "integer"
+          "type": "integer",
+          "description": "ReserveForOutput reserves tokens for the response (default 4000)"
         },
         "strategy": {
-          "type": "string"
+          "type": "string",
+          "description": "Strategy is the truncation strategy: \"oldest\", \"summarize\", \"relevance\", \"fail\""
         },
         "cache_breakpoints": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "CacheBreakpoints enables Anthropic caching"
         },
         "relevance": {
-          "$ref": "#/$defs/RelevanceConfig"
+          "$ref": "#/$defs/RelevanceConfig",
+          "description": "Relevance configures embedding-based truncation when Strategy is \"relevance\""
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "ContextPolicy defines context management for a scenario"
     },
     "DuplexConfig": {
       "properties": {
         "timeout": {
-          "type": "string"
+          "type": "string",
+          "description": "Timeout is the maximum session duration (e.g., \"10m\", \"5m30s\")."
         },
         "turn_detection": {
-          "$ref": "#/$defs/TurnDetectionConfig"
+          "$ref": "#/$defs/TurnDetectionConfig",
+          "description": "TurnDetection configures how turn boundaries are detected."
         },
         "resilience": {
-          "$ref": "#/$defs/DuplexResilienceConfig"
+          "$ref": "#/$defs/DuplexResilienceConfig",
+          "description": "Resilience configures error handling and retry behavior."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "DuplexConfig enables duplex (bidirectional) streaming mode for a scenario."
     },
     "DuplexResilienceConfig": {
       "properties": {
         "max_retries": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MaxRetries is the number of retry attempts for failed turns (default: 0).\nEach retry creates a new session if the previous one ended."
         },
         "retry_delay_ms": {
-          "type": "integer"
+          "type": "integer",
+          "description": "RetryDelayMs is the delay in milliseconds between retries (default: 1000)."
         },
         "partial_success_min_turns": {
-          "type": "integer"
+          "type": "integer",
+          "description": "PartialSuccessMinTurns is the minimum completed turns to accept partial success (default: 1).\nIf the session ends unexpectedly but this many turns completed, treat as success."
         },
         "ignore_last_turn_session_end": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "IgnoreLastTurnSessionEnd treats session end on the final turn as success (default: true).\nUseful when providers may close sessions after completing the expected conversation."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "DuplexResilienceConfig configures error handling and retry behavior for duplex streaming."
     },
     "ObjectMeta": {
       "properties": {
@@ -286,38 +317,48 @@
     "RelevanceConfig": {
       "properties": {
         "provider": {
-          "type": "string"
+          "type": "string",
+          "description": "Provider specifies the embedding provider: \"openai\" or \"gemini\""
         },
         "model": {
-          "type": "string"
+          "type": "string",
+          "description": "Model optionally overrides the default embedding model for the provider"
         },
         "min_recent_messages": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MinRecentMessages always keeps the N most recent messages regardless of relevance.\nDefault: 3"
         },
         "always_keep_system_role": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "AlwaysKeepSystemRole keeps all system role messages regardless of score.\nDefault: true"
         },
         "similarity_threshold": {
-          "type": "number"
+          "type": "number",
+          "description": "SimilarityThreshold is the minimum score (0.0-1.0) to consider a message relevant.\nMessages below this threshold are dropped first. Default: 0.0 (no threshold)"
         },
         "query_source": {
-          "type": "string"
+          "type": "string",
+          "description": "QuerySource determines what text to compare messages against.\nValues: \"last_user\" (default), \"last_n\", \"custom\""
         },
         "last_n_count": {
-          "type": "integer"
+          "type": "integer",
+          "description": "LastNCount is the number of messages to use when QuerySource is \"last_n\".\nDefault: 3"
         },
         "custom_query": {
-          "type": "string"
+          "type": "string",
+          "description": "CustomQuery is the query text when QuerySource is \"custom\"."
         },
         "cache_embeddings": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "CacheEmbeddings enables caching of embeddings across truncation calls.\nDefault: false"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "provider"
-      ]
+      ],
+      "description": "RelevanceConfig configures embedding-based relevance truncation."
     },
     "Scenario": {
       "oneOf": [
@@ -353,7 +394,8 @@
           "additionalProperties": {
             "type": "string"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Labels are key/value tags copied from the scenario manifest's metadata.labels\n(K8s-style). Used for stratified reporting in arena. Populated by LoadScenario;\nnot read from the spec body itself."
         },
         "context_metadata": {
           "$ref": "#/$defs/ContextMetadata"
@@ -377,7 +419,8 @@
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "description": "ProvidersOverride: If empty, uses all arena providers."
         },
         "provider_group": {
           "type": "string"
@@ -386,25 +429,31 @@
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "description": "RequiredCapabilities filters providers to only those supporting all listed capabilities.\nValid values: text, streaming, vision, tools, json, audio, video, documents"
         },
         "streaming": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Enable streaming for all turns by default."
         },
         "context_policy": {
-          "$ref": "#/$defs/ContextPolicy"
+          "$ref": "#/$defs/ContextPolicy",
+          "description": "Context management policy for long conversations."
         },
         "conversation_assertions": {
           "items": {
             "$ref": "#/$defs/AssertionConfig"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Assertions evaluated after the entire conversation completes."
         },
         "duplex": {
-          "$ref": "#/$defs/DuplexConfig"
+          "$ref": "#/$defs/DuplexConfig",
+          "description": "Duplex enables bidirectional streaming mode for voice/audio scenarios."
         },
         "voice": {
-          "type": "string"
+          "type": "string",
+          "description": "Voice references an arena-level voice id (see Config.Voices) used to\nsynthesize this scenario's scripted-text user turns. The duplex executor\nresolves the voice via Config.ResolveVoice.\n\nFor selfplay scenarios (turns with role: selfplay-user) the persona owns\nvoice choice; Scenario.Voice is ignored."
         },
         "variables": {
           "additionalProperties": {
@@ -421,14 +470,16 @@
           "items": {
             "$ref": "#/$defs/SeedMemoryEntry"
           },
-          "type": "array"
+          "type": "array",
+          "description": "SeedMemories pre-populates the memory store before the first turn.\nUses the same fields as memory__remember: content (required), type, confidence, metadata."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "description"
-      ]
+      ],
+      "description": "Scenario describes user turns, context, and validation constraints."
     },
     "SeedMemoryEntry": {
       "properties": {
@@ -449,12 +500,14 @@
       "type": "object",
       "required": [
         "content"
-      ]
+      ],
+      "description": "SeedMemoryEntry defines a memory to pre-populate before scenario execution."
     },
     "ToolPolicy": {
       "properties": {
         "tool_choice": {
-          "type": "string"
+          "type": "string",
+          "description": "\"auto\" | \"required\" | \"none\""
         },
         "max_tool_calls_per_turn": {
           "type": "integer"
@@ -469,13 +522,16 @@
           "type": "array"
         },
         "max_rounds": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MaxRounds is the maximum number of tool-call rounds per turn.\n0/unset means use the Arena default (50). Never unlimited."
         },
         "max_cost_usd": {
-          "type": "number"
+          "type": "number",
+          "description": "MaxCostUSD is the maximum cost in USD allowed per turn.\n0/unset means use the Arena default ($2.00). Never unlimited."
         },
         "max_identical_tool_calls": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MaxIdenticalToolCalls is the maximum number of times the same tool may be\ncalled with identical arguments before the loop is aborted.\n0/unset means use the Arena default (3). Never unlimited."
         }
       },
       "additionalProperties": false,
@@ -484,30 +540,36 @@
         "tool_choice",
         "max_tool_calls_per_turn",
         "max_total_tool_calls"
-      ]
+      ],
+      "description": "ToolPolicy defines constraints for tool usage in scenarios"
     },
     "TurnContentPart": {
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "\"text\", \"image\", \"audio\", \"video\""
         },
         "text": {
-          "type": "string"
+          "type": "string",
+          "description": "Text content (for type=text)"
         },
         "media": {
-          "$ref": "#/$defs/TurnMediaContent"
+          "$ref": "#/$defs/TurnMediaContent",
+          "description": "For media content"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "type"
-      ]
+      ],
+      "description": "TurnContentPart represents a content part in a scenario turn (simplified for YAML configuration)"
     },
     "TurnDefinition": {
       "properties": {
         "role": {
-          "type": "string"
+          "type": "string",
+          "description": "\"user\", \"assistant\", or provider selector like \"claude-user\" (only for self-play turns)"
         },
         "content": {
           "type": "string"
@@ -516,34 +578,43 @@
           "items": {
             "$ref": "#/$defs/TurnContentPart"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Multimodal content parts (text, images, audio, video)\nIf Parts is non-empty, it takes precedence over Content."
         },
         "persona": {
-          "type": "string"
+          "type": "string",
+          "description": "Self-play specific fields (when role is a provider selector like \"claude-user\")"
         },
         "turns": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Turns is the number of self-play exchanges. Exact count if MaxTurns absent."
         },
         "max_turns": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MaxTurns is the upper bound; enables natural termination when \u003e Turns."
         },
         "assistant_temp": {
-          "type": "number"
+          "type": "number",
+          "description": "Override assistant temperature"
         },
         "user_temp": {
-          "type": "number"
+          "type": "number",
+          "description": "Override user temperature"
         },
         "seed": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Override seed"
         },
         "streaming": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Streaming control - if nil, uses scenario-level streaming setting"
         },
         "consent_overrides": {
           "additionalProperties": {
             "type": "string"
           },
-          "type": "object"
+          "type": "object",
+          "description": "ConsentOverrides controls consent simulation for client-side tools.\nKeys are tool names, values are \"grant\", \"deny\", or \"timeout\"."
         },
         "perturbations": {
           "additionalProperties": {
@@ -552,80 +623,99 @@
             },
             "type": "array"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Perturbations define variable substitutions for behavioral testing.\nEach key is a placeholder name (e.g., \"city\") and the value is a list of variants.\nThe engine expands each variant into a separate trial, substituting {key} in Content."
         },
         "chaos": {
-          "$ref": "#/$defs/ChaosConfig"
+          "$ref": "#/$defs/ChaosConfig",
+          "description": "Chaos configures fault injection for resilience testing."
         },
         "assertions": {
           "items": {
             "$ref": "#/$defs/AssertionConfig"
           },
-          "type": "array"
+          "type": "array",
+          "description": "Turn-level assertions (for testing only)"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "role"
-      ]
+      ],
+      "description": "TurnDefinition represents a single conversation turn definition"
     },
     "TurnDetectionConfig": {
       "properties": {
         "mode": {
-          "type": "string"
+          "type": "string",
+          "description": "Mode specifies the turn detection method: \"vad\" (voice activity detection) or \"asm\" (provider-native)."
         },
         "vad": {
-          "$ref": "#/$defs/VADConfig"
+          "$ref": "#/$defs/VADConfig",
+          "description": "VAD contains voice activity detection settings (used when Mode is \"vad\")."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "TurnDetectionConfig configures turn detection for duplex mode."
     },
     "TurnMediaContent": {
       "properties": {
         "file_path": {
-          "type": "string"
+          "type": "string",
+          "description": "Relative path to media file (resolved at test time)"
         },
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "External URL (http/https)"
         },
         "data": {
-          "type": "string"
+          "type": "string",
+          "description": "Base64-encoded data (for inline media)"
         },
         "storage_reference": {
-          "type": "string"
+          "type": "string",
+          "description": "Storage backend reference (for externalized media)"
         },
         "mime_type": {
-          "type": "string"
+          "type": "string",
+          "description": "MIME type (e.g., \"image/jpeg\")"
         },
         "detail": {
-          "type": "string"
+          "type": "string",
+          "description": "Detail level for images: \"low\", \"high\", \"auto\""
         },
         "caption": {
-          "type": "string"
+          "type": "string",
+          "description": "Optional caption/description"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
         "mime_type"
-      ]
+      ],
+      "description": "TurnMediaContent represents media content in a turn definition"
     },
     "VADConfig": {
       "properties": {
         "silence_threshold_ms": {
-          "type": "integer"
+          "type": "integer",
+          "description": "SilenceThresholdMs is the silence duration in milliseconds to trigger turn end (default: 500)."
         },
         "min_speech_ms": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MinSpeechMs is the minimum speech duration before silence counts (default: 1000)."
         },
         "max_turn_duration_s": {
-          "type": "integer"
+          "type": "integer",
+          "description": "MaxTurnDurationS forces turn end after this duration in seconds (default: 60)."
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "VADConfig configures voice activity detection for turn detection."
     }
   },
   "properties": {


### PR DESCRIPTION
## What

Re-runs `make schemas` to refresh the committed copy of `schemas/v1alpha1` from promptarena, the schema owner. Fixes the failing **Validate JSON Schemas** check, which is currently red on `main`.

## Why it drifted

| | |
|---|---|
| `2026-06-20` (`b2bc77e4`) | last promptkit commit touching `schemas/v1alpha1/` — copy frozen here |
| `2026-07-08` (promptarena `4f0c20ae`, PR #31) | promptarena regenerated with doc-comment → `description` emission, for its TUI schema-autocomplete feature |

PromptKit never re-fetched, so the committed copy sat ~3 weeks stale.

## The diff is descriptions-only

Four files change: `arena.json`, `eval.json`, `persona.json`, `scenario.json`. Verified structurally by stripping every `description` key and re-diffing:

| File | Non-description differences |
|---|---|
| `eval.json` | 0 |
| `persona.json` | 0 |
| `scenario.json` | 0 |
| `arena.json` | 4, all cosmetic |

The four in `arena.json` are `$defs.Config.properties.{agents,workflow,memory,compositions}` going from `true` to `{"description": "..."}`. In JSON Schema a boolean `true` and `{}` are the same "accept anything" schema, so **validation behaviour is unchanged**. Nothing was added, removed, retyped, or made required.

## Impact was nil

The docs site fetches schemas fresh at build time rather than serving the committed copy, so `promptkit.altairalabs.ai/schemas/v1alpha1/` was **already** serving the current version — 329 `description` values, matching upstream exactly. Downstream consumers (packc, promptarena's validator, the TUI) were never affected. Only the in-tree artifact was stale, and since the delta is descriptions-only, `pkg/config`'s validator behaved identically against it too.

## Verification

```
make schemas-check          ✓ Schemas are in sync with promptarena
go test ./pkg/config/...    159 passed
go test ./runtime/prompt/…  406 passed
```

## Follow-up

This drift was invisible by construction: `schemas.yml` triggers only on promptkit-side paths (`schemas/**/*.json`, `scripts/fetch-schemas.sh`, `runtime/prompt/schema/**`, `.github/workflows/schemas.yml`) and has no `schedule:`, so it cannot fire when promptarena regenerates upstream. It only surfaced here because a dependabot `actions/checkout` bump (#1688) happened to touch `schemas.yml`. Tracked separately in the issue linked below.

---

Follow-up on the detection gap: #1700
