### PR TITLE
feat(seamscan): find untested seams and tests that cannot fail

### DIFF
--- a/.claude/skills/audit-test-seams/SKILL.md
+++ b/.claude/skills/audit-test-seams/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: audit-test-seams
+description: Use when auditing a subsystem's tests for untested component handoffs and assertions that cannot fail - finds seams where two units each pass their own tests but the contract between them is unverified
+---
+
+# Auditing Test Seams
+
+## Overview
+
+Four defects shipped through a suite with 88% coverage and a 2:1 test-to-production
+line ratio. Each sat at a *seam* — a point where one component hands off to
+another and the contract is written down in neither. Two failure modes let
+them through:
+
+1. **Untested seams.** A contract between two components, written down in
+   neither. Each side's tests assert against that side's *assumption* about
+   the other, so both suites pass while the handoff is broken.
+2. **Assertions that cannot fail.** Tests checking only `NoError`/`Nil`/`NotNil`,
+   which pass whether or not the code produced the right answer — while
+   counting fully toward the coverage gate.
+
+Coverage does not detect either. This audit does. `tools/seamscan` (the
+`seamscan` command) finds candidates for both; this skill is the judgment that
+turns a candidate into a finding.
+
+**Announce at start:** "I'm using audit-test-seams to audit `<target>`."
+
+## Scope
+
+Audit **one subsystem at a time** — a package tree someone is actively working
+in, e.g. `runtime/hooks`. Per-package is the default and useful unit. A
+whole-repo run produces a report nobody reads (113 packages as of this
+writing) and a whole-repo pattern is rejected outright — see Step 1.
+
+## Step 1: Run the analyzer
+
+Run from the **repo root** (not from inside `tools/seamscan` — the module is
+part of this repo's `go.work`, so `go run ./tools/seamscan` resolves
+correctly without a directory change):
+
+```bash
+# weak-assertions takes a plain directory, walked recursively already —
+# do NOT add a "/..." suffix, it will look for a literal directory of that name.
+go run ./tools/seamscan weak-assertions --text <target>
+
+# seams uses go/packages patterns and DOES need the "/..." suffix to recurse;
+# a bare directory scans only that one package, non-recursively.
+go run ./tools/seamscan seams --text <target>/...
+```
+
+Both commands emit JSON by default; `--text` is for a human reading the
+output directly (`file:line`, kind, subject, one per line). `seams` also
+accepts `--min-fields` (default 5, ignore structs with fewer exported fields)
+and `--min-dropped` (default 3, ignore literals dropping fewer fields) if a
+subsystem's own struct conventions call for retuning them.
+
+A whole-repo pattern (`./...` from the repo root) **deliberately errors**
+rather than silently reporting zero — `seamscan` treats "no packages could be
+loaded" as a hard failure, not an empty result. Scope the pattern to a real
+subsystem.
+
+Findings are **candidates**. The analyzer decides nothing; every candidate
+below is judged, not accepted as-is.
+
+## Known limitations — read before trusting a clean scan
+
+A scan with zero findings is not an all-clear. State these to whoever reads
+the results:
+
+1. **The counts are floors, not ground truth.** Whole-tree `weak-assertions`
+   count and any `seams` count are lower bounds on what exists, not exhaustive
+   totals.
+2. **Lossy-rebuild misses method-call-sourced values.** It detects a struct
+   literal that reads an existing *field* but drops most of the type's other
+   fields. It does **not** see a value that comes from a method call on a
+   collaborator (`state.accumulatedContent()`) rather than a field read —
+   `sdk/streaming.go:444` (`&types.Message{Role, Content}`, 2 of 13 fields,
+   dropping `FinishReason`) is a live, undetected instance of exactly the
+   defect class this signature is named for. Recovering it needs call-graph
+   analysis or a per-site allowlist. The converse also holds: `x.Field.Method()`
+   **does** qualify (the receiver chain reads a field), so some findings are
+   method-call results that may be unrelated to the field read.
+3. **Lossy-rebuild is literal-only.** It cannot see fields assigned after
+   construction (`m := T{}; m.X = …`); its `unset:` list can name fields that
+   are, in fact, set later in the same function.
+4. **Weak-assertions suppresses locally-defined `assert*`/`must*` helpers.**
+   This is a deliberate bias toward under-reporting — a guard that fires on
+   legitimate helper-wrapped tests gets disabled by whoever it annoys — so a
+   weak assertion hidden behind a local helper is invisible to the scan.
+5. **Weak-assertions misses a closure that a subtest-hosting parent defines
+   and invokes itself** (as opposed to delegating to a `t.Run` subtest). Its
+   weak assertion is silently unflagged.
+6. **Weak-assertions has a known false-positive shape.** `NotNil`/`Nil` on a
+   field whose zero value is genuinely reachable (i.e. the check really can
+   fail) gets flagged anyway, because the heuristic is blanket: any bare
+   `NoError`/`Nil`/`NotNil`/…-`f` call counts as "proves nothing," without
+   checking whether the specific call is actually unfalsifiable. Measured
+   rate on the last 20 merged PRs: 1 in 20. Expect to dismiss some candidates
+   for exactly this reason — see Step 3.
+
+## Step 2: Judge each seam candidate
+
+For each candidate, answer in order. Stop at the first "no."
+
+1. **Is there a real contract here?** Two components exchanging data with an
+   expectation neither states. A partial literal for a builder is not a
+   contract; a message rebuilt at a module boundary is.
+2. **Could the two sides disagree while both pass their own tests?** This is
+   the actual test. If side A cannot be wrong about side B, there is no seam.
+3. **Does any test exercise both sides with the real collaborator?** This is
+   the handoff-coverage check, and it needs a concrete rule or it is
+   unfalsifiable:
+
+   > A test counts as covering the seam if it imports both packages, or
+   > constructs both concrete types, **and neither side is substituted**.
+   > "Substituted" means: the test constructs a type from a package whose
+   > path or name contains `mock`, `fake`, `stub`, or `testutil`, **and**
+   > that type stands in for one of the two sides of the seam under test.
+
+   A mock of something that is *not* one of the two sides is irrelevant — a
+   seam test for adapter↔handler may legitimately use a mock *provider*,
+   because the provider isn't either side of that seam.
+
+   This heuristic will misjudge a hand-rolled fake that follows no naming
+   convention. Treat its answer as a prompt to go look at the test, not as a
+   verdict by itself.
+
+Only candidates reaching step 3 with "no test" are findings.
+
+## Step 3: Judge each weak-assertion candidate
+
+For each, name the **mutation** the test would catch. Break the
+implementation in your head — return the zero value, skip the side effect,
+invert the condition — and ask whether the test notices.
+
+- Notices → not weak, dismiss the candidate. This is where limitation 6 above
+  shows up in practice: a `require.Nil(t, ValidatorsToHooks(...))` call looks
+  like the boilerplate the tool is built to catch, but if the function can
+  legitimately return a non-nil empty slice instead of nil, the assertion is
+  real and the candidate is a false positive.
+- Does not notice → finding. Either strengthen the assertion or delete the
+  test.
+
+Watch specifically for an assertion that is *structurally* unable to fail:
+`assert.NotEqual(X, field)` where nothing ever sets `field`, or
+`require.NoError` on a call that cannot error. Also watch for a test that
+duplicates a compile-time interface assertion already made in production code
+(`var _ SomeInterface = (*Impl)(nil)`) — it is not wrong, just dead weight;
+recommend deleting it rather than strengthening it.
+
+## Step 4: Report
+
+For each finding give: the two sides (for a seam) or the test (for a weak
+assertion), what the contract or assertion should be, and the concrete
+failure a test would catch. Rank by blast radius — a seam on a safety path
+(guardrails, auth, budget enforcement) outranks one on a debug helper.
+
+Do not write the tests as part of the audit. The audit produces a work list;
+writing tests is separate work with its own review.
+
+## Anti-patterns
+
+| Temptation | Why it is wrong |
+|---|---|
+| "Coverage is 90%, we are fine" | Coverage measures executed lines, not verified behavior. All the weak tests are coverage-positive. |
+| Adding a unit test for each side | That is what already failed. The seam needs one test running both sides for real. |
+| Mocking the collaborator "to isolate" | The mock encodes your assumption about it. When the assumption is wrong the test agrees with you. |
+| Fixing candidates without judging them | Most candidates are not defects. Unjudged fixes add noise and churn. |
+| Deleting weak tests wholesale | Some are weak but load-bearing (smoke tests). Strengthen where the behavior matters. |
+| Treating a clean scan as an all-clear | See Known limitations above — the scan is a floor, not a certificate. |
+
+## Cost of the cleanup
+
+Removing assertion-free tests **lowers** the coverage number: they execute
+real lines, and the seam tests replacing them are far fewer. Expect a dip,
+and agree it is acceptable before starting — otherwise the coverage gate
+blocks the cleanup and the fix is to backfill exactly the junk you removed.
+
+## Non-goals
+
+- **No generated tests.** The audit produces a work list of findings; a human
+  or agent writes the tests as separate, separately-reviewed work.
+- **No score, grade, or percentage.** A number becomes a target, and targets
+  get gamed — that is the failure mode of the coverage gate this audit exists
+  to supplement. Report findings, not a metric.
+- **No gating.** This audit does not block a build or a merge. (Weak, brand
+  new assertions are separately caught pre-commit and in CI by
+  `make check-weak-assertions` — a different, narrower, gating mechanism; see
+  `scripts/check-weak-assertions.sh`. It is local opt-in tooling, not wired
+  into `.github/workflows/ci.yml`, and it is not this skill.)

--- a/.claude/skills/audit-test-seams/SKILL.md
+++ b/.claude/skills/audit-test-seams/SKILL.md
@@ -82,8 +82,8 @@ the results:
    **does** qualify (the receiver chain reads a field), so some findings are
    method-call results that may be unrelated to the field read.
 3. **Lossy-rebuild is literal-only.** It cannot see fields assigned after
-   construction (`m := T{}; m.X = …`); its `unset:` list can name fields that
-   are, in fact, set later in the same function.
+   construction (`m := T{}; m.X = …`); its `not set in literal:` list can name
+   fields that are, in fact, set later in the same function.
 4. **Weak-assertions suppresses locally-defined `assert*`/`must*` helpers.**
    This is a deliberate bias toward under-reporting — a guard that fires on
    legitimate helper-wrapped tests gets disabled by whoever it annoys — so a
@@ -185,7 +185,8 @@ blocks the cleanup and the fix is to backfill exactly the junk you removed.
   get gamed — that is the failure mode of the coverage gate this audit exists
   to supplement. Report findings, not a metric.
 - **No gating.** This audit does not block a build or a merge. (Weak, brand
-  new assertions are separately caught pre-commit and in CI by
-  `make check-weak-assertions` — a different, narrower, gating mechanism; see
-  `scripts/check-weak-assertions.sh`. It is local opt-in tooling, not wired
-  into `.github/workflows/ci.yml`, and it is not this skill.)
+  new assertions can separately be caught by running `make check-weak-assertions`
+  locally — a different, narrower mechanism; see
+  `scripts/check-weak-assertions.sh`. It is local opt-in tooling only: it is
+  not run in pre-commit, it is not wired into
+  `.github/workflows/ci.yml`, and it is not this skill.)

--- a/.claude/skills/audit-test-seams/SKILL.md
+++ b/.claude/skills/audit-test-seams/SKILL.md
@@ -29,8 +29,9 @@ turns a candidate into a finding.
 
 Audit **one subsystem at a time** — a package tree someone is actively working
 in, e.g. `runtime/hooks`. Per-package is the default and useful unit. A
-whole-repo run produces a report nobody reads (113 packages as of this
-writing) and a whole-repo pattern is rejected outright — see Step 1.
+whole-repo run produces a report nobody reads (well over a hundred packages
+across the workspace modules) and a whole-repo pattern is rejected outright —
+see Step 1.
 
 ## Step 1: Run the analyzer
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.dylib
 bin/
 dist/
+/tools/seamscan/seamscan
 
 # Generated files
 schemas/*

--- a/Makefile
+++ b/Makefile
@@ -434,3 +434,6 @@ sonar-scan: sonar-deps ## Run SonarScanner locally (requires SONAR_TOKEN env var
 	fi
 
 sonar-quick: coverage sonar-scan ## Generate coverage and run Sonar analysis in one command
+
+check-weak-assertions: ## Fail on new tests whose assertions cannot fail
+	@./scripts/check-weak-assertions.sh

--- a/go.work
+++ b/go.work
@@ -20,4 +20,5 @@ use (
 	./server/a2a
 	./server/a2a/examples/a2a-auth-test
 	./server/a2a/examples/a2a-demo
+	./tools/seamscan
 )

--- a/scripts/check-weak-assertions.sh
+++ b/scripts/check-weak-assertions.sh
@@ -8,7 +8,7 @@
 # one went green against a bug that had been observed minutes earlier and would
 # have closed the issue as unreproducible.
 #
-# New findings only: the ~678 pre-existing ones are a separate, deliberate
+# New findings only: the ~676 pre-existing ones are a separate, deliberate
 # cleanup and must not block unrelated work. Mirrors the --new-from-rev
 # convention golangci-lint uses in the pre-commit hook.
 #
@@ -27,36 +27,72 @@ ROOT="$(git rev-parse --show-toplevel)"
 SCAN="go -C ${ROOT}/tools/seamscan run ."
 
 # Findings on the merge base, then on the working tree; anything only in the
-# latter is new. Subject+kind identifies a finding stably across line moves,
-# so that pair is what the diff runs on; file+line is kept alongside on the
-# head side only, purely to report where to look — a scan can carry the same
-# subject in several files (sdk/examples/*/smoke_test.go all define
-# TestSmoke), so the kind+subject tuple alone doesn't say which one to open.
+# latter is new. The comparison key is kind+file+subject — file is part of
+# identity, not just display: several files legitimately share a subject
+# (sdk/examples/*/smoke_test.go all define TestSmoke), and comparing on
+# kind+subject alone means one genuinely new finding makes every other
+# same-named pre-existing finding look new too, in every file that happens to
+# share the name. Line is deliberately left out of the key (carried on the
+# head side only, for display): a comparison that included line would make an
+# unrelated edit that merely shifts an existing test's line number look like a
+# newly introduced one.
+#
+# The base scan runs against a throwaway worktree under a temp directory, so
+# its absolute file paths never equal the head scan's paths even for a file
+# that didn't change — comparing raw absolute paths would make every
+# pre-existing finding look new. Both sides are normalized to a path relative
+# to the tree that was scanned (stripping the temp-worktree prefix on the base
+# side, ${ROOT}/ on the head side) via literal index()/substr(), not a regex
+# substitution, so a path containing regex metacharacters can't miscompare.
+#
 # Paths passed to seamscan are absolute so `go -C` (which changes the process
 # working directory, not just the module lookup) doesn't make them resolve
 # against tools/seamscan instead of the tree we mean to scan.
 tmp="$(mktemp -d)"
 trap 'rm -rf "${tmp}"' EXIT
 
-git -C "${ROOT}" worktree add --quiet --detach "${tmp}/base" "$(git -C "${ROOT}" merge-base HEAD "${BASE}")"
-${SCAN} weak-assertions "${tmp}/base/runtime" "${tmp}/base/sdk" "${tmp}/base/pkg" 2>/dev/null \
-  | grep -oE '"kind": "[^"]+"|"subject": "[^"]+"' | paste - - | sort > "${tmp}/base_ks.txt" || true
-git -C "${ROOT}" worktree remove --force "${tmp}/base"
+relativize_file_field() {
+  # Strips a literal "<prefix>/" from the value of a `"file": "..."` grep
+  # match, leaving other matched lines (kind/line/subject) untouched. Uses
+  # index()/substr() rather than sub()'s regex so the prefix (an arbitrary
+  # absolute path) never needs escaping.
+  awk -v pfx="$1/" '
+    {
+      marker = "\"file\": \"" pfx
+      if (index($0, marker) == 1) {
+        print "\"file\": \"" substr($0, length(marker) + 1)
+      } else {
+        print
+      }
+    }'
+}
+
+BASE_CHECKOUT="${tmp}/base"
+git -C "${ROOT}" worktree add --quiet --detach "${BASE_CHECKOUT}" "$(git -C "${ROOT}" merge-base HEAD "${BASE}")"
+${SCAN} weak-assertions "${BASE_CHECKOUT}/runtime" "${BASE_CHECKOUT}/sdk" "${BASE_CHECKOUT}/pkg" 2>/dev/null \
+  | grep -oE '"kind": "[^"]+"|"file": "[^"]+"|"subject": "[^"]+"' \
+  | relativize_file_field "${BASE_CHECKOUT}" \
+  | paste - - - | sort > "${tmp}/base_kfs.txt" || true
+git -C "${ROOT}" worktree remove --force "${BASE_CHECKOUT}"
 
 ${SCAN} weak-assertions "${ROOT}/runtime" "${ROOT}/sdk" "${ROOT}/pkg" 2>/dev/null \
   | grep -oE '"kind": "[^"]+"|"file": "[^"]+"|"line": [0-9]+|"subject": "[^"]+"' \
+  | relativize_file_field "${ROOT}" \
   | paste - - - - > "${tmp}/head_full.txt"
-cut -f1,4 "${tmp}/head_full.txt" | sort > "${tmp}/head_ks.txt"
+cut -f1,2,4 "${tmp}/head_full.txt" | sort > "${tmp}/head_kfs.txt"
 
 # Split from the `if` deliberately: with set -e, `if cmd && [ ... ]` would
 # swallow a genuine comm failure as "no findings", which would make the guard
 # silently useless — the exact failure mode this whole plan exists to prevent.
-new="$(comm -13 "${tmp}/base_ks.txt" "${tmp}/head_ks.txt" || true)"
+new="$(comm -13 "${tmp}/base_kfs.txt" "${tmp}/head_kfs.txt" || true)"
 if [ -n "${new}" ]; then
-  while IFS= read -r ks; do
-    [ -z "${ks}" ] && continue
-    awk -F'\t' -v ks="${ks}" -v OFS='\t' '
-      $1"\t"$4 == ks {
+  while IFS= read -r kfs; do
+    [ -z "${kfs}" ] && continue
+    # Matches the exact (kind, file, subject) triple identified as new —
+    # not just subject+kind — so a shared name in an untouched file never
+    # gets pulled in alongside the one genuinely new finding.
+    awk -F'\t' -v kfs="${kfs}" -v OFS='\t' '
+      $1"\t"$2"\t"$4 == kfs {
         file = $2; sub(/^"file": "/, "", file); sub(/"$/, "", file)
         line = $3; sub(/^"line": /, "", line)
         kind = $1; sub(/^"kind": "/, "", kind); sub(/"$/, "", kind)

--- a/scripts/check-weak-assertions.sh
+++ b/scripts/check-weak-assertions.sh
@@ -27,7 +27,11 @@ ROOT="$(git rev-parse --show-toplevel)"
 SCAN="go -C ${ROOT}/tools/seamscan run ."
 
 # Findings on the merge base, then on the working tree; anything only in the
-# latter is new. Subject+kind identifies a finding stably across line moves.
+# latter is new. Subject+kind identifies a finding stably across line moves,
+# so that pair is what the diff runs on; file+line is kept alongside on the
+# head side only, purely to report where to look — a scan can carry the same
+# subject in several files (sdk/examples/*/smoke_test.go all define
+# TestSmoke), so the kind+subject tuple alone doesn't say which one to open.
 # Paths passed to seamscan are absolute so `go -C` (which changes the process
 # working directory, not just the module lookup) doesn't make them resolve
 # against tools/seamscan instead of the tree we mean to scan.
@@ -36,18 +40,30 @@ trap 'rm -rf "${tmp}"' EXIT
 
 git -C "${ROOT}" worktree add --quiet --detach "${tmp}/base" "$(git -C "${ROOT}" merge-base HEAD "${BASE}")"
 ${SCAN} weak-assertions "${tmp}/base/runtime" "${tmp}/base/sdk" "${tmp}/base/pkg" 2>/dev/null \
-  | grep -oE '"kind": "[^"]+"|"subject": "[^"]+"' | paste - - | sort > "${tmp}/base.txt" || true
+  | grep -oE '"kind": "[^"]+"|"subject": "[^"]+"' | paste - - | sort > "${tmp}/base_ks.txt" || true
 git -C "${ROOT}" worktree remove --force "${tmp}/base"
 
 ${SCAN} weak-assertions "${ROOT}/runtime" "${ROOT}/sdk" "${ROOT}/pkg" 2>/dev/null \
-  | grep -oE '"kind": "[^"]+"|"subject": "[^"]+"' | paste - - | sort > "${tmp}/head.txt"
+  | grep -oE '"kind": "[^"]+"|"file": "[^"]+"|"line": [0-9]+|"subject": "[^"]+"' \
+  | paste - - - - > "${tmp}/head_full.txt"
+cut -f1,4 "${tmp}/head_full.txt" | sort > "${tmp}/head_ks.txt"
 
 # Split from the `if` deliberately: with set -e, `if cmd && [ ... ]` would
 # swallow a genuine comm failure as "no findings", which would make the guard
 # silently useless — the exact failure mode this whole plan exists to prevent.
-new="$(comm -13 "${tmp}/base.txt" "${tmp}/head.txt" || true)"
+new="$(comm -13 "${tmp}/base_ks.txt" "${tmp}/head_ks.txt" || true)"
 if [ -n "${new}" ]; then
-  echo "${new}" | while read -r line; do echo "FAIL: ${line}"; done
+  while IFS= read -r ks; do
+    [ -z "${ks}" ] && continue
+    awk -F'\t' -v ks="${ks}" -v OFS='\t' '
+      $1"\t"$4 == ks {
+        file = $2; sub(/^"file": "/, "", file); sub(/"$/, "", file)
+        line = $3; sub(/^"line": /, "", line)
+        kind = $1; sub(/^"kind": "/, "", kind); sub(/"$/, "", kind)
+        subj = $4; sub(/^"subject": "/, "", subj); sub(/"$/, "", subj)
+        printf "FAIL: %s:%s\t%s\t%s\n", file, line, kind, subj
+      }' "${tmp}/head_full.txt"
+  done <<< "${new}"
   echo ""
   echo "These tests assert only that a call did not fail, so they pass whether or"
   echo "not the code produced the right answer. Name the mutation each assertion"

--- a/scripts/check-weak-assertions.sh
+++ b/scripts/check-weak-assertions.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Fails when a commit adds a test whose assertions cannot fail — one asserting
+# only NoError/Nil/NotNil, which passes whether or not the code under test
+# produced the right answer while still counting toward the coverage gate.
+#
+# Nine such tests were written during the guardrail work (#1678/#1683/#1684);
+# one went green against a bug that had been observed minutes earlier and would
+# have closed the issue as unreproducible.
+#
+# New findings only: the ~678 pre-existing ones are a separate, deliberate
+# cleanup and must not block unrelated work. Mirrors the --new-from-rev
+# convention golangci-lint uses in the pre-commit hook.
+#
+# Run from the repo root: scripts/check-weak-assertions.sh [base-ref]
+set -euo pipefail
+
+# Some execution contexts (e.g. worktree pre-commit hooks — see
+# reference_worktree_gitdir_golangci) leak GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE
+# into subprocesses, which silently redirects every git command below at the
+# wrong repo. Unset defensively so `git worktree add`/`merge-base` always
+# resolve against the repo this script actually lives in.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+BASE="${1:-origin/main}"
+ROOT="$(git rev-parse --show-toplevel)"
+SCAN="go -C ${ROOT}/tools/seamscan run ."
+
+# Findings on the merge base, then on the working tree; anything only in the
+# latter is new. Subject+kind identifies a finding stably across line moves.
+# Paths passed to seamscan are absolute so `go -C` (which changes the process
+# working directory, not just the module lookup) doesn't make them resolve
+# against tools/seamscan instead of the tree we mean to scan.
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+git -C "${ROOT}" worktree add --quiet --detach "${tmp}/base" "$(git -C "${ROOT}" merge-base HEAD "${BASE}")"
+${SCAN} weak-assertions "${tmp}/base/runtime" "${tmp}/base/sdk" "${tmp}/base/pkg" 2>/dev/null \
+  | grep -oE '"kind": "[^"]+"|"subject": "[^"]+"' | paste - - | sort > "${tmp}/base.txt" || true
+git -C "${ROOT}" worktree remove --force "${tmp}/base"
+
+${SCAN} weak-assertions "${ROOT}/runtime" "${ROOT}/sdk" "${ROOT}/pkg" 2>/dev/null \
+  | grep -oE '"kind": "[^"]+"|"subject": "[^"]+"' | paste - - | sort > "${tmp}/head.txt"
+
+# Split from the `if` deliberately: with set -e, `if cmd && [ ... ]` would
+# swallow a genuine comm failure as "no findings", which would make the guard
+# silently useless — the exact failure mode this whole plan exists to prevent.
+new="$(comm -13 "${tmp}/base.txt" "${tmp}/head.txt" || true)"
+if [ -n "${new}" ]; then
+  echo "${new}" | while read -r line; do echo "FAIL: ${line}"; done
+  echo ""
+  echo "These tests assert only that a call did not fail, so they pass whether or"
+  echo "not the code produced the right answer. Name the mutation each assertion"
+  echo "would catch — break the implementation in your head and check the test"
+  echo "notices — then strengthen it, or delete the test."
+  exit 1
+fi
+
+echo "OK:   no new tests with unfalsifiable assertions."

--- a/scripts/check-weak-assertions.sh
+++ b/scripts/check-weak-assertions.sh
@@ -69,16 +69,43 @@ relativize_file_field() {
 
 BASE_CHECKOUT="${tmp}/base"
 git -C "${ROOT}" worktree add --quiet --detach "${BASE_CHECKOUT}" "$(git -C "${ROOT}" merge-base HEAD "${BASE}")"
-${SCAN} weak-assertions "${BASE_CHECKOUT}/runtime" "${BASE_CHECKOUT}/sdk" "${BASE_CHECKOUT}/pkg" 2>/dev/null \
+${SCAN} weak-assertions "${BASE_CHECKOUT}/runtime" "${BASE_CHECKOUT}/sdk" "${BASE_CHECKOUT}/pkg" "${BASE_CHECKOUT}/server/a2a" 2>/dev/null \
   | grep -oE '"kind": "[^"]+"|"file": "[^"]+"|"subject": "[^"]+"' \
   | relativize_file_field "${BASE_CHECKOUT}" \
   | paste - - - | sort > "${tmp}/base_kfs.txt" || true
 git -C "${ROOT}" worktree remove --force "${BASE_CHECKOUT}"
 
-${SCAN} weak-assertions "${ROOT}/runtime" "${ROOT}/sdk" "${ROOT}/pkg" 2>/dev/null \
+# Head-side scan: unlike the base-side scan above, stderr is deliberately NOT
+# redirected to /dev/null here — swallowing it would also hide *why* a genuine
+# head-side scan failure happened, which is the failure mode this whole guard
+# exists to surface, not paper over. A zero-findings result (grep exits 1
+# because nothing matched) is handled explicitly below and is not an error:
+# it is the legitimate outcome once the cleanup this tool drives finishes.
+${SCAN} weak-assertions "${ROOT}/runtime" "${ROOT}/sdk" "${ROOT}/pkg" "${ROOT}/server/a2a" \
   | grep -oE '"kind": "[^"]+"|"file": "[^"]+"|"line": [0-9]+|"subject": "[^"]+"' \
   | relativize_file_field "${ROOT}" \
-  | paste - - - - > "${tmp}/head_full.txt"
+  | paste - - - - > "${tmp}/head_full.txt" || {
+  # Captured into an array in one step, before anything else runs: reading
+  # PIPESTATUS[0] and PIPESTATUS[1] as two separate statements would lose the
+  # array after the first read — a bare variable assignment is itself a
+  # simple command, and bash resets PIPESTATUS after every simple command,
+  # pipeline or not.
+  pipe_status=("${PIPESTATUS[@]}")
+  scan_rc=${pipe_status[0]}
+  grep_rc=${pipe_status[1]}
+  if [ "${scan_rc}" -ne 0 ]; then
+    echo "check-weak-assertions: head-side scan failed (exit ${scan_rc})" >&2
+    exit 1
+  fi
+  if [ "${grep_rc}" -gt 1 ]; then
+    echo "check-weak-assertions: parsing head-side scan output failed (exit ${grep_rc})" >&2
+    exit 1
+  fi
+  # grep_rc == 1: grep found no "kind"/"file"/"line"/"subject" lines at all —
+  # a legitimate outcome (every weak-assertion finding across the scanned
+  # trees has been cleaned up, not just the new ones), not a failure. Fall
+  # through with the empty head_full.txt the redirect already created.
+}
 cut -f1,2,4 "${tmp}/head_full.txt" | sort > "${tmp}/head_kfs.txt"
 
 # Split from the `if` deliberately: with set -e, `if cmd && [ ... ]` would

--- a/tools/seamscan/finding.go
+++ b/tools/seamscan/finding.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Finding is one candidate. seamscan never decides whether a candidate is a
+// defect — that judgment belongs to the audit skill.
+type Finding struct {
+	Kind    string `json:"kind"`
+	File    string `json:"file"`
+	Line    int    `json:"line"`
+	Subject string `json:"subject"`
+	Detail  string `json:"detail,omitempty"`
+}
+
+// EmitText writes findings one per line, file:line first so editors can jump.
+func EmitText(w io.Writer, fs []Finding) {
+	for _, f := range fs {
+		_, _ = fmt.Fprintf(w, "%s:%d\t%s\t%s", f.File, f.Line, f.Kind, f.Subject)
+		if f.Detail != "" {
+			_, _ = fmt.Fprintf(w, "\t%s", f.Detail)
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+}
+
+// EmitJSON writes findings as a JSON array, always an array even when empty so
+// consumers need no special case.
+func EmitJSON(w io.Writer, fs []Finding) error {
+	if fs == nil {
+		fs = []Finding{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(fs)
+}

--- a/tools/seamscan/finding_test.go
+++ b/tools/seamscan/finding_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmitText_WritesFileLineKindSubject(t *testing.T) {
+	var buf bytes.Buffer
+	EmitText(&buf, []Finding{{Kind: "weak-assertion", File: "x_test.go", Line: 12, Subject: "TestFoo"}})
+	assert.Equal(t, "x_test.go:12\tweak-assertion\tTestFoo\n", buf.String())
+}
+
+func TestEmitText_IncludesDetailWhenPresent(t *testing.T) {
+	var buf bytes.Buffer
+	EmitText(&buf, []Finding{{Kind: "no-assertion", File: "y_test.go", Line: 3, Subject: "TestBar", Detail: "no calls found"}})
+	assert.Equal(t, "y_test.go:3\tno-assertion\tTestBar\tno calls found\n", buf.String())
+}
+
+func TestEmitText_MultipleFindingsOnePerLine(t *testing.T) {
+	var buf bytes.Buffer
+	EmitText(&buf, []Finding{
+		{Kind: "no-assertion", File: "a_test.go", Line: 1, Subject: "TestA"},
+		{Kind: "weak-assertion", File: "b_test.go", Line: 2, Subject: "TestB"},
+	})
+	assert.Equal(t, "a_test.go:1\tno-assertion\tTestA\nb_test.go:2\tweak-assertion\tTestB\n", buf.String())
+}
+
+func TestEmitJSON_EmptySliceIsJSONArrayNotNull(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, EmitJSON(&buf, nil))
+	assert.Equal(t, "[]\n", buf.String())
+}
+
+func TestEmitJSON_EncodesFindingFields(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, EmitJSON(&buf, []Finding{{Kind: "weak-assertion", File: "x_test.go", Line: 1, Subject: "TestFoo"}}))
+
+	var got []Finding
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, Finding{Kind: "weak-assertion", File: "x_test.go", Line: 1, Subject: "TestFoo"}, got[0])
+}

--- a/tools/seamscan/go.mod
+++ b/tools/seamscan/go.mod
@@ -2,10 +2,15 @@ module github.com/AltairaLabs/PromptKit/tools/seamscan
 
 go 1.26.0
 
-require github.com/stretchr/testify v1.11.1
+require (
+	github.com/stretchr/testify v1.11.1
+	golang.org/x/tools v0.48.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/mod v0.38.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/tools/seamscan/go.mod
+++ b/tools/seamscan/go.mod
@@ -1,0 +1,11 @@
+module github.com/AltairaLabs/PromptKit/tools/seamscan
+
+go 1.26.0
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/tools/seamscan/go.sum
+++ b/tools/seamscan/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tools/seamscan/go.sum
+++ b/tools/seamscan/go.sum
@@ -1,9 +1,17 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=
+golang.org/x/mod v0.38.0/go.mod h1:V6Xz0pq8TQ3dGqVQ1FVHuelZpAL0uNhSkk9ogYP3c40=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.48.0 h1:3+hClM1aLL5mjMKm5ovokw9epgRXPuu2tILgismM6RE=
+golang.org/x/tools v0.48.0/go.mod h1:08xX0orndb/F7jJxGDicx061tyd5pcMto75YMAXr6lk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/tools/seamscan/lossy.go
+++ b/tools/seamscan/lossy.go
@@ -28,6 +28,39 @@ import (
 // twice (once under the plain package, once under its test variant) and
 // double-count every finding in it, on top of surfacing enormous volumes of
 // deliberate partial construction in test fixtures that swamp real signal.
+//
+// # Detection boundary
+//
+// A literal only qualifies once at least one field value reads existing data
+// rather than authoring it fresh (see hasFieldSourcedValue). This is what
+// separates a rebuild from an ordinary sparse constructor (e.g. the
+// runtime/evals result-builder convention, which sets a couple of fields from
+// locals/call results and leaves the rest for a later stage by design — not a
+// bug).
+//
+// What it detects: a field read anywhere in a value's expression subtree, not
+// just as the top-level expression — directly (src.Content, &src.Content) or
+// nested in a conversion, concatenation, index expression, or sub-literal
+// (string(src.A), src.A+"!", src.Items[0], Inner{X: src.A}) — plus any
+// slice/array/map index read, regardless of what it indexes.
+//
+// What it does not detect: any method call, including one that's really just
+// a field forwarded through a getter. A narrow rule counting calls to a
+// concrete (non-interface) receiver's method was tried specifically to
+// recover the streaming twin of #1681 at sdk/streaming.go:444
+// (state.accumulatedContent()), which is exactly that shape. It was reverted:
+// receiver concreteness doesn't separate a data-forwarding getter from an
+// ordinary computed one (h.Type() returning a hardcoded literal is just as
+// concrete-receiver as state.accumulatedContent() reading accumulated state),
+// and it drove runtime/hooks+runtime/evals from 14 findings to 186 — the
+// eval-handler convention of a hardcoded Type()/Name() getter appears in
+// nearly every EvalResult constructor in that package. streaming.go:444 is
+// therefore a known false negative, not a bug: recovering it needs either
+// call-graph analysis of the callee (does its body actually read a field?)
+// or a per-site allowlist, both out of scope for this pass. Also undetected,
+// for the same reason (no data-flow tracing here): a value already copied out
+// of a field by an earlier statement (x := src.A; T{F: x}), and a parameter
+// or local forwarded opaquely.
 func LossyRebuilds(patterns []string, minFields, minDropped int) ([]Finding, error) {
 	var out []Finding
 	for _, pattern := range patterns {
@@ -55,6 +88,13 @@ func LossyRebuilds(patterns []string, minFields, minDropped int) ([]Finding, err
 // scan target that is part of a multi-module workspace resolves against that
 // workspace, and an isolated single-module fixture (as the tests build) falls
 // back to its own go.mod because no go.work is reachable above it.
+//
+// A pattern that matches nothing, or that go/packages could not load at all
+// (no reachable go.mod, a malformed module, ...), is treated as an error
+// rather than a silent zero findings: go/packages reports a load failure as a
+// package whose Errors is non-empty rather than a Go error return, so a caller
+// that only checks the err from packages.Load never notices. That is exactly
+// how "seams" on the whole repo root used to exit 0 having scanned nothing.
 func lossyRebuildsInPattern(pattern string, minFields, minDropped int) ([]Finding, error) {
 	dir, listPattern := splitPatternDir(pattern)
 	cfg := &packages.Config{
@@ -65,6 +105,12 @@ func lossyRebuildsInPattern(pattern string, minFields, minDropped int) ([]Findin
 	pkgs, err := packages.Load(cfg, listPattern)
 	if err != nil {
 		return nil, fmt.Errorf("loading packages for %q: %w", pattern, err)
+	}
+	if len(pkgs) == 0 {
+		return nil, fmt.Errorf("no packages matched %q", pattern)
+	}
+	if n := packages.PrintErrors(pkgs); n > 0 {
+		return nil, fmt.Errorf("%d package load error(s) for %q (see above)", n, pattern)
 	}
 
 	var out []Finding
@@ -130,13 +176,11 @@ func checkLiteral(
 		return Finding{}, false
 	}
 	if !hasFieldSourcedValue(p, lit) {
-		// Nothing here reads a field off some other value — this literal was
-		// authored from scratch (constants, locals, call results), the normal
-		// shape of a sparse builder/result type where the caller or a later
-		// stage is expected to fill in the rest. #1681 forwarded fields read
-		// off an existing value of a related type (result.Response.Content);
-		// requiring that shape is what tells a rebuild-in-progress apart from
-		// an ordinary constructor.
+		// Nothing here reads existing data — this literal was authored from
+		// scratch (constants, locals, call results), the normal shape of a
+		// sparse builder/result type where the caller or a later stage is
+		// expected to fill in the rest. See the package doc for the exact
+		// detection boundary.
 		return Finding{}, false
 	}
 
@@ -184,42 +228,52 @@ func setFieldNames(lit *ast.CompositeLit) (set map[string]bool, positional bool)
 	return set, false
 }
 
-// hasFieldSourcedValue reports whether any field in a keyed composite literal
-// is set from a plain field read on some other value (an expression like
-// src.Content, seen through any number of & / * / parens). A literal built
-// entirely from constants, bare locals, call results, and package-qualified
-// names (enum constants, http.MethodGet, ...) was authored fresh; one that
-// forwards a field from elsewhere is, structurally, a rebuild.
+// hasFieldSourcedValue reports whether any element of a composite literal
+// (keyed or positional) is set from an expression that reads existing data —
+// a field or index read anywhere in its subtree — as opposed to one authored
+// fresh from constants, locals, and call results (method or otherwise). See
+// LossyRebuilds' doc for exactly what shapes this does and does not catch.
 func hasFieldSourcedValue(p *packages.Package, lit *ast.CompositeLit) bool {
 	for _, elt := range lit.Elts {
-		kv, ok := elt.(*ast.KeyValueExpr)
-		if ok && isFieldRead(p, kv.Value) {
+		value := elt
+		if kv, ok := elt.(*ast.KeyValueExpr); ok {
+			value = kv.Value
+		}
+		if readsExistingData(p, value) {
 			return true
 		}
 	}
 	return false
 }
 
-// isFieldRead unwraps &x, *x, and (x) to see whether the expression underneath
-// selects a struct field — as opposed to a method value or a package-qualified
-// name, both of which are also *ast.SelectorExpr but read nothing off a value
-// in scope.
-func isFieldRead(p *packages.Package, e ast.Expr) bool {
-	for {
-		switch v := e.(type) {
-		case *ast.UnaryExpr:
-			e = v.X
-		case *ast.StarExpr:
-			e = v.X
-		case *ast.ParenExpr:
-			e = v.X
-		case *ast.SelectorExpr:
-			sel, ok := p.TypesInfo.Selections[v]
-			return ok && sel.Kind() == types.FieldVal
-		default:
+// readsExistingData walks e's entire expression subtree (so a conversion,
+// concatenation, index, or nested sub-literal wrapping a field read still
+// counts) looking for a field selection or an index expression.
+//
+// A narrow rule counting method calls on a concrete (non-interface) receiver
+// was tried, to recover the streaming.go:444 shape (state.accumulatedContent())
+// — see LossyRebuilds' doc for why it was reverted: receiver concreteness
+// does not separate a data read from an ordinary computed getter, and the
+// measured false-positive cost was far too high.
+func readsExistingData(p *packages.Package, e ast.Expr) bool {
+	found := false
+	ast.Inspect(e, func(n ast.Node) bool {
+		if found {
 			return false
 		}
-	}
+		switch v := n.(type) {
+		case *ast.IndexExpr:
+			found = true
+			return false
+		case *ast.SelectorExpr:
+			if sel, ok := p.TypesInfo.Selections[v]; ok && sel.Kind() == types.FieldVal {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
 }
 
 // droppedFieldNames returns the sorted names present in exported but absent

--- a/tools/seamscan/lossy.go
+++ b/tools/seamscan/lossy.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"sort"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// LossyRebuilds reports composite literals that set materially fewer exported
+// fields than their struct type has.
+//
+// This is the shape that dropped types.Message.FinishReason in #1681: a fresh
+// Message was built from a narrower pipeline type with four of thirteen fields
+// set, so everything else silently became the zero value. Detecting it needs
+// resolved types — the full field set of a named struct is not recoverable from
+// syntax alone, which is why this cannot be a regex.
+//
+// minFields suppresses small structs, where partial construction is usually
+// deliberate. minDropped suppresses near-complete literals.
+//
+// The scan deliberately loads only the non-test package (packages.Config.Tests
+// is left false): #1681 was production code, and asking go/packages for the
+// "[pkg.test]" variant too would parse every production file in the package
+// twice (once under the plain package, once under its test variant) and
+// double-count every finding in it, on top of surfacing enormous volumes of
+// deliberate partial construction in test fixtures that swamp real signal.
+func LossyRebuilds(patterns []string, minFields, minDropped int) ([]Finding, error) {
+	var out []Finding
+	for _, pattern := range patterns {
+		found, err := lossyRebuildsInPattern(pattern, minFields, minDropped)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, found...)
+	}
+	return out, nil
+}
+
+// lossyRebuildsInPattern loads the single pattern (a filesystem path, plain or
+// with a "/..." recursive suffix) and reports lossy rebuilds found in it.
+//
+// Go's module resolution keys off the process working directory, not off the
+// pattern string: "go list /abs/path/..." run with the working directory
+// fixed at this tool's own module fails with "directory prefix ... does not
+// contain main module or its selected dependencies" whenever the pattern
+// names some other module entirely — which is every real invocation, since
+// this tool's own module is never the thing being scanned. splitPatternDir
+// turns the pattern into (Dir, listPattern) so packages.Load's working
+// directory sits inside the target itself; from there Go's normal upward
+// go.work search does the right thing in both cases this tool needs: a real
+// scan target that is part of a multi-module workspace resolves against that
+// workspace, and an isolated single-module fixture (as the tests build) falls
+// back to its own go.mod because no go.work is reachable above it.
+func lossyRebuildsInPattern(pattern string, minFields, minDropped int) ([]Finding, error) {
+	dir, listPattern := splitPatternDir(pattern)
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo,
+		Dir: dir,
+	}
+	pkgs, err := packages.Load(cfg, listPattern)
+	if err != nil {
+		return nil, fmt.Errorf("loading packages for %q: %w", pattern, err)
+	}
+
+	var out []Finding
+	packages.Visit(pkgs, nil, func(p *packages.Package) {
+		if p.TypesInfo == nil {
+			return
+		}
+		for _, file := range p.Syntax {
+			ast.Inspect(file, func(n ast.Node) bool {
+				lit, ok := n.(*ast.CompositeLit)
+				if !ok {
+					return true
+				}
+				f, ok := checkLiteral(p, lit, minFields, minDropped)
+				if ok {
+					out = append(out, f)
+				}
+				return true
+			})
+		}
+	})
+	return out, nil
+}
+
+// recursivePattern is the go/packages pattern for "this directory and
+// everything under it," used once splitPatternDir has resolved the directory
+// to run the query from.
+const recursivePattern = "./..."
+
+// splitPatternDir splits a filesystem-path package pattern into a directory
+// to run the query from and a pattern relative to that directory. "dir/..."
+// becomes ("dir", "./..."); a bare directory becomes (dir, ".").
+func splitPatternDir(pattern string) (dir, listPattern string) {
+	if rest, ok := strings.CutSuffix(pattern, "/..."); ok {
+		if rest == "" {
+			rest = "."
+		}
+		return rest, recursivePattern
+	}
+	if pattern == "..." {
+		return ".", recursivePattern
+	}
+	return pattern, "."
+}
+
+// checkLiteral decides whether one composite literal is a lossy rebuild.
+func checkLiteral(
+	p *packages.Package, lit *ast.CompositeLit, minFields, minDropped int,
+) (Finding, bool) {
+	st, name := structType(p.TypesInfo.TypeOf(lit))
+	if st == nil {
+		return Finding{}, false
+	}
+
+	exported := exportedFieldNames(st)
+	if len(exported) < minFields {
+		return Finding{}, false
+	}
+
+	set, positional := setFieldNames(lit)
+	if positional {
+		// A positional literal sets every field, so it cannot be lossy.
+		return Finding{}, false
+	}
+	if !hasFieldSourcedValue(p, lit) {
+		// Nothing here reads a field off some other value — this literal was
+		// authored from scratch (constants, locals, call results), the normal
+		// shape of a sparse builder/result type where the caller or a later
+		// stage is expected to fill in the rest. #1681 forwarded fields read
+		// off an existing value of a related type (result.Response.Content);
+		// requiring that shape is what tells a rebuild-in-progress apart from
+		// an ordinary constructor.
+		return Finding{}, false
+	}
+
+	dropped := droppedFieldNames(exported, set)
+	if len(dropped) < minDropped {
+		return Finding{}, false
+	}
+
+	pos := p.Fset.Position(lit.Pos())
+	return Finding{
+		Kind:    "lossy-rebuild",
+		File:    pos.Filename,
+		Line:    pos.Line,
+		Subject: fmt.Sprintf("%s (%d/%d exported fields set)", name, len(set), len(exported)),
+		Detail:  "unset: " + strings.Join(dropped, ", "),
+	}, true
+}
+
+// exportedFieldNames returns the set of exported field names on st.
+func exportedFieldNames(st *types.Struct) map[string]bool {
+	exported := map[string]bool{}
+	for i := 0; i < st.NumFields(); i++ {
+		if fld := st.Field(i); fld.Exported() {
+			exported[fld.Name()] = true
+		}
+	}
+	return exported
+}
+
+// setFieldNames returns the field names set by a keyed composite literal. If
+// the literal is positional (or empty of keyed elements while non-empty), it
+// reports positional=true, since a positional literal sets every field by
+// definition.
+func setFieldNames(lit *ast.CompositeLit) (set map[string]bool, positional bool) {
+	set = map[string]bool{}
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			return nil, true
+		}
+		if id, ok := kv.Key.(*ast.Ident); ok {
+			set[id.Name] = true
+		}
+	}
+	return set, false
+}
+
+// hasFieldSourcedValue reports whether any field in a keyed composite literal
+// is set from a plain field read on some other value (an expression like
+// src.Content, seen through any number of & / * / parens). A literal built
+// entirely from constants, bare locals, call results, and package-qualified
+// names (enum constants, http.MethodGet, ...) was authored fresh; one that
+// forwards a field from elsewhere is, structurally, a rebuild.
+func hasFieldSourcedValue(p *packages.Package, lit *ast.CompositeLit) bool {
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if ok && isFieldRead(p, kv.Value) {
+			return true
+		}
+	}
+	return false
+}
+
+// isFieldRead unwraps &x, *x, and (x) to see whether the expression underneath
+// selects a struct field — as opposed to a method value or a package-qualified
+// name, both of which are also *ast.SelectorExpr but read nothing off a value
+// in scope.
+func isFieldRead(p *packages.Package, e ast.Expr) bool {
+	for {
+		switch v := e.(type) {
+		case *ast.UnaryExpr:
+			e = v.X
+		case *ast.StarExpr:
+			e = v.X
+		case *ast.ParenExpr:
+			e = v.X
+		case *ast.SelectorExpr:
+			sel, ok := p.TypesInfo.Selections[v]
+			return ok && sel.Kind() == types.FieldVal
+		default:
+			return false
+		}
+	}
+}
+
+// droppedFieldNames returns the sorted names present in exported but absent
+// from set.
+func droppedFieldNames(exported, set map[string]bool) []string {
+	var dropped []string
+	for f := range exported {
+		if !set[f] {
+			dropped = append(dropped, f)
+		}
+	}
+	sort.Strings(dropped)
+	return dropped
+}
+
+// structType unwraps pointers and named types to the underlying struct,
+// returning it with a readable type name.
+func structType(t types.Type) (*types.Struct, string) {
+	if t == nil {
+		return nil, ""
+	}
+	name := t.String()
+	if ptr, ok := t.Underlying().(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	st, ok := t.Underlying().(*types.Struct)
+	if !ok {
+		return nil, ""
+	}
+	return st, name
+}

--- a/tools/seamscan/lossy.go
+++ b/tools/seamscan/lossy.go
@@ -201,7 +201,7 @@ func checkLiteral(
 		File:    pos.Filename,
 		Line:    pos.Line,
 		Subject: fmt.Sprintf("%s (%d/%d exported fields set)", name, len(set), len(exported)),
-		Detail:  "unset: " + strings.Join(dropped, ", "),
+		Detail:  "not set in literal: " + strings.Join(dropped, ", "),
 	}, true
 }
 

--- a/tools/seamscan/lossy.go
+++ b/tools/seamscan/lossy.go
@@ -44,8 +44,14 @@ import (
 // (string(src.A), src.A+"!", src.Items[0], Inner{X: src.A}) — plus any
 // slice/array/map index read, regardless of what it indexes.
 //
-// What it does not detect: any method call, including one that's really just
-// a field forwarded through a getter. A narrow rule counting calls to a
+// What it does not detect: a method call whose receiver and arguments contain
+// no field or index read anywhere — state.accumulatedContent() and f(x) are
+// invisible, even when the callee really is just forwarding a field through a
+// getter. Note the converse: because the walk covers the whole subtree
+// including a call's receiver chain, x.Field.Method() DOES qualify (the
+// receiver reads a field), so some findings are method-call values whose
+// result may be unrelated to the field read — resp.Message.GetContent() and
+// int(d.turns.Load()) both fire on that basis. A narrow rule counting calls to a
 // concrete (non-interface) receiver's method was tried specifically to
 // recover the streaming twin of #1681 at sdk/streaming.go:444
 // (state.accumulatedContent()), which is exactly that shape. It was reverted:

--- a/tools/seamscan/lossy_test.go
+++ b/tools/seamscan/lossy_test.go
@@ -45,6 +45,12 @@ func Rebuild(src Wide) Wide {
 }
 
 // A literal setting every field is not lossy, however many fields there are.
+//
+// The literal must still contain a field-sourced value (s.A, s.B) so this
+// exercises the completeness check itself rather than being suppressed
+// earlier by hasFieldSourcedValue: a mutation that made droppedFieldNames
+// ignore what the literal actually sets (reporting every exported field as
+// dropped regardless) must turn this from empty to non-empty.
 func TestLossyRebuilds_IgnoresCompleteLiteral(t *testing.T) {
 	dir := writeModule(t, `package m
 
@@ -52,8 +58,8 @@ type Wide struct {
 	A, B, C, D string
 }
 
-func Build() Wide {
-	return Wide{A: "a", B: "b", C: "c", D: "d"}
+func Build(s Wide) Wide {
+	return Wide{A: s.A, B: s.B, C: "c", D: "d"}
 }
 `)
 
@@ -62,16 +68,23 @@ func Build() Wide {
 	assert.Empty(t, got)
 }
 
-// Small structs are noise: a 2-field literal setting 1 field is usually fine.
+// Small structs are noise: a 3-field struct with 1 field set is usually fine.
+//
+// Trio has exactly 3 exported fields, one below the minFields=4 threshold
+// used here, but enough that dropping 2 of them (B, C) clears minDropped=2 —
+// unlike a 2-field Pair, which can never drop 2 fields and so cannot
+// distinguish "the minFields gate ran" from "the minFields gate was deleted."
+// The literal must contain a field-sourced value (s.A) so this test is not
+// short-circuited by hasFieldSourcedValue before the gate under test runs.
 func TestLossyRebuilds_IgnoresSmallStructs(t *testing.T) {
 	dir := writeModule(t, `package m
 
-type Pair struct {
-	A, B string
+type Trio struct {
+	A, B, C string
 }
 
-func Build() Pair {
-	return Pair{A: "a"}
+func Build(s Trio) Trio {
+	return Trio{A: s.A}
 }
 `)
 
@@ -81,6 +94,12 @@ func Build() Pair {
 }
 
 // Unexported fields are not the caller's business and must not count.
+//
+// All four exported fields are set (one of them, A, via a field-sourced
+// value so the literal isn't excluded before this check runs), so the
+// correct result is empty. A mutation that counted the three unexported
+// fields (e, f, g) as exported would make them look dropped and produce a
+// finding.
 func TestLossyRebuilds_IgnoresUnexportedFields(t *testing.T) {
 	dir := writeModule(t, `package m
 
@@ -89,17 +108,24 @@ type Mixed struct {
 	e, f, g    string
 }
 
-func Build() Mixed {
-	return Mixed{A: "a", B: "b", C: "c", D: "d"}
+func Build(s Mixed) Mixed {
+	return Mixed{A: s.A, B: s.B, C: "c", D: "d"}
 }
 `)
 
 	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
-	require.NoError(t, err)
+	require.NoError(t, err, "all four exported fields are set; unexported ones are irrelevant")
 	assert.Empty(t, got, "all four exported fields are set; unexported ones are irrelevant")
 }
 
-// Positional literals set every field by definition.
+// Positional literals set every field by definition — but only because
+// setFieldNames reports positional=true and checkLiteral returns before ever
+// computing dropped fields. The literal here uses field-sourced values
+// (s.A, s.B) so hasFieldSourcedValue would say yes if reached: if the
+// positional gate is deleted, checkLiteral falls through to
+// droppedFieldNames(exported, nil) — since setFieldNames returns a nil set
+// for a positional literal — which treats every exported field as dropped
+// and reports a spurious 100%-dropped finding on a fully-specified literal.
 func TestLossyRebuilds_IgnoresPositionalLiteral(t *testing.T) {
 	dir := writeModule(t, `package m
 
@@ -107,8 +133,8 @@ type Wide struct {
 	A, B, C, D string
 }
 
-func Build() Wide {
-	return Wide{"a", "b", "c", "d"}
+func Build(s Wide) Wide {
+	return Wide{s.A, s.B, "c", "d"}
 }
 `)
 
@@ -208,4 +234,194 @@ func Build() Wide {
 	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
 	require.NoError(t, err)
 	assert.Empty(t, got, "no field is read off another value, so this is a fresh build, not a rebuild")
+}
+
+// TestLossyRebuilds_DetectsNestedFieldReads pins the post-review broadening:
+// a field read counts wherever it appears in the value's expression subtree,
+// not just as the top-level expression. Each of these wraps a field read in
+// a conversion, a concatenation, and an index expression respectively — all
+// three were rejected by the pre-review isFieldRead, which only unwrapped
+// &/*/parens around a bare selector.
+func TestLossyRebuilds_DetectsNestedFieldReads(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Source struct {
+	A     string
+	Items []string
+}
+
+type Wide struct {
+	A, B, C, D, E, F string
+}
+
+func BuildConversion(s Source) Wide {
+	return Wide{A: string(s.A), B: "b"}
+}
+
+func BuildConcatenation(s Source) Wide {
+	return Wide{A: s.A + "!", B: "b"}
+}
+
+func BuildIndex(s Source) Wide {
+	return Wide{A: s.Items[0], B: "b"}
+}
+`)
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	require.NoError(t, err)
+	require.Len(t, got, 3, "conversion, concatenation, and index reads must all be recognized as field-sourced")
+}
+
+// TestLossyRebuilds_DetectsConcreteMethodCallSource pins the narrow
+// method-call boundary: LossyRebuilds does not count a method call as
+// reading existing data, on a concrete receiver or an interface one. A
+// narrow rule recovering concrete-receiver calls (to catch the streaming
+// twin of #1681, state.accumulatedContent() at sdk/streaming.go:444) was
+// tried and reverted — see LossyRebuilds' doc for why: it could not tell
+// state.accumulatedContent() (a real data read) apart from the eval-handler
+// convention's h.Type() (a hardcoded getter), and counting both drove
+// runtime/hooks+runtime/evals from 14 findings to 186. streaming.go:444 is
+// therefore a known false negative.
+func TestLossyRebuilds_IgnoresMethodCallSource(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type State struct {
+	buf string
+}
+
+func (s *State) Content() string { return s.buf }
+
+type Reader interface {
+	Content() string
+}
+
+type Wide struct {
+	A, B, C, D, E, F string
+}
+
+func BuildConcrete(s *State) Wide {
+	return Wide{A: s.Content(), B: "b"}
+}
+
+func BuildInterface(r Reader) Wide {
+	return Wide{A: r.Content(), B: "b"}
+}
+`)
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	require.NoError(t, err)
+	assert.Empty(t, got, "neither a concrete-receiver nor an interface method call is a field read")
+}
+
+// TestLossyRebuilds_IgnoresIndirectFieldForwarding plainly pins the far edge
+// of the recall boundary documented on LossyRebuilds: a value copied out of a
+// field by an earlier statement, a parameter forwarded opaquely, and a plain
+// (non-method) function's return value are all indistinguishable, at this
+// pass, from data authored fresh — none of them contain a field read, index
+// read, or concrete method call anywhere in the literal's own value
+// expression. Recovering these needs data-flow tracing this tool doesn't do.
+func TestLossyRebuilds_IgnoresIndirectFieldForwarding(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Source struct {
+	A string
+}
+
+type Wide struct {
+	A, B, C, D, E, F string
+}
+
+func fresh() string { return "x" }
+
+func BuildFromLocal(s Source) Wide {
+	x := s.A
+	return Wide{A: x, B: "b"}
+}
+
+func BuildFromParam(a string) Wide {
+	return Wide{A: a, B: "b"}
+}
+
+func BuildFromFunc() Wide {
+	return Wide{A: fresh(), B: "b"}
+}
+`)
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestLossyRebuilds_DoesNotDoubleCountViaTestVariant pins the Tests:false
+// decision: go/packages' "[pkg.test]" variant shares the same non-test syntax
+// as the plain package, so loading with Tests:true would parse — and report
+// — every production-code literal once per variant. This fixture has both a
+// production file and a _test.go file in the same package, which no other
+// fixture in this file does.
+func TestLossyRebuilds_DoesNotDoubleCountViaTestVariant(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/m\n\ngo 1.26.0\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.go"), []byte(`package m
+
+type Wide struct {
+	A, B, C, D, E, F string
+}
+
+func Rebuild(src Wide) Wide {
+	return Wide{A: src.A, B: src.B}
+}
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a_test.go"), []byte(`package m
+
+import "testing"
+
+func TestSomething(t *testing.T) {
+	_ = Rebuild(Wide{})
+}
+`), 0o600))
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	require.NoError(t, err)
+	assert.Len(t, got, 1, "the production literal in a.go must be counted exactly once, "+
+		"not once per package variant ([pkg] and [pkg.test])")
+}
+
+// TestLossyRebuilds_ErrorsOnUnloadablePattern pins Finding 1: a directory
+// go/packages cannot resolve to any module at all (no reachable go.mod) must
+// surface as an error, not a silent empty result.
+func TestLossyRebuilds_ErrorsOnUnloadablePattern(t *testing.T) {
+	dir := t.TempDir() // deliberately no go.mod
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.go"), []byte(`package m
+
+type Wide struct{ A, B string }
+`), 0o600))
+
+	_, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	assert.Error(t, err)
+}
+
+// TestLossyRebuilds_ErrorsOnRootNotCoveredByGoWork reproduces the exact shape
+// that used to make a whole-repo scan silently report 0 findings and exit 0:
+// a go.work exists, but the directory being scanned (here, the workspace
+// root) is not itself a module and is not one of the workspace's members, so
+// "go list ./..." from that directory fails with "directory prefix . does
+// not contain modules listed in go.work" — a package-level load error, not a
+// Go error return from packages.Load, so it must be checked explicitly.
+func TestLossyRebuilds_ErrorsOnRootNotCoveredByGoWork(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "modA")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.work"),
+		[]byte("go 1.26.0\n\nuse (\n\t./modA\n)\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "go.mod"),
+		[]byte("module example.com/modA\n\ngo 1.26.0\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "a.go"), []byte(`package m
+
+type Wide struct{ A, B string }
+`), 0o600))
+
+	_, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	assert.Error(t, err,
+		"scanning the workspace root itself (not a module member) must not silently report zero findings")
 }

--- a/tools/seamscan/lossy_test.go
+++ b/tools/seamscan/lossy_test.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeModule writes a single-package module to a temp dir and returns its path.
+// go/packages needs a real module to resolve types.
+func writeModule(t *testing.T, src string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/m\n\ngo 1.26.0\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.go"), []byte(src), 0o600))
+	return dir
+}
+
+func TestLossyRebuilds_ReportsDroppedFields(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Wide struct {
+	A, B, C, D, E, F string
+}
+
+func Rebuild(src Wide) Wide {
+	return Wide{A: src.A, B: src.B}
+}
+`)
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "lossy-rebuild", got[0].Kind)
+	assert.Contains(t, got[0].Subject, "Wide")
+	// The point of the finding is naming what was dropped.
+	for _, f := range []string{"C", "D", "E", "F"} {
+		assert.Contains(t, got[0].Detail, f)
+	}
+}
+
+// A literal setting every field is not lossy, however many fields there are.
+func TestLossyRebuilds_IgnoresCompleteLiteral(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Wide struct {
+	A, B, C, D string
+}
+
+func Build() Wide {
+	return Wide{A: "a", B: "b", C: "c", D: "d"}
+}
+`)
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// Small structs are noise: a 2-field literal setting 1 field is usually fine.
+func TestLossyRebuilds_IgnoresSmallStructs(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Pair struct {
+	A, B string
+}
+
+func Build() Pair {
+	return Pair{A: "a"}
+}
+`)
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// Unexported fields are not the caller's business and must not count.
+func TestLossyRebuilds_IgnoresUnexportedFields(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Mixed struct {
+	A, B, C, D string
+	e, f, g    string
+}
+
+func Build() Mixed {
+	return Mixed{A: "a", B: "b", C: "c", D: "d"}
+}
+`)
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	require.NoError(t, err)
+	assert.Empty(t, got, "all four exported fields are set; unexported ones are irrelevant")
+}
+
+// Positional literals set every field by definition.
+func TestLossyRebuilds_IgnoresPositionalLiteral(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Wide struct {
+	A, B, C, D string
+}
+
+func Build() Wide {
+	return Wide{"a", "b", "c", "d"}
+}
+`)
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestLossyRebuilds_DetectsTheMessageRebuildShape reproduces the #1681 defect
+// in miniature: a wide struct rebuilt from a narrower source with most fields
+// left zero. The live acceptance run against commit 53441944 is documented in
+// the plan; this keeps the signature honest afterwards.
+func TestLossyRebuilds_DetectsTheMessageRebuildShape(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Message struct {
+	Role         string
+	Content      string
+	Parts        []string
+	CostInfo     *int
+	FinishReason string
+	Meta         map[string]any
+	Reasoning    *int
+	Timestamp    int64
+	LatencyMs    int64
+	ToolCalls    []string
+	Validations  []string
+	Name         string
+	ID           string
+}
+
+type Narrow struct {
+	Content string
+	Parts   []string
+}
+
+func build(src Narrow, cost *int) *Message {
+	return &Message{
+		Role:     "assistant",
+		Content:  src.Content,
+		Parts:    src.Parts,
+		CostInfo: cost,
+	}
+}
+`)
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 5, 3)
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Contains(t, got[0].Detail, "FinishReason",
+		"the field that actually broke #1681 must be named")
+	assert.Contains(t, got[0].Subject, "4/13")
+}
+
+func TestSplitPatternDir(t *testing.T) {
+	cases := []struct {
+		name        string
+		pattern     string
+		wantDir     string
+		wantPattern string
+	}{
+		{"recursive suffix", "some/dir/...", "some/dir", "./..."},
+		{"recursive suffix at root", "/...", ".", "./..."},
+		{"bare ellipsis", "...", ".", "./..."},
+		{"plain directory", "some/dir", "some/dir", "."},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir, pattern := splitPatternDir(c.pattern)
+			assert.Equal(t, c.wantDir, dir)
+			assert.Equal(t, c.wantPattern, pattern)
+		})
+	}
+}
+
+// TestLossyRebuilds_IgnoresFreshBuildFromScratch pins the discriminator added
+// after Step 6's false-positive measurement: a literal whose values are all
+// constants, locals, or call results (never a field read off some other
+// value) was authored fresh, not rebuilt, however many fields it drops. This
+// is the shape of every eval-handler result constructor in
+// runtime/evals/handlers, which otherwise swamped the signature with noise.
+func TestLossyRebuilds_IgnoresFreshBuildFromScratch(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Wide struct {
+	A, B, C, D, E, F string
+}
+
+func label() string { return "x" }
+
+func Build() Wide {
+	return Wide{A: "a", B: label()}
+}
+`)
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	require.NoError(t, err)
+	assert.Empty(t, got, "no field is read off another value, so this is a fresh build, not a rebuild")
+}

--- a/tools/seamscan/lossy_test.go
+++ b/tools/seamscan/lossy_test.go
@@ -42,6 +42,13 @@ func Rebuild(src Wide) Wide {
 	for _, f := range []string{"C", "D", "E", "F"} {
 		assert.Contains(t, got[0].Detail, f)
 	}
+	// File/Line are part of the finding's identity, not just display — a
+	// mutation blanking File: pos.Filename -> "" would collapse this finding
+	// together with every other same-named struct's findings under the
+	// guard script's kind+file+subject comparison key, and Line is how a
+	// human reaches the literal from the report.
+	assert.Equal(t, filepath.Join(dir, "a.go"), got[0].File)
+	assert.Equal(t, 8, got[0].Line)
 }
 
 // A literal setting every field is not lossy, however many fields there are.
@@ -270,6 +277,32 @@ func BuildIndex(s Source) Wide {
 	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
 	require.NoError(t, err)
 	require.Len(t, got, 3, "conversion, concatenation, and index reads must all be recognized as field-sourced")
+}
+
+// TestLossyRebuilds_DetectsBareIndexRead pins the *ast.IndexExpr case in
+// readsExistingData directly: "items" here is a bare slice parameter, not a
+// struct field, so this literal can only qualify as reading existing data
+// via the index-read case, unlike DetectsNestedFieldReads' BuildIndex
+// example (s.Items[0]), which already qualifies through its *ast.SelectorExpr
+// on s.Items even with the IndexExpr case deleted entirely. The package doc
+// and readsExistingData's docstring both claim "any slice/array/map index
+// read, regardless of what it indexes" is covered; this is what actually
+// pins that claim.
+func TestLossyRebuilds_DetectsBareIndexRead(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Wide struct {
+	A, B, C, D, E, F string
+}
+
+func Build(items []string) Wide {
+	return Wide{A: items[0], B: "b"}
+}
+`)
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "an index read on a bare parameter (not a struct field) must qualify as field-sourced")
 }
 
 // TestLossyRebuilds_DetectsConcreteMethodCallSource pins the narrow

--- a/tools/seamscan/main.go
+++ b/tools/seamscan/main.go
@@ -1,0 +1,58 @@
+// Command seamscan reports candidate test-quality problems: assertions that
+// cannot fail, and handoffs between components that no test exercises.
+//
+// It emits candidates only. Deciding whether a candidate is a real defect is
+// the job of the audit-test-seams skill.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, "seamscan:", err)
+		os.Exit(1)
+	}
+}
+
+// run takes an io.Writer rather than *os.File so a test can capture output.
+func run(args []string, stdout io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: seamscan weak-assertions [--text] <path> [<path> ...]")
+	}
+
+	cmd, rest := args[0], args[1:]
+	fs := flag.NewFlagSet(cmd, flag.ContinueOnError)
+	text := fs.Bool("text", false, "human-readable output instead of JSON")
+	if err := fs.Parse(rest); err != nil {
+		return err
+	}
+	paths := fs.Args()
+	if len(paths) == 0 {
+		paths = []string{"."}
+	}
+
+	var (
+		found []Finding
+		err   error
+	)
+	switch cmd {
+	case "weak-assertions":
+		found, err = WeakAssertions(paths)
+	default:
+		return fmt.Errorf("unknown subcommand %q", cmd)
+	}
+	if err != nil {
+		return err
+	}
+
+	if *text {
+		EmitText(stdout, found)
+		return nil
+	}
+	return EmitJSON(stdout, found)
+}

--- a/tools/seamscan/main.go
+++ b/tools/seamscan/main.go
@@ -12,6 +12,13 @@ import (
 	"os"
 )
 
+// defaultMinFields/defaultMinDropped tune the "seams" lossy-rebuild signature
+// for signal on this codebase; see LossyRebuilds for what they gate.
+const (
+	defaultMinFields  = 5
+	defaultMinDropped = 3
+)
+
 func main() {
 	if err := run(os.Args[1:], os.Stdout); err != nil {
 		fmt.Fprintln(os.Stderr, "seamscan:", err)
@@ -22,12 +29,15 @@ func main() {
 // run takes an io.Writer rather than *os.File so a test can capture output.
 func run(args []string, stdout io.Writer) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: seamscan weak-assertions [--text] <path> [<path> ...]")
+		return fmt.Errorf(
+			"usage: seamscan <weak-assertions|seams> [--text] [--min-fields N] [--min-dropped N] <path> [<path> ...]")
 	}
 
 	cmd, rest := args[0], args[1:]
 	fs := flag.NewFlagSet(cmd, flag.ContinueOnError)
 	text := fs.Bool("text", false, "human-readable output instead of JSON")
+	minFields := fs.Int("min-fields", defaultMinFields, "ignore structs with fewer exported fields")
+	minDropped := fs.Int("min-dropped", defaultMinDropped, "ignore literals dropping fewer fields")
 	if err := fs.Parse(rest); err != nil {
 		return err
 	}
@@ -43,6 +53,8 @@ func run(args []string, stdout io.Writer) error {
 	switch cmd {
 	case "weak-assertions":
 		found, err = WeakAssertions(paths)
+	case "seams":
+		found, err = LossyRebuilds(paths, *minFields, *minDropped)
 	default:
 		return fmt.Errorf("unknown subcommand %q", cmd)
 	}

--- a/tools/seamscan/main_test.go
+++ b/tools/seamscan/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,9 +64,24 @@ func TestDoesNothing(t *testing.T) {
 }
 
 func TestRun_WeakAssertionsDefaultsToCurrentDir(t *testing.T) {
-	// No paths given: falls back to "." rather than erroring. Run from a temp
-	// dir with no Go files so the scan is a trivial no-op.
+	// No paths given: falls back to "." rather than erroring. Write a weak
+	// test file directly into the chdir'd directory so the default-to-"."
+	// scan actually finds something. A previous version of this test scanned
+	// an empty temp dir, where "defaulted to . and found nothing" is
+	// indistinguishable from "scanned nothing at all" — that version stayed
+	// green even with the `if len(paths) == 0 { paths = []string{"."} }`
+	// branch deleted from run, since fs.Args() being empty then left paths
+	// as a nil/empty slice and WeakAssertions(nil) also reports zero
+	// findings by iterating zero times.
 	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "x_test.go"), []byte(`package p
+
+import "testing"
+
+func TestDoesNothing(t *testing.T) {
+	_ = 1 + 1
+}
+`), 0o600))
 	t.Chdir(dir)
 
 	var buf bytes.Buffer
@@ -72,7 +89,26 @@ func TestRun_WeakAssertionsDefaultsToCurrentDir(t *testing.T) {
 
 	var got []Finding
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
-	assert.Empty(t, got)
+	require.Len(t, got, 1)
+	assert.Equal(t, "TestDoesNothing", got[0].Subject)
+}
+
+// TestRun_PropagatesSeamsAnalyzerError pins run()'s error propagation for the
+// "seams" subcommand: a path with no reachable go.mod makes LossyRebuilds
+// return an error (see TestLossyRebuilds_ErrorsOnUnloadablePattern), and run
+// must surface it rather than swallow it. Replacing `if err != nil { return
+// err }` with a no-op would leave this suite green everywhere else, since no
+// other run-level test drives an analyzer into an error path.
+func TestRun_PropagatesSeamsAnalyzerError(t *testing.T) {
+	dir := t.TempDir() // deliberately no go.mod anywhere reachable above it
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.go"), []byte(`package m
+
+type Wide struct{ A, B string }
+`), 0o600))
+
+	var buf bytes.Buffer
+	err := run([]string{"seams", dir + "/..."}, &buf)
+	assert.Error(t, err)
 }
 
 // TestRun_SeamsAppliesMinFieldsAndMinDroppedInOrder pins both the --min-fields

--- a/tools/seamscan/main_test.go
+++ b/tools/seamscan/main_test.go
@@ -74,3 +74,78 @@ func TestRun_WeakAssertionsDefaultsToCurrentDir(t *testing.T) {
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
 	assert.Empty(t, got)
 }
+
+// TestRun_SeamsAppliesMinFieldsAndMinDroppedInOrder pins both the --min-fields
+// and --min-dropped flags AND their order at the LossyRebuilds call site.
+// Wide has 6 exported fields; the literal sets 4 of them (via field-sourced
+// values, so it clears hasFieldSourcedValue), dropping 2 (E, F). With
+// min-fields=5 and min-dropped=2, both gates pass (6>=5, 2>=2) and a finding
+// is expected. Two distinct regressions would silently swap what these flags
+// mean to LossyRebuilds and both make this test fail:
+//   - registering --min-fields/--min-dropped after fs.Parse: Parse would
+//     reject them as undefined flags, and run would return an error instead
+//     of nil.
+//   - swapping the two ints at the LossyRebuilds(paths, *minFields,
+//     *minDropped) call site: minFields would effectively receive 2 (passes,
+//     6>=2) and minDropped would effectively receive 5 — but only 2 fields
+//     are dropped, so 2>=5 is false and the finding disappears.
+func TestRun_SeamsAppliesMinFieldsAndMinDroppedInOrder(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Wide struct {
+	A, B, C, D, E, F string
+}
+
+func Rebuild(src Wide) Wide {
+	return Wide{A: src.A, B: src.B, C: "c", D: "d"}
+}
+`)
+	var buf bytes.Buffer
+	err := run([]string{"seams", "--text", "--min-fields=5", "--min-dropped=2", dir}, &buf)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "lossy-rebuild")
+	assert.Contains(t, buf.String(), "Wide")
+}
+
+// TestRun_SeamsUsesDefaultThresholds exercises the "seams" subcommand with no
+// threshold flags at all, pinning the documented defaults (min-fields=5,
+// min-dropped=3) end to end through run(). Message has 6 exported fields and
+// the literal sets 2 of them via field-sourced values (src.Role, src.Content),
+// dropping 4 — both defaults are cleared.
+func TestRun_SeamsUsesDefaultThresholds(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Message struct {
+	Role, Content, FinishReason, Meta, Reasoning, Extra string
+}
+
+func Rebuild(src Message) *Message {
+	return &Message{Role: src.Role, Content: src.Content}
+}
+`)
+	var buf bytes.Buffer
+	require.NoError(t, run([]string{"seams", "--text", dir}, &buf))
+	assert.Contains(t, buf.String(), "lossy-rebuild")
+}
+
+// TestRun_SeamsEmitsJSONByDefault mirrors the weak-assertions coverage of the
+// default (non --text) output path for the seams subcommand.
+func TestRun_SeamsEmitsJSONByDefault(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Wide struct {
+	A, B, C, D, E, F string
+}
+
+func Rebuild(src Wide) Wide {
+	return Wide{A: src.A, B: src.B}
+}
+`)
+	var buf bytes.Buffer
+	require.NoError(t, run([]string{"seams", dir}, &buf))
+
+	var got []Finding
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "lossy-rebuild", got[0].Kind)
+}

--- a/tools/seamscan/main_test.go
+++ b/tools/seamscan/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun_NoArgsReturnsUsageError(t *testing.T) {
+	var buf bytes.Buffer
+	err := run(nil, &buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "usage")
+}
+
+func TestRun_UnknownSubcommandReturnsError(t *testing.T) {
+	var buf bytes.Buffer
+	err := run([]string{"bogus"}, &buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown subcommand "bogus"`)
+}
+
+func TestRun_BadFlagReturnsError(t *testing.T) {
+	var buf bytes.Buffer
+	err := run([]string{"weak-assertions", "--nope"}, &buf)
+	require.Error(t, err)
+}
+
+func TestRun_WeakAssertionsEmitsJSONByDefault(t *testing.T) {
+	dir := writeGo(t, "x_test.go", `package p
+
+import "testing"
+
+func TestDoesNothing(t *testing.T) {
+	_ = 1 + 1
+}
+`)
+	var buf bytes.Buffer
+	require.NoError(t, run([]string{"weak-assertions", dir}, &buf))
+
+	var got []Finding
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "TestDoesNothing", got[0].Subject)
+}
+
+func TestRun_WeakAssertionsTextFlagEmitsPlainText(t *testing.T) {
+	dir := writeGo(t, "x_test.go", `package p
+
+import "testing"
+
+func TestDoesNothing(t *testing.T) {
+	_ = 1 + 1
+}
+`)
+	var buf bytes.Buffer
+	require.NoError(t, run([]string{"weak-assertions", "--text", dir}, &buf))
+	assert.Contains(t, buf.String(), "no-assertion\tTestDoesNothing")
+}
+
+func TestRun_WeakAssertionsDefaultsToCurrentDir(t *testing.T) {
+	// No paths given: falls back to "." rather than erroring. Run from a temp
+	// dir with no Go files so the scan is a trivial no-op.
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	var buf bytes.Buffer
+	require.NoError(t, run([]string{"weak-assertions"}, &buf))
+
+	var got []Finding
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Empty(t, got)
+}

--- a/tools/seamscan/weakassert.go
+++ b/tools/seamscan/weakassert.go
@@ -9,6 +9,20 @@ import (
 	"strings"
 )
 
+// Finding kinds produced by classify/classifyBody.
+const (
+	kindNoAssertion   = "no-assertion"
+	kindWeakAssertion = "weak-assertion"
+)
+
+// testifyPackageAlias/testifyRequireAlias are the conventional local names
+// testify assertion packages are imported under (assert.Equal,
+// require.NoError, ...).
+const (
+	testifyPackageAlias = "assert"
+	testifyRequireAlias = "require"
+)
+
 // assertionsProvingNothing are testify calls that establish only that a call
 // did not fail. A test whose every assertion is one of these passes regardless
 // of whether the code under test produced the right answer.
@@ -83,14 +97,30 @@ func goTestFiles(root string) ([]string, error) {
 	return files, err
 }
 
-// inspectTestFunc classifies a test function and each of its subtests.
+// inspectTestFunc classifies a test function and, recursively, every t.Run
+// subtest nested inside it.
 func inspectTestFunc(fset *token.FileSet, path string, fn *ast.FuncDecl) []Finding {
 	var out []Finding
+	classifyBody(fset, path, fn.Name.Name, fn.Pos(), fn.Body, &out)
+	return out
+}
 
-	// Subtests first, and record their bodies so the parent is judged on the
-	// statements that are actually its own.
-	subBodies := map[ast.Node]bool{}
-	ast.Inspect(fn.Body, func(n ast.Node) bool {
+// subtestCall is one t.Run(name, func(t *testing.T) {...}) found directly
+// inside a body — "directly" meaning not itself nested inside some other
+// subtest's body discovered at this same level.
+type subtestCall struct {
+	name string
+	pos  token.Pos
+	body *ast.BlockStmt
+}
+
+// directSubtests finds every t.Run call that is a direct child of body. It
+// does not descend into a matched call's own FuncLit body, so a t.Run nested
+// two levels deep is reported only once, as a direct child of its immediate
+// parent — never double-counted as a child of body too.
+func directSubtests(body *ast.BlockStmt) []subtestCall {
+	var out []subtestCall
+	ast.Inspect(body, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok || !isTRun(call) || len(call.Args) < 2 {
 			return true
@@ -99,35 +129,45 @@ func inspectTestFunc(fset *token.FileSet, path string, fn *ast.FuncDecl) []Findi
 		if !ok {
 			return true
 		}
-		subBodies[lit.Body] = true
-		name := fn.Name.Name + "/" + subtestName(call.Args[0])
-		if k := classify(lit.Body, subBodies); k != "" {
-			out = append(out, Finding{
-				Kind:    k,
-				File:    path,
-				Line:    fset.Position(call.Pos()).Line,
-				Subject: name,
-			})
-		}
-		return true
+		out = append(out, subtestCall{name: subtestName(call.Args[0]), pos: call.Pos(), body: lit.Body})
+		return false
 	})
-
-	// The parent is only reported when it has no subtests of its own; a parent
-	// that exists purely to host t.Run calls asserts nothing by design.
-	if len(subBodies) == 0 {
-		if k := classify(fn.Body, nil); k != "" {
-			out = append(out, Finding{
-				Kind:    k,
-				File:    path,
-				Line:    fset.Position(fn.Pos()).Line,
-				Subject: fn.Name.Name,
-			})
-		}
-	}
 	return out
 }
 
-// classify returns "no-assertion", "weak-assertion", or "" for a body,
+// classifyBody classifies one test/subtest body and recurses into its own
+// direct subtests, appending every finding to out. subject is the full
+// slash-joined nesting path (e.g. "TestParent/outer/inner") and pos is the
+// position to report the finding at (the t.Run call site, or the function
+// position for the top-level test).
+//
+// A body that hosts subtests of its own is reported only when its own scope
+// (excluding those subtest bodies) contains a weak assertion: a parent that
+// merely hosts t.Run calls, with no assertion of its own, asserts nothing by
+// design and must not be flagged as "no-assertion".
+func classifyBody(fset *token.FileSet, path, subject string, pos token.Pos, body *ast.BlockStmt, out *[]Finding) {
+	children := directSubtests(body)
+
+	skip := make(map[ast.Node]bool, len(children))
+	for _, c := range children {
+		skip[c.body] = true
+	}
+
+	k := classify(body, skip)
+	report := k != ""
+	if len(children) > 0 {
+		report = k == kindWeakAssertion
+	}
+	if report {
+		*out = append(*out, Finding{Kind: k, File: path, Line: fset.Position(pos).Line, Subject: subject})
+	}
+
+	for _, c := range children {
+		classifyBody(fset, path, subject+"/"+c.name, c.pos, c.body, out)
+	}
+}
+
+// classify returns kindNoAssertion, kindWeakAssertion, or "" for a body,
 // skipping any nested subtest bodies which are reported separately.
 func classify(body *ast.BlockStmt, skip map[ast.Node]bool) string {
 	testify, native := collectAssertionCalls(body, skip)
@@ -136,14 +176,14 @@ func classify(body *ast.BlockStmt, skip map[ast.Node]bool) string {
 		return ""
 	}
 	if len(testify) == 0 {
-		return "no-assertion"
+		return kindNoAssertion
 	}
 	for _, name := range testify {
 		if !assertionsProvingNothing[name] {
 			return ""
 		}
 	}
-	return "weak-assertion"
+	return kindWeakAssertion
 }
 
 // collectAssertionCalls walks body, skipping any nested subtest bodies, and
@@ -164,8 +204,9 @@ type assertionCollector struct {
 	native  bool
 }
 
-// visit is an ast.Inspect callback: it records testify assertion calls and
-// native t.Error/t.Fatal calls, stepping over any nested subtest body.
+// visit is an ast.Inspect callback: it records testify assertion calls,
+// native t.Error/t.Fatal calls, and calls to locally-defined assertion
+// helpers, stepping over any nested subtest body.
 func (c *assertionCollector) visit(n ast.Node) bool {
 	if n == nil {
 		return false
@@ -177,23 +218,52 @@ func (c *assertionCollector) visit(n ast.Node) bool {
 	if !ok {
 		return true
 	}
-	sel, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok {
-		return true
-	}
-	pkg, ok := sel.X.(*ast.Ident)
-	if !ok {
-		return true
-	}
-	switch pkg.Name {
-	case "assert", "require":
-		c.testify = append(c.testify, sel.Sel.Name)
-	case "t":
-		if strings.HasPrefix(sel.Sel.Name, "Error") || strings.HasPrefix(sel.Sel.Name, "Fatal") {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		// A bare call like assertCard(t, got) or mustParse(...) verifies
+		// something internally (often via t.Fatalf) with no assert./require.
+		// call visible here. Treating it as a real assertion may miss a
+		// truly weak helper, but treating it as weak/no-assertion risks
+		// flagging a legitimate test — for a candidate-generating tool, the
+		// false positive is the worse failure mode.
+		if isAssertionHelperName(fn.Name) {
 			c.native = true
+		}
+	case *ast.SelectorExpr:
+		pkg, ok := fn.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		switch pkg.Name {
+		case testifyPackageAlias, testifyRequireAlias:
+			c.testify = append(c.testify, fn.Sel.Name)
+		case "t":
+			if strings.HasPrefix(fn.Sel.Name, "Error") || strings.HasPrefix(fn.Sel.Name, "Fatal") {
+				c.native = true
+			}
 		}
 	}
 	return true
+}
+
+// assertionHelperPrefixes are name prefixes (checked case-insensitively)
+// that mark a bare function call as a local assertion helper rather than
+// ordinary test logic.
+var assertionHelperPrefixes = []string{
+	testifyPackageAlias, testifyRequireAlias, "check", "verify", "must",
+}
+
+// isAssertionHelperName reports whether name looks like a locally-defined
+// assertion helper (assertCard, requireThing, checkThing, verifyThing,
+// mustThing, ...).
+func isAssertionHelperName(name string) bool {
+	lower := strings.ToLower(name)
+	for _, prefix := range assertionHelperPrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func isTRun(call *ast.CallExpr) bool {

--- a/tools/seamscan/weakassert.go
+++ b/tools/seamscan/weakassert.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// assertionsProvingNothing are testify calls that establish only that a call
+// did not fail. A test whose every assertion is one of these passes regardless
+// of whether the code under test produced the right answer.
+var assertionsProvingNothing = map[string]bool{
+	"NoError": true, "NoErrorf": true,
+	"Nil": true, "Nilf": true,
+	"NotNil": true, "NotNilf": true,
+}
+
+// WeakAssertions reports test functions and subtests whose assertions cannot
+// distinguish correct behavior from broken behavior.
+func WeakAssertions(paths []string) ([]Finding, error) {
+	var out []Finding
+	for _, root := range paths {
+		files, err := goTestFiles(root)
+		if err != nil {
+			return nil, err
+		}
+		for _, path := range files {
+			found, err := scanTestFile(path)
+			if err != nil {
+				// A file that does not parse is not our problem to report.
+				continue
+			}
+			out = append(out, found...)
+		}
+	}
+	return out, nil
+}
+
+// scanTestFile parses a single test file and classifies each of its Test*
+// functions.
+func scanTestFile(path string) ([]Finding, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	var out []Finding
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil || !strings.HasPrefix(fn.Name.Name, "Test") {
+			continue
+		}
+		out = append(out, inspectTestFunc(fset, path, fn)...)
+	}
+	return out, nil
+}
+
+// goTestFiles walks root collecting *_test.go paths. root is always a
+// caller-supplied analysis target (CLI args or test fixtures), never
+// untrusted request input.
+//
+//nolint:gosec // root is a trusted local analysis path, not request input
+func goTestFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if name := d.Name(); name == "vendor" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(p, "_test.go") {
+			files = append(files, p)
+		}
+		return nil
+	})
+	return files, err
+}
+
+// inspectTestFunc classifies a test function and each of its subtests.
+func inspectTestFunc(fset *token.FileSet, path string, fn *ast.FuncDecl) []Finding {
+	var out []Finding
+
+	// Subtests first, and record their bodies so the parent is judged on the
+	// statements that are actually its own.
+	subBodies := map[ast.Node]bool{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || !isTRun(call) || len(call.Args) < 2 {
+			return true
+		}
+		lit, ok := call.Args[1].(*ast.FuncLit)
+		if !ok {
+			return true
+		}
+		subBodies[lit.Body] = true
+		name := fn.Name.Name + "/" + subtestName(call.Args[0])
+		if k := classify(lit.Body, subBodies); k != "" {
+			out = append(out, Finding{
+				Kind:    k,
+				File:    path,
+				Line:    fset.Position(call.Pos()).Line,
+				Subject: name,
+			})
+		}
+		return true
+	})
+
+	// The parent is only reported when it has no subtests of its own; a parent
+	// that exists purely to host t.Run calls asserts nothing by design.
+	if len(subBodies) == 0 {
+		if k := classify(fn.Body, nil); k != "" {
+			out = append(out, Finding{
+				Kind:    k,
+				File:    path,
+				Line:    fset.Position(fn.Pos()).Line,
+				Subject: fn.Name.Name,
+			})
+		}
+	}
+	return out
+}
+
+// classify returns "no-assertion", "weak-assertion", or "" for a body,
+// skipping any nested subtest bodies which are reported separately.
+func classify(body *ast.BlockStmt, skip map[ast.Node]bool) string {
+	testify, native := collectAssertionCalls(body, skip)
+
+	if native {
+		return ""
+	}
+	if len(testify) == 0 {
+		return "no-assertion"
+	}
+	for _, name := range testify {
+		if !assertionsProvingNothing[name] {
+			return ""
+		}
+	}
+	return "weak-assertion"
+}
+
+// collectAssertionCalls walks body, skipping any nested subtest bodies, and
+// returns every testify assertion method invoked plus whether a native
+// t.Error/t.Fatal call was used.
+func collectAssertionCalls(body *ast.BlockStmt, skip map[ast.Node]bool) ([]string, bool) {
+	c := &assertionCollector{body: body, skip: skip}
+	ast.Inspect(body, c.visit)
+	return c.testify, c.native
+}
+
+// assertionCollector accumulates the assertion calls found while walking a
+// single test/subtest body.
+type assertionCollector struct {
+	body    *ast.BlockStmt
+	skip    map[ast.Node]bool
+	testify []string
+	native  bool
+}
+
+// visit is an ast.Inspect callback: it records testify assertion calls and
+// native t.Error/t.Fatal calls, stepping over any nested subtest body.
+func (c *assertionCollector) visit(n ast.Node) bool {
+	if n == nil {
+		return false
+	}
+	if b, ok := n.(*ast.BlockStmt); ok && c.skip[b] && b != c.body {
+		return false
+	}
+	call, ok := n.(*ast.CallExpr)
+	if !ok {
+		return true
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return true
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return true
+	}
+	switch pkg.Name {
+	case "assert", "require":
+		c.testify = append(c.testify, sel.Sel.Name)
+	case "t":
+		if strings.HasPrefix(sel.Sel.Name, "Error") || strings.HasPrefix(sel.Sel.Name, "Fatal") {
+			c.native = true
+		}
+	}
+	return true
+}
+
+func isTRun(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Run" {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	return ok && id.Name == "t"
+}
+
+// subtestName extracts a readable name from a t.Run first argument.
+func subtestName(arg ast.Expr) string {
+	if lit, ok := arg.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+		return strings.Trim(lit.Value, `"`)
+	}
+	return "?"
+}

--- a/tools/seamscan/weakassert.go
+++ b/tools/seamscan/weakassert.go
@@ -145,6 +145,18 @@ func directSubtests(body *ast.BlockStmt) []subtestCall {
 // (excluding those subtest bodies) contains a weak assertion: a parent that
 // merely hosts t.Run calls, with no assertion of its own, asserts nothing by
 // design and must not be flagged as "no-assertion".
+//
+// When a body delegates to subtests, any other nested function literal in its
+// own scope — a `newFixture := func(t *testing.T) {...}` helper shared by the
+// subtests, say — is fixture setup, not the parent's assertion surface: it
+// runs once per subtest that calls it, at a point the parent chose to
+// delegate away from. Without this, factoring identical fixture code out of
+// two subtests into one shared closure (pure DRY, no behavior change) could
+// flip the parent from unreported to reported, purely because its one weak
+// assertion (say, a `require.NoError` guarding construction) became visible
+// to the walk that used to only see it duplicated inside each *subtest* body
+// (already skipped). Assertions the parent makes directly in its own
+// statements, outside of any nested func literal, still count.
 func classifyBody(fset *token.FileSet, path, subject string, pos token.Pos, body *ast.BlockStmt, out *[]Finding) {
 	children := directSubtests(body)
 
@@ -153,7 +165,7 @@ func classifyBody(fset *token.FileSet, path, subject string, pos token.Pos, body
 		skip[c.body] = true
 	}
 
-	k := classify(body, skip)
+	k := classify(body, skip, len(children) > 0)
 	report := k != ""
 	if len(children) > 0 {
 		report = k == kindWeakAssertion
@@ -168,9 +180,11 @@ func classifyBody(fset *token.FileSet, path, subject string, pos token.Pos, body
 }
 
 // classify returns kindNoAssertion, kindWeakAssertion, or "" for a body,
-// skipping any nested subtest bodies which are reported separately.
-func classify(body *ast.BlockStmt, skip map[ast.Node]bool) string {
-	testify, native := collectAssertionCalls(body, skip)
+// skipping any nested subtest bodies which are reported separately. When
+// delegatesToSubtests is true, assertions inside any other nested function
+// literal are treated as fixture setup and excluded too — see classifyBody.
+func classify(body *ast.BlockStmt, skip map[ast.Node]bool, delegatesToSubtests bool) string {
+	testify, native := collectAssertionCalls(body, skip, delegatesToSubtests)
 
 	if native {
 		return ""
@@ -188,9 +202,11 @@ func classify(body *ast.BlockStmt, skip map[ast.Node]bool) string {
 
 // collectAssertionCalls walks body, skipping any nested subtest bodies, and
 // returns every testify assertion method invoked plus whether a native
-// t.Error/t.Fatal call was used.
-func collectAssertionCalls(body *ast.BlockStmt, skip map[ast.Node]bool) ([]string, bool) {
-	c := &assertionCollector{body: body, skip: skip}
+// t.Error/t.Fatal call was used. skipFuncLits additionally treats every other
+// nested function literal's body as out of scope (fixture helpers, not the
+// body's own assertion surface) — see classifyBody.
+func collectAssertionCalls(body *ast.BlockStmt, skip map[ast.Node]bool, skipFuncLits bool) ([]string, bool) {
+	c := &assertionCollector{body: body, skip: skip, skipFuncLits: skipFuncLits}
 	ast.Inspect(body, c.visit)
 	return c.testify, c.native
 }
@@ -198,26 +214,48 @@ func collectAssertionCalls(body *ast.BlockStmt, skip map[ast.Node]bool) ([]strin
 // assertionCollector accumulates the assertion calls found while walking a
 // single test/subtest body.
 type assertionCollector struct {
-	body    *ast.BlockStmt
-	skip    map[ast.Node]bool
-	testify []string
-	native  bool
+	body         *ast.BlockStmt
+	skip         map[ast.Node]bool
+	skipFuncLits bool
+	testify      []string
+	native       bool
 }
 
 // visit is an ast.Inspect callback: it records testify assertion calls,
 // native t.Error/t.Fatal calls, and calls to locally-defined assertion
-// helpers, stepping over any nested subtest body.
+// helpers, stepping over any nested subtest body (and, when skipFuncLits is
+// set, over every other nested function literal too — see classify).
 func (c *assertionCollector) visit(n ast.Node) bool {
 	if n == nil {
 		return false
 	}
-	if b, ok := n.(*ast.BlockStmt); ok && c.skip[b] && b != c.body {
+	if c.shouldSkip(n) {
 		return false
 	}
 	call, ok := n.(*ast.CallExpr)
 	if !ok {
 		return true
 	}
+	return c.recordCall(call)
+}
+
+// shouldSkip reports whether n roots a subtree outside this collector's
+// assertion surface: a nested subtest body (reported separately by its own
+// classifyBody call) or, when skipFuncLits is set, any other nested function
+// literal (fixture setup — see classify).
+func (c *assertionCollector) shouldSkip(n ast.Node) bool {
+	if b, ok := n.(*ast.BlockStmt); ok && c.skip[b] && b != c.body {
+		return true
+	}
+	_, isFuncLit := n.(*ast.FuncLit)
+	return isFuncLit && c.skipFuncLits
+}
+
+// recordCall inspects one call expression, recording it as a testify
+// assertion, a native (t.Error/t.Fatal or locally-defined helper) assertion,
+// or neither. Always returns true so ast.Inspect keeps descending into the
+// call's own arguments.
+func (c *assertionCollector) recordCall(call *ast.CallExpr) bool {
 	switch fn := call.Fun.(type) {
 	case *ast.Ident:
 		// A bare call like assertCard(t, got) or mustParse(...) verifies

--- a/tools/seamscan/weakassert_test.go
+++ b/tools/seamscan/weakassert_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeGo writes src to a temp dir as a Go file and returns the dir.
+func writeGo(t *testing.T, name, src string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(src), 0o600))
+	return dir
+}
+
+func TestWeakAssertions_FlagsNoAssertionTest(t *testing.T) {
+	dir := writeGo(t, "x_test.go", `package p
+
+import "testing"
+
+func TestDoesNothing(t *testing.T) {
+	_ = 1 + 1
+}
+`)
+
+	got, err := WeakAssertions([]string{dir})
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "no-assertion", got[0].Kind)
+	assert.Equal(t, "TestDoesNothing", got[0].Subject)
+}
+
+func TestWeakAssertions_FlagsErrorOnlyTest(t *testing.T) {
+	dir := writeGo(t, "x_test.go", `package p
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnlyChecksError(t *testing.T) {
+	err := doThing()
+	require.NoError(t, err)
+}
+`)
+
+	got, err := WeakAssertions([]string{dir})
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "weak-assertion", got[0].Kind)
+	assert.Equal(t, "TestOnlyChecksError", got[0].Subject)
+}
+
+// A test that checks a real value must NOT be reported — otherwise the guard
+// would fire on most of the suite and get switched off.
+func TestWeakAssertions_IgnoresRealAssertion(t *testing.T) {
+	dir := writeGo(t, "x_test.go", `package p
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChecksAValue(t *testing.T) {
+	got, err := doThing()
+	require.NoError(t, err)
+	require.Equal(t, 42, got)
+}
+`)
+
+	got, err := WeakAssertions([]string{dir})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// t.Error / t.Fatal are assertions without testify; not weak.
+func TestWeakAssertions_IgnoresTErrorStyle(t *testing.T) {
+	dir := writeGo(t, "x_test.go", `package p
+
+import "testing"
+
+func TestUsesTError(t *testing.T) {
+	if got := doThing(); got != 42 {
+		t.Errorf("got %d", got)
+	}
+}
+`)
+
+	got, err := WeakAssertions([]string{dir})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// Subtests are analysed as their own units, so a weak subtest inside a strong
+// parent is still reported.
+func TestWeakAssertions_AnalysesSubtestsSeparately(t *testing.T) {
+	dir := writeGo(t, "x_test.go", `package p
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParent(t *testing.T) {
+	t.Run("strong", func(t *testing.T) {
+		require.Equal(t, 1, one())
+	})
+	t.Run("weak", func(t *testing.T) {
+		require.NoError(t, doThing2())
+	})
+}
+`)
+
+	got, err := WeakAssertions([]string{dir})
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "weak-assertion", got[0].Kind)
+	assert.Equal(t, "TestParent/weak", got[0].Subject)
+}

--- a/tools/seamscan/weakassert_test.go
+++ b/tools/seamscan/weakassert_test.go
@@ -33,6 +33,27 @@ func TestDoesNothing(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.Equal(t, "no-assertion", got[0].Kind)
 	assert.Equal(t, "TestDoesNothing", got[0].Subject)
+	// File/Line are part of the finding's identity (the guard script keys on
+	// kind+file+subject) and are how a human reaches the flagged test, so
+	// both must be pinned, not just Kind/Subject: File: path -> "" or
+	// Line: fset.Position(pos).Line -> 0 would otherwise leave the suite
+	// green.
+	assert.Equal(t, filepath.Join(dir, "x_test.go"), got[0].File)
+	assert.Equal(t, 5, got[0].Line)
+}
+
+// A path WeakAssertions cannot walk at all (no such directory) must surface
+// as an error, not a silent empty result: files, _ := goTestFiles(root)
+// would turn a bad path into "0 findings, exit 0," which is exactly the
+// failure mode documented for a "/..." suffix passed to weak-assertions and
+// the failure mode the guard script's own error handling assumes can't
+// happen silently.
+func TestWeakAssertions_ErrorsOnNonexistentPath(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "does-not-exist")
+
+	_, err := WeakAssertions([]string{missing})
+	assert.Error(t, err)
 }
 
 func TestWeakAssertions_FlagsErrorOnlyTest(t *testing.T) {
@@ -269,6 +290,41 @@ func TestParent(t *testing.T) {
 	t.Run("one", func(t *testing.T) {
 		require.Equal(t, 1, newFixture(t))
 	})
+}
+`)
+
+	got, err := WeakAssertions([]string{dir})
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "weak-assertion", got[0].Kind)
+	assert.Equal(t, "TestParent", got[0].Subject)
+}
+
+// The fixture-closure suppression (skipping a nested func literal's body
+// when the parent delegates to t.Run subtests) must only apply when the
+// parent actually has subtests. A closure that runs itself immediately, with
+// no t.Run anywhere in the body, is not fixture setup for anything — it is
+// the test's own assertion surface — and must still be flagged. This pins
+// classifyBody's "len(children) > 0" gate specifically: hardcoding it to
+// true (treating every closure as fixture setup regardless of whether any
+// subtest exists to delegate to) would silently reclassify this weak
+// assertion as kindNoAssertion instead of kindWeakAssertion, with no fixture
+// elsewhere in this file able to notice, since every other closure fixture
+// here is always paired with at least one t.Run.
+func TestWeakAssertions_FlagsWeakAssertionInsideClosureWithoutSubtests(t *testing.T) {
+	dir := writeGo(t, "x_test.go", `package p
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParent(t *testing.T) {
+	func() {
+		require.NoError(t, teardown())
+	}()
 }
 `)
 

--- a/tools/seamscan/weakassert_test.go
+++ b/tools/seamscan/weakassert_test.go
@@ -209,6 +209,77 @@ func TestParent(t *testing.T) {
 	assert.Equal(t, "TestParent/outer/inner", got[0].Subject)
 }
 
+// Factoring a fixture closure out of two subtests (pure DRY, no behavior
+// change) must not flip the parent from unreported to reported. The parent's
+// only "own scope" assertion is the require.NoError inside the shared
+// newFixture closure — fixture setup, not the parent's assertion surface —
+// and both subtests carry real assertions of their own, so nothing here
+// should be flagged.
+func TestWeakAssertions_IgnoresFixtureClosureSharedBySubtests(t *testing.T) {
+	dir := writeGo(t, "x_test.go", `package p
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParent(t *testing.T) {
+	newFixture := func(t *testing.T) int {
+		v, err := setup()
+		require.NoError(t, err)
+		return v
+	}
+
+	t.Run("one", func(t *testing.T) {
+		require.Equal(t, 1, newFixture(t))
+	})
+	t.Run("two", func(t *testing.T) {
+		require.Equal(t, 2, newFixture(t))
+	})
+}
+`)
+
+	got, err := WeakAssertions([]string{dir})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// A weak assertion the parent makes directly, in its own statements outside
+// any nested func literal, must still be flagged even when the parent also
+// hosts a fixture closure — the fixture-closure suppression must not swallow
+// genuine direct assertions living alongside it.
+func TestWeakAssertions_StillFlagsDirectWeakAssertionBesideFixtureClosure(t *testing.T) {
+	dir := writeGo(t, "x_test.go", `package p
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParent(t *testing.T) {
+	newFixture := func(t *testing.T) int {
+		v, err := setup()
+		require.NoError(t, err)
+		return v
+	}
+	require.NoError(t, teardown())
+
+	t.Run("one", func(t *testing.T) {
+		require.Equal(t, 1, newFixture(t))
+	})
+}
+`)
+
+	got, err := WeakAssertions([]string{dir})
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "weak-assertion", got[0].Kind)
+	assert.Equal(t, "TestParent", got[0].Subject)
+}
+
 // A locally-defined assertion helper (assertX/requireX/checkX/verifyX/mustX,
 // called as a bare identifier) verifies something internally, usually via
 // t.Fatalf, so a test that only calls one must not be reported. False

--- a/tools/seamscan/weakassert_test.go
+++ b/tools/seamscan/weakassert_test.go
@@ -127,3 +127,124 @@ func TestParent(t *testing.T) {
 	assert.Equal(t, "weak-assertion", got[0].Kind)
 	assert.Equal(t, "TestParent/weak", got[0].Subject)
 }
+
+// A parent's own assertions — the ones living outside any t.Run — must be
+// classified too, not just its subtests.
+func TestWeakAssertions_ReportsParentOwnAssertionOutsideSubtests(t *testing.T) {
+	dir := writeGo(t, "x_test.go", `package p
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParent(t *testing.T) {
+	require.NoError(t, setup())
+	t.Run("strong", func(t *testing.T) {
+		require.Equal(t, 1, one())
+	})
+}
+`)
+
+	got, err := WeakAssertions([]string{dir})
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "weak-assertion", got[0].Kind)
+	assert.Equal(t, "TestParent", got[0].Subject)
+}
+
+// A parent that exists purely to host t.Run calls, with no assertion of its
+// own, asserts nothing by design and must never be reported — pinned
+// explicitly rather than left implied by another test's incidental shape.
+func TestWeakAssertions_IgnoresParentThatOnlyHostsSubtests(t *testing.T) {
+	dir := writeGo(t, "x_test.go", `package p
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParent(t *testing.T) {
+	t.Run("strong", func(t *testing.T) {
+		require.Equal(t, 1, one())
+	})
+}
+`)
+
+	got, err := WeakAssertions([]string{dir})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// Nested t.Run calls must be isolated from their ancestors (an inner
+// subtest's assertions must not leak into its parent's classification) and
+// named by their full path, since a shallow "parent/leaf" name collides
+// across siblings at different depths.
+func TestWeakAssertions_NestedSubtestsIsolatedAndFullyNamed(t *testing.T) {
+	dir := writeGo(t, "x_test.go", `package p
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParent(t *testing.T) {
+	t.Run("outer", func(t *testing.T) {
+		t.Run("inner", func(t *testing.T) {
+			require.NoError(t, doThing())
+		})
+	})
+}
+`)
+
+	got, err := WeakAssertions([]string{dir})
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "weak-assertion", got[0].Kind)
+	assert.Equal(t, "TestParent/outer/inner", got[0].Subject)
+}
+
+// A locally-defined assertion helper (assertX/requireX/checkX/verifyX/mustX,
+// called as a bare identifier) verifies something internally, usually via
+// t.Fatalf, so a test that only calls one must not be reported. False
+// positives here would get the guard switched off, so this errs toward
+// under-reporting: any of these prefixes counts as a real assertion.
+func TestWeakAssertions_IgnoresLocalAssertionHelpers(t *testing.T) {
+	dir := writeGo(t, "x_test.go", `package p
+
+import "testing"
+
+func TestUsesAssertHelper(t *testing.T) {
+	assertCard(t, got())
+}
+
+func TestUsesRequireHelper(t *testing.T) {
+	requireThing(t, got())
+}
+
+func TestUsesCheckHelper(t *testing.T) {
+	checkThing(t, got())
+}
+
+func TestUsesVerifyHelper(t *testing.T) {
+	verifyThing(t, got())
+}
+
+func TestUsesMustHelper(t *testing.T) {
+	mustThing(t, got())
+}
+
+func TestUsesUpperCaseHelper(t *testing.T) {
+	AssertCard(t, got())
+}
+`)
+
+	got, err := WeakAssertions([]string{dir})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}


### PR DESCRIPTION
## Summary

Six defects (#1678, #1679, #1681, #1683, #1684, #1697) shipped through a test
suite at **88% coverage** and a **2:1 test-to-production line ratio**. Each sat
at a *seam* — a handoff between two components where the contract lived in
neither side — and each side's tests passed because they only asserted their
own assumption about the other. Coverage cannot see this class of defect: the
executed lines are real, the behavior verified is not.

This PR adds `tools/seamscan`, a small static-analysis CLI that finds
candidates for two of the shapes behind those defects, plus the judgment
procedure for turning a candidate into a finding, plus a narrow, opt-in CI
guard so the cheapest of the two (an assertion that cannot fail) doesn't grow
faster than it's cleaned up.

## What's in this PR

1. **`tools/seamscan`** (new Go module, added to `go.work`) — two subcommands
   sharing a `Finding`/`EmitText`/`EmitJSON` core:
   - `weak-assertions <dir>` — flags tests whose only assertions are
     `NoError`/`Nil`/`NotNil`/etc., which pass regardless of whether the code
     under test did the right thing.
   - `seams <pattern/...>` — flags *lossy struct rebuilds*: a struct literal
     that reads an existing field off another value but drops most of the
     type's other exported fields (the shape behind #1681, the *lossy rebuild*
     signature, spec §4.1).

   This is **not a shipped library** — it's excluded from `release.yml`
   (which tags only `runtime`, `pkg`, `sdk`, `server/a2a`).

2. **`scripts/check-weak-assertions.sh` + `make check-weak-assertions`** — a
   git-diff-scoped guard that fails only on **new** weak assertions (base vs.
   head), not the pre-existing backlog. Local opt-in only — **not wired into
   `.github/workflows/ci.yml`** (see Known limitations).

3. **`.claude/skills/audit-test-seams/SKILL.md`** — the judgment half. The
   tool reports candidates; a human or agent still has to decide whether a
   candidate is a real seam, and whether a weak assertion is load-bearing
   (e.g. a smoke test) or dead weight.

## Acceptance results

Re-verified directly against the numbers below (not re-quoted from an earlier
task) as part of this PR's final verification pass:

- **Whole-tree `weak-assertions`** across all four shipped modules
  (`runtime sdk pkg server/a2a`): **679** findings — 676 in the first three
  plus 3 in `server/a2a`, which an earlier draft of the guard silently skipped.
  This is a floor, not ground truth (see limitations).
- **`seams` false-positive counts**, the numbers used to judge minutes-scale
  triage: `runtime/hooks/... runtime/evals/...` → **29**; `sdk/...` → **60**.
  Most of the 29 are a documented, deliberate convention in
  `runtime/evals/handlers` (sparse `EvalResult{Score, Explanation}`
  constructors, filled in by a wrapper later) — not defects. Two are not:
  see "One thing the tool found" below.
- **Defaults**: `--min-fields 5`, `--min-dropped 3` on `seams`.
- **Argument shapes differ** between the two subcommands and this is
  load-bearing, not incidental: `weak-assertions` takes a plain directory,
  already recursive, and **errors** on a `/...` suffix (treats it as a
  literal missing directory). `seams` is a `go/packages` pattern and
  **requires** `/...` to recurse — a bare directory silently scans exactly
  one package non-recursively and under-reports. Both directions reconfirmed
  by direct comparison (bare `./runtime/hooks` → 0 findings, `./runtime/hooks/...`
  → 2, on the same tree).
- **Whole-repo pattern deliberately errors.** `seams ./...` from the repo
  root fails hard (`1 package load error(s)`) rather than silently reporting
  zero — this repo's `go.work` has no root `go.mod`, so `./...` at the root
  can't resolve to begin with, and the tool treats "no packages loaded" as a
  hard failure rather than an empty, falsely-clean result.

**Historical-defect acceptance (spec §8) — re-run against a scratch worktree
per commit, not assumed from an earlier task:**

| Commit | Result |
|---|---|
| `53441944` (pre-fix for #1681) | `seams` on `sdk/...` fires: `sdk/conversation.go:730` — `types.Message (4/13 exported fields set)`, `unset: FinishReason, LatencyMs, Meta, Reasoning, Source, Timestamp, ToolCalls, ToolResult, Validations`. Matches the real fix (`12dffbb2`, "preserve FinishReason so a blocked turn is detectable") exactly. |
| `9ee0c80a` (pre-fix for #1683's content-source bug) | No signature fires on this defect — correctly. It's a content-selection bug (ignoring `EvalContext.CurrentOutput`), not a lossy rebuild or an unfalsifiable assertion; §4.2 divergent-twins is the signature that would have had a shot at it, and it was never built. |
| `8d374a85` (pre-fix for #1684's score-type-assertion bug and duplicated-block "stage coupling") | No signature fires on *that* defect either (a `*float64`/`float64` type-assertion mismatch and duplicated inline hook-call blocks — again §4.2/§4.4 territory, not built). `seams` does fire on this same commit's `runtime/hooks/guardrails/adapter.go`, but for a *different, still-live* issue — see below. |

Three of the spec's four signatures (§4.2 divergent twins, §4.3 write-only
struct field, §4.4 unpaired collaborator) were **deliberately not built**.
The spec sanctions this explicitly: treat the four as an ordered backlog and
stop when the marginal signature stops earning its triage cost. §4.1
(lossy rebuild) plus the weak-assertion scan were judged to clear that bar;
the other three were not attempted, not attempted-and-failed. Confirmed here
by grepping every `Finding{Kind: ...}` site in the tool: only
`weak-assertion`, `no-assertion`, and `lossy-rebuild` exist — there is no
`divergent-twins`/`write-only-field`/`unpaired-collaborator` kind to have
silently failed to fire.

## One thing the tool found

The skill's trial run on `runtime/hooks` surfaced a real, previously-unknown
defect (independently re-verified for this PR, not just carried over from an
earlier task's report):

`guardrails.GuardrailHookAdapter.BeforeCall`/`AfterCall`
(`runtime/hooks/guardrails/adapter.go:93`, `:134`) each build a fresh
`evals.EvalContext{}` inline, setting only 3 of its 11 exported fields
(`CurrentOutput`, `Messages`, `ContentScope`) — never through
`BuildEvalContext` (`runtime/evals/context.go`), which is the only place that
populates `TurnIndex`, `ToolCalls`, `SessionID`, `PromptID`, `Extras`,
`Metadata`, `PriorResults`. `runtime/hooks/guardrails/factory.go:31`
documents "Any registered eval handler (including aliases) can be used as a
guardrail" — but 7 of the registered handlers read exactly the fields this
path zeroes: `guardrail_triggered` (`PriorResults`), `cost_budget` /
`latency_budget` / `tool_exec` / `llm_judge` (`Metadata`), and
`workflow_complete` / `workflow_state_is` (`Extras`). Used as a guardrail,
every one of them silently falls into its "no data" branch instead of
actually gating. No test wires a stateful handler through the real adapter —
every adapter/factory test uses either a stub that ignores `EvalContext`
entirely, or a stateless content/length handler (`banned_words`, `length`,
`content_excludes`, ...). A separate issue is being filed for this; it is not
fixed in this PR (out of scope — this PR ships the audit tooling, not fixes
for what it finds).

## Known limitations (from the skill, not softened)

1. **The counts are floors, not ground truth.** Whole-tree `weak-assertions`
   and any `seams` count are lower bounds, not exhaustive totals.
2. **Lossy-rebuild misses method-call-sourced values.** It only sees a struct
   literal that reads an existing *field*; a value from a collaborator method
   call (`state.accumulatedContent()`) is invisible to it —
   `sdk/streaming.go:444` (`&types.Message{Role, Content}`, 2 of 13 fields,
   dropping `FinishReason`) is a live, undetected instance of exactly this
   defect class. Recovering it needs call-graph analysis or a per-site
   allowlist. The converse also holds: `x.Field.Method()` **does** qualify,
   so some findings are method-call results that may be unrelated to the
   field read.
3. **Lossy-rebuild is literal-only.** It can't see fields assigned after
   construction (`m := T{}; m.X = …`), so a field it names may in fact be set
   later in the same function. The output says `not set in literal:` rather
   than `unset:` for exactly this reason — the narrower phrasing is the true
   one, and `sdk/agui/convert.go:39` is a live example of the difference.
4. **Weak-assertions suppresses locally-defined `assert*`/`must*` helpers.**
   Deliberate under-reporting bias — a guard that fires on legitimate
   helper-wrapped tests gets disabled by whoever it annoys.
5. **Weak-assertions misses a closure a subtest-hosting parent defines and
   invokes itself** (as opposed to delegating to `t.Run`). Its weak assertion
   is silently unflagged.
6. **Weak-assertions has a known false-positive shape.** `NotNil`/`Nil` on a
   field whose zero value is genuinely reachable gets flagged anyway, because
   the heuristic doesn't check whether the specific call can actually fail.
   Measured rate on the last 20 merged PRs: 1 in 20.

A clean scan is **not** an all-clear — see the skill's dedicated section and
anti-pattern table for this.

## Explicitly deferred (not defects, not omissions)

- **§4.2 divergent twins** (would have caught #1697's `Eval`/`EvalPartial`
  drift and the #1684 duplicated `AfterCall` blocks) — highest-value of the
  remainder; needs an AST-similarity measure, which is where the design risk
  sits.
- **§4.3 write-only struct field** (would have caught #1679) — needs
  whole-program analysis since producer and consumer are typically in
  different packages; slow, and would need to stay out of any CI guard.
- **§4.4 unpaired collaborator** — lowest precision; build only if §4.2/§4.3
  prove the triage cost is worth it.

## CI guard: local opt-in, not wired

`make check-weak-assertions` fires on **new** weak assertions only (diffed
against the merge base), so it doesn't choke on the pre-existing 679. It is
**deliberately not added to `.github/workflows/ci.yml`** — the `gh` CLI
available in this environment lacks the workflow-file scope needed to modify
workflow YAML, so wiring it is a separate, explicit follow-up rather than an
oversight.

## Open policy question

Removing the 679 existing weak tests **lowers** measured coverage — they
execute real lines, and the seam tests that would replace them are far
fewer. That
trade needs an explicit decision before any cleanup starts, or the coverage
gate blocks the cleanup and the fix becomes backfilling the exact junk that
was removed. This PR does not resolve that question; it ships the tooling
that makes the trade-off visible.

## Verification performed for this PR

- `go -C tools/seamscan test ./... -count=1 -race` — pass.
- `go build`/`go test -count=1` across `runtime`, `sdk`, `pkg`,
  `server/a2a`, `tools/seamscan` — pass (11874 tests, 118 packages). Note:
  this repo's `go.work` has no root `go.mod`, so a bare `./...` at the repo
  root cannot resolve in *any* module-based Go command, independent of this
  branch — not a regression this PR introduces.
- `golangci-lint run ./tools/seamscan/...` — 0 issues.
- `shellcheck scripts/check-weak-assertions.sh` — clean.
- `grep tools/seamscan .github/workflows/release.yml` — correctly absent.
- No stray `tools/seamscan/seamscan` binary in the git index (and it is now
  `.gitignore`d, so a `git add -A` can't commit one).
- All 11 commits on this branch carry a DCO `Signed-off-by:` trailer
  matching their author.

**On the tests of the tool itself.** Since this tool's whole purpose is
finding tests that cannot fail, it would be worthless — worse, actively
misleading — if it shipped with any. A whole-branch review ran **51
mutations** against the three signatures: 44 were killed, and **7 survived**,
five of them tests of `seamscan` that could not fail. All seven are closed in
`9b22578f`, and each fix was verified by applying the mutation, watching the
specific test go red, and reverting. Two earlier rounds on this branch
reported mutation coverage that a reviewer then disproved, so every claim
here was independently re-derived rather than accepted.

## Test plan

- [x] `tools/seamscan` unit tests pass with `-race`
- [x] Full workspace build + test unaffected by the `go.work` addition
- [x] Lint (seamscan module) and shellcheck (guard script) clean
- [x] Release pipeline untouched (`tools/seamscan` absent from `release.yml`)
- [x] Acceptance: fires correctly on `53441944` (#1681); correctly does not
      fire a nonexistent signature on `9ee0c80a`/`8d374a85`
- [ ] CI wiring for `check-weak-assertions` (explicit follow-up, see above)
- [ ] Coverage-impact policy decision for removing existing weak tests
      (explicit follow-up, see above)
