### PR TITLE
fix(sdk): update the stale Anthropic auto-detect default

### DIFF
--- a/sdk/internal/provider/detect.go
+++ b/sdk/internal/provider/detect.go
@@ -29,6 +29,26 @@ const (
 	providerOllama    = "ollama"
 )
 
+// Default model per provider, used when the caller supplies no model and the
+// provider is auto-detected from the environment.
+const (
+	defaultOpenAIModel = "gpt-4o"
+	// claude-sonnet-5 is the documented drop-in successor to the previous
+	// default (claude-sonnet-4-20250514), which is deprecated. Same tier, so
+	// auto-detected callers keep their cost profile; pass an explicit model to
+	// opt into claude-opus-5.
+	defaultAnthropicModel = "claude-sonnet-5"
+	defaultGeminiModel    = "gemini-1.5-pro"
+)
+
+// Environment variables consulted during provider auto-detection.
+const (
+	envOpenAIKey    = "OPENAI_API_KEY"
+	envAnthropicKey = "ANTHROPIC_API_KEY"
+	envGoogleKey    = "GOOGLE_API_KEY"
+	envGeminiKey    = "GEMINI_API_KEY"
+)
+
 // Info contains detected provider information.
 type Info struct {
 	// Name is the provider identifier (e.g., "openai", "anthropic", "gemini").
@@ -72,7 +92,7 @@ func Detect(apiKey, model string) (providers.Provider, error) {
 	if info == nil {
 		slog.Warn("no provider detected from environment; defaulting to OpenAI gpt-4o",
 			"hint", "set OPENAI_API_KEY, ANTHROPIC_API_KEY, or GOOGLE_API_KEY to be explicit")
-		info = &Info{Name: "openai", APIKey: apiKey, Model: "gpt-4o"}
+		info = &Info{Name: providerOpenAI, APIKey: apiKey, Model: defaultOpenAIModel}
 	}
 
 	// Override with provided values
@@ -121,9 +141,9 @@ func detectInfoForProvider(providerName string) *Info {
 	}
 
 	envKeys := map[string][]string{
-		"openai":    {"OPENAI_API_KEY"},
-		"anthropic": {"ANTHROPIC_API_KEY"},
-		"gemini":    {"GOOGLE_API_KEY", "GEMINI_API_KEY"},
+		providerOpenAI:    {envOpenAIKey},
+		providerAnthropic: {envAnthropicKey},
+		providerGemini:    {envGoogleKey, envGeminiKey},
 	}
 
 	keys, ok := envKeys[providerName]
@@ -152,10 +172,10 @@ func detectInfo() *Info {
 		keyEnv   string
 		defModel string
 	}{
-		{"openai", "OPENAI_API_KEY", "gpt-4o"},
-		{"anthropic", "ANTHROPIC_API_KEY", "claude-sonnet-4-20250514"},
-		{"gemini", "GOOGLE_API_KEY", "gemini-1.5-pro"},
-		{"gemini", "GEMINI_API_KEY", "gemini-1.5-pro"},
+		{providerOpenAI, envOpenAIKey, defaultOpenAIModel},
+		{providerAnthropic, envAnthropicKey, defaultAnthropicModel},
+		{providerGemini, envGoogleKey, defaultGeminiModel},
+		{providerGemini, envGeminiKey, defaultGeminiModel},
 	}
 
 	for _, c := range checks {

--- a/sdk/internal/provider/detect_test.go
+++ b/sdk/internal/provider/detect_test.go
@@ -56,7 +56,10 @@ func TestDetectInfo(t *testing.T) {
 		require.NotNil(t, info)
 		assert.Equal(t, "anthropic", info.Name)
 		assert.Equal(t, "sk-ant-test", info.APIKey)
-		assert.Contains(t, info.Model, "claude")
+		// Pin the exact ID, not Contains(model, "claude"): that passes for any
+		// Claude ID including retired ones, so it could not fail when the
+		// default went stale. Update deliberately when the default moves.
+		assert.Equal(t, "claude-sonnet-5", info.Model)
 	})
 
 	t.Run("google key set", func(t *testing.T) {
@@ -70,7 +73,7 @@ func TestDetectInfo(t *testing.T) {
 		require.NotNil(t, info)
 		assert.Equal(t, "gemini", info.Name)
 		assert.Equal(t, "google-key", info.APIKey)
-		assert.Contains(t, info.Model, "gemini")
+		assert.Equal(t, "gemini-1.5-pro", info.Model)
 	})
 
 	t.Run("gemini key set", func(t *testing.T) {


### PR DESCRIPTION
## The bug

When a caller supplies no model, the SDK auto-detects a provider from the environment and picks a default. The Anthropic default was:

```go
{"anthropic", "ANTHROPIC_API_KEY", "claude-sonnet-4-20250514"},
```

That ID is **deprecated**. Every caller who set only `ANTHROPIC_API_KEY` silently got a model two generations behind the current Claude 5 family.

Moved to `claude-sonnet-5`, the documented drop-in successor. **Same tier deliberately** — auto-detected callers keep their cost profile rather than being silently promoted to Opus. Callers who want the most capable model pass one explicitly.

## The root cause was the test

```go
assert.Contains(t, info.Model, "claude")
```

That assertion **cannot fail** when the ID goes stale — it passes for any Claude ID, retired ones included. The OpenAI case one block above already pinned its default with `assert.Equal(t, "gpt-4o", info.Model)`; the Anthropic case didn't, so nothing caught the drift.

Tightened the Anthropic and Gemini cases to exact equality, then **mutation-checked** the new assertion:

```
# constant reverted to the stale ID:
--- FAIL: TestDetectInfo/anthropic_key_set
    expected: "claude-sonnet-5"
    actual  : "claude-sonnet-4-20250514"

# constant restored:
ok  github.com/AltairaLabs/PromptKit/sdk/internal/provider
```

## Also: cleared pre-existing lint

Extracted the repeated model IDs, provider names, and env var names into constants. The package already had `providerOpenAI` / `providerAnthropic` / `providerGemini`, but the detection tables used raw strings. This clears **5 pre-existing `goconst` findings** in the file — `golangci-lint` now reports 0 issues.

## Deliberately not changed

The OpenAI (`gpt-4o`) and Gemini (`gemini-1.5-pro`) defaults are also aging. I have **no authoritative source** for those providers' current model IDs, and a guessed ID would 404 for every caller — so I left them and am flagging them for someone who can confirm. They're now named constants, so updating them is a one-line change.

## Verification

```
go test ./sdk/...                          all pass
golangci-lint run ./sdk/internal/provider  0 issues
pre-commit hook                            lint + build + coverage pass
detect.go coverage                         98.0%
```

Found during the example audit in #1702.
