### PR TITLE
docs(examples): correct stale prerequisites and repo layout

### DIFF
--- a/docs/src/components/landing/RepoStructure.astro
+++ b/docs/src/components/landing/RepoStructure.astro
@@ -4,7 +4,8 @@ const entries = [
   { dir: 'sdk/', desc: 'Developer SDK — Open, Send, Stream, options, capabilities.' },
   { dir: 'pkg/', desc: 'Shared packages — config and schema validation.' },
   { dir: 'server/a2a/', desc: 'The A2A protocol server module.' },
-  { dir: 'examples/', desc: 'Runnable example projects and SDK usage.' },
+  { dir: 'sdk/examples/', desc: 'Runnable example projects and SDK usage.' },
+  { dir: 'schemas/', desc: 'JSON schemas, hosted at promptkit.altairalabs.ai.' },
   { dir: 'docs/', desc: 'This Starlight documentation site.' },
 ];
 ---
@@ -36,9 +37,11 @@ const entries = [
 │   ├── workflow/  <span class="cmt"># state machines</span>
 │   └── types/     <span class="cmt"># messages · content parts</span>
 ├── <span class="dir">sdk/</span>          <span class="cmt"># Open() · Send() · Stream()</span>
+│   └── examples/  <span class="cmt"># runnable SDK examples</span>
 ├── <span class="dir">pkg/</span>          <span class="cmt"># config · schema validation</span>
 ├── <span class="dir">server/a2a/</span>   <span class="cmt"># A2A protocol server</span>
-├── <span class="dir">examples/</span>     <span class="cmt"># runnable SDK examples</span>
+├── <span class="dir">schemas/</span>      <span class="cmt"># JSON schemas (hosted)</span>
+├── <span class="dir">benchmarks/</span>   <span class="cmt"># vs LangChain · Vercel AI · Strands</span>
 └── <span class="dir">docs/</span>         <span class="cmt"># this site</span></code></pre>
   </div>
 </section>

--- a/docs/src/content/docs/contributors/contributing.md
+++ b/docs/src/content/docs/contributors/contributing.md
@@ -98,7 +98,10 @@ PromptKit/
 ├── runtime/          # Core runtime components
 ├── pkg/              # Shared packages
 ├── sdk/              # PromptKit SDK
-├── examples/         # Example configurations
+│   └── examples/     # Runnable SDK examples
+├── server/a2a/       # A2A protocol server module
+├── schemas/          # JSON schemas (hosted)
+├── benchmarks/       # Framework comparison benchmarks
 └── docs/             # Documentation
 ```
 
@@ -129,7 +132,7 @@ cd sdk && go test ./...
 cd sdk && go test -tags=integration ./...
 
 # Test with examples
-cd examples/customer-support && go run main.go
+cd sdk/examples/hello && go run .
 ```
 
 ### Runtime (`runtime/`)

--- a/sdk/examples/a2a-agent/README.md
+++ b/sdk/examples/a2a-agent/README.md
@@ -12,8 +12,8 @@ Connect to remote A2A (Agent-to-Agent) agents with authentication via the Prompt
 
 ## Prerequisites
 
-- Go 1.21+
-- OpenAI API key
+- Go 1.26+
+- An API key for one of: OpenAI, Anthropic, or Google (the packs do not pin a provider)
 - A running A2A agent (this example uses the echo server from `server/a2a/examples/a2a-auth-test`)
 
 ## Running the Example

--- a/sdk/examples/hello/README.md
+++ b/sdk/examples/hello/README.md
@@ -11,13 +11,21 @@ The simplest SDK example - open a conversation and send a message.
 
 ## Prerequisites
 
-- Go 1.21+
-- OpenAI API key
+- Go 1.26+
+- An API key for one of: OpenAI, Anthropic, or Google
 
 ## Running the Example
 
+The pack does not name a provider — the SDK detects one from the environment,
+so any of these works:
+
 ```bash
-export OPENAI_API_KEY=your-key
+export OPENAI_API_KEY=your-key       # uses gpt-4o
+# or
+export ANTHROPIC_API_KEY=your-key
+# or
+export GOOGLE_API_KEY=your-key
+
 go run .
 ```
 
@@ -48,8 +56,10 @@ fmt.Println(resp.Text())  // Remembers "World"
 
 The `hello.pack.json` defines:
 
-- **Provider**: OpenAI with `gpt-4o-mini`
 - **Prompt**: A friendly assistant with `{{user_name}}` template variable
+
+It deliberately does not pin a provider, so the example runs against whichever
+of OpenAI / Anthropic / Google you have a key for.
 
 ```json
 {

--- a/sdk/examples/hitl/README.md
+++ b/sdk/examples/hitl/README.md
@@ -11,8 +11,8 @@ Approval workflows for sensitive operations with the PromptKit SDK.
 
 ## Prerequisites
 
-- Go 1.21+
-- OpenAI API key
+- Go 1.26+
+- An API key for one of: OpenAI, Anthropic, or Google (the packs do not pin a provider)
 
 ## Running the Example
 

--- a/sdk/examples/hooks/README.md
+++ b/sdk/examples/hooks/README.md
@@ -24,8 +24,8 @@ response after it comes back.
 
 ## Prerequisites
 
-- Go 1.21+
-- OpenAI API key
+- Go 1.26+
+- An API key for one of: OpenAI, Anthropic, or Google (the packs do not pin a provider)
 
 ## Running the Example
 

--- a/sdk/examples/http-transforms/README.md
+++ b/sdk/examples/http-transforms/README.md
@@ -11,8 +11,8 @@ Customize HTTP tool behavior with argument transforms, request hooks, and respon
 
 ## Prerequisites
 
-- Go 1.21+
-- OpenAI API key
+- Go 1.26+
+- An API key for one of: OpenAI, Anthropic, or Google (the packs do not pin a provider)
 
 ## Running the Example
 

--- a/sdk/examples/long-conversation/README.md
+++ b/sdk/examples/long-conversation/README.md
@@ -37,7 +37,7 @@ The PromptKit SDK solves both with a three-tier context system:
 
 ## Prerequisites
 
-- Go 1.21+
+- Go 1.26+
 - OpenAI API key (for the LLM, embeddings, and summarization)
 
 ## Running the Example

--- a/sdk/examples/mcp-tools/README.md
+++ b/sdk/examples/mcp-tools/README.md
@@ -10,8 +10,8 @@ Connect to MCP (Model Context Protocol) tool servers via the PromptKit SDK.
 
 ## Prerequisites
 
-- Go 1.21+
-- OpenAI API key
+- Go 1.26+
+- An API key for one of: OpenAI, Anthropic, or Google (the packs do not pin a provider)
 - Node.js / npx (for the MCP server)
 - `@modelcontextprotocol/server-everything` npm package
 

--- a/sdk/examples/multimodal/README.md
+++ b/sdk/examples/multimodal/README.md
@@ -12,7 +12,7 @@ This example demonstrates multimodal (vision) capabilities using the PromptKit S
 ## Prerequisites
 
 1. A Google Gemini API key (for vision capabilities)
-2. Go 1.21 or later
+2. Go 1.26 or later
 
 ## Setup
 

--- a/sdk/examples/streaming/README.md
+++ b/sdk/examples/streaming/README.md
@@ -11,13 +11,21 @@ Real-time response streaming with the PromptKit SDK.
 
 ## Prerequisites
 
-- Go 1.21+
-- OpenAI API key
+- Go 1.26+
+- An API key for one of: OpenAI, Anthropic, or Google
 
 ## Running the Example
 
+The pack does not name a provider — the SDK detects one from the environment,
+so any of these works:
+
 ```bash
-export OPENAI_API_KEY=your-key
+export OPENAI_API_KEY=your-key       # uses gpt-4o
+# or
+export ANTHROPIC_API_KEY=your-key
+# or
+export GOOGLE_API_KEY=your-key
+
 go run .
 ```
 
@@ -61,8 +69,10 @@ const (
 
 The `streaming.pack.json` defines:
 
-- **Provider**: OpenAI with `gpt-4o-mini`
 - **Prompt**: A creative storyteller with higher temperature
+
+It deliberately does not pin a provider, so the example runs against whichever
+of OpenAI / Anthropic / Google you have a key for.
 
 ```json
 {

--- a/sdk/examples/tools/README.md
+++ b/sdk/examples/tools/README.md
@@ -11,8 +11,8 @@ Function calling with the PromptKit SDK.
 
 ## Prerequisites
 
-- Go 1.21+
-- OpenAI API key
+- Go 1.26+
+- An API key for one of: OpenAI, Anthropic, or Google (the packs do not pin a provider)
 
 ## Running the Example
 


### PR DESCRIPTION
## What

Audited all **39 examples** (37 under `sdk/examples`, 2 under `server/a2a/examples`) by compile-checking each under the correct module lens, then fixed the documentation defects that surfaced.

Docs pages under `docs/src/content/docs/sdk/examples/` are **generated from the READMEs** by `scripts/prepare-examples-docs.sh` and gitignored, so correcting the README is sufficient — the generated page follows.

## Example READMEs

| Defect | Scope |
|---|---|
| `Go 1.21+` claimed, but every module requires `go 1.26.0` | 10 READMEs |
| `**Provider**: OpenAI with gpt-4o-mini` under "Pack File Structure" | `hello`, `streaming` |
| `OpenAI API key` listed as the *sole* prerequisite | 6 READMEs |

The provider claim was wrong twice over: **no example pack declares a provider at all** (0 of 32). The SDK detects one from the environment via `sdk/internal/provider/detect.go`, and the OpenAI default there is `gpt-4o`, not `gpt-4o-mini`. The six "OpenAI API key" READMEs (`a2a-agent`, `hitl`, `hooks`, `http-transforms`, `mcp-tools`, `tools`) pin nothing in code, so any of the three keys works.

Model claims in `long-conversation`, `duplex-streaming`, `multimodal` and `voice-interview` were checked against their code and **match** — left alone.

## Hand-written pages

- **`RepoStructure.astro`** (the homepage "A tidy Go workspace" section) listed a top-level `examples/` in both the entries list and the ASCII tree. No such directory exists. Also adds `schemas/` and `benchmarks/`, which are real and were omitted.
- **`contributing.md`** had the same phantom `examples/`, plus `cd examples/customer-support && go run main.go` — an example that has **never existed** in this repo. Repointed at `sdk/examples/hello`, which builds and whose smoke test passes.

## Verification

```
scripts/prepare-examples-docs.sh   regenerates cleanly; README drift gate passes
npx astro build                    194 pages built
rendered dist/index.html           0 references to a top-level examples/
```

## Not included — follow-ups worth filing

The audit turned up three things outside this PR's scope:

1. **CI does not build or test 12 examples.** CI runs `./sdk/...`, and Go's `./...` does not descend into nested modules. The 10 SDK examples with their own `go.mod` plus both `server/a2a` examples are invisible to it — confirmed with `go list`. **Seven test files have never run in CI.**
2. **`onnx-audio-emotion` is broken standalone.** It is the only example with its own `go.mod` that is not in `go.work`. Inside the repo it builds; with `GOWORK=off` it fails `updates to go.mod needed; go mod tidy`. This is a direct consequence of (1).
3. **Stale auto-detect model defaults** in `sdk/internal/provider/detect.go:155-158`: `claude-sonnet-4-20250514` and `gemini-1.5-pro`. The Anthropic default is two generations behind the current Claude 5 family, so every example auto-detecting Anthropic silently runs an outdated model.
