### PR TITLE
ci(schemas): run the drift check on a schedule

### DIFF
--- a/.github/workflows/schemas.yml
+++ b/.github/workflows/schemas.yml
@@ -1,6 +1,14 @@
 name: Schema Validation
 
 on:
+  # The path filters below only fire on OUR edits. Drift is caused by the
+  # upstream repos regenerating (promptarena for schemas/v1alpha1, promptpack.org
+  # for the embedded PromptPack schema), which touches nothing here — so without
+  # a scheduled run this workflow is blind to the exact failure it exists to
+  # catch. See #1700.
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
   push:
     branches: [ main ]
     paths:


### PR DESCRIPTION
## What

Adds a daily `schedule:` trigger and `workflow_dispatch` to `schemas.yml`.

```diff
 on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
   push:
     branches: [ main ]
     paths: ...
```

## Why

The workflow's path filters only fire on **promptkit-side** edits:

```yaml
paths:
  - 'schemas/**/*.json'
  - 'scripts/fetch-schemas.sh'
  - 'runtime/prompt/schema/**'
  - '.github/workflows/schemas.yml'
```

But drift is caused by the **upstream** repos regenerating — promptarena for `schemas/v1alpha1`, promptpack.org for the embedded PromptPack schema — which touches none of those paths. The check was blind to the one failure mode it exists to catch.

Not hypothetical: promptarena regenerated on 2026-07-08 and the committed copy sat stale for three weeks with fully green CI. It surfaced on 2026-07-28 only because a dependabot `actions/checkout` bump (#1688) happened to touch `schemas.yml` and incidentally tripped the path filter. Refreshed in #1699; this closes the gap so the next regeneration is caught within a day rather than by luck.

## Notes

- Scheduled runs execute against the default branch, so a failure means `main` has drifted — which is exactly the signal we want.
- This also puts the `check-promptpack-schema` job on the schedule. That job only emits a non-blocking `::warning::`, so on a cron it will now *report* PromptPack drift without gating anything. Whether it should become a hard gate is a separate call, deliberately not made here.
- `workflow_dispatch` added so the check can be run on demand without pushing a no-op commit.

## Verification

```
actionlint .github/workflows/schemas.yml    clean
python3 -c "yaml.safe_load(...)"            parses; triggers = [schedule, workflow_dispatch, push, pull_request]
```

The PR itself touches `.github/workflows/schemas.yml`, so it trips the existing path filter and the real check runs on this PR.

Closes #1700
