### PR TITLE
fix(guardrails): give eval handlers the EvalContext they read

### DIFF
--- a/runtime/evals/context.go
+++ b/runtime/evals/context.go
@@ -30,20 +30,6 @@ func BuildEvalContext(
 		}
 	}
 
-	extras := ExtractWorkflowExtras(messages)
-
-	// Merge workflow metadata from the metadata map (set by engine for workflow scenarios)
-	if metadata != nil {
-		for _, key := range []string{"workflow_current_state", "workflow_transitions", "workflow_complete"} {
-			if v, ok := metadata[key]; ok {
-				if extras == nil {
-					extras = make(map[string]any)
-				}
-				extras[key] = v
-			}
-		}
-	}
-
 	return &EvalContext{
 		Messages:      messages,
 		TurnIndex:     turnIndex,
@@ -51,10 +37,78 @@ func BuildEvalContext(
 		ToolCalls:     ExtractToolCalls(messages),
 		SessionID:     sessionID,
 		PromptID:      promptID,
-		Extras:        extras,
+		Extras:        workflowExtras(messages, metadata),
 		Metadata:      metadata,
 		PriorResults:  validationsToPriorResults(messages),
 	}
+}
+
+// BuildGuardrailEvalContext constructs an EvalContext for a guardrail, which
+// judges one specific message rather than scanning a transcript.
+//
+// Two things make this different from BuildEvalContext, and both are
+// deliberate:
+//
+// It does NOT infer CurrentOutput from the last assistant turn. An input
+// guardrail judges the *user's* message, so deriving the content under test
+// from assistant messages makes a content check silently pass everything —
+// that was #1679. The caller states the content, and ContentScope is pinned to
+// ContentScopeCurrent to match.
+//
+// Everything else is derived from the same message history BuildEvalContext
+// uses. factory.go promises that any registered eval handler can serve as a
+// guardrail, so a handler must see the same ToolCalls, Extras, Metadata and
+// PriorResults either way. Building this context inline with only three fields
+// set left ~30 ToolCalls-reading handlers blind, made cost_budget compute zero
+// spend and never fire, and made state_is report "no workflow state" — which
+// scores 0, and a score below 1.0 means enforce, so it blocked every turn
+// (#1704).
+//
+// TurnIndex, SessionID, PromptID and Variables are still absent: unlike the
+// rest they cannot be derived from the message history, and the hook boundary
+// does not carry them. Handlers depending on those remain unsuitable as
+// guardrails.
+func BuildGuardrailEvalContext(
+	messages []types.Message, currentOutput string, metadata map[string]any,
+) *EvalContext {
+	return &EvalContext{
+		Messages:      messages,
+		CurrentOutput: currentOutput,
+		ContentScope:  ContentScopeCurrent,
+		ToolCalls:     ExtractToolCalls(messages),
+		Extras:        workflowExtras(messages, metadata),
+		Metadata:      metadata,
+		PriorResults:  validationsToPriorResults(messages),
+	}
+}
+
+// workflowMetadataKeys are the workflow fields an engine sets on the metadata
+// map for workflow scenarios, rather than on message Meta.
+var workflowMetadataKeys = []string{
+	"workflow_current_state",
+	"workflow_transitions",
+	"workflow_complete",
+}
+
+// workflowExtras merges workflow state found in the message history with the
+// workflow keys an engine may have placed on the metadata map. Shared by
+// BuildEvalContext and BuildGuardrailEvalContext so the eval and guardrail
+// paths cannot drift on what a workflow handler gets to see.
+//
+// Indexing a nil metadata map is safe, so no nil check is needed.
+func workflowExtras(messages []types.Message, metadata map[string]any) map[string]any {
+	extras := ExtractWorkflowExtras(messages)
+	for _, key := range workflowMetadataKeys {
+		v, ok := metadata[key]
+		if !ok {
+			continue
+		}
+		if extras == nil {
+			extras = make(map[string]any)
+		}
+		extras[key] = v
+	}
+	return extras
 }
 
 // ExtractToolCalls builds ToolCallRecords from a message history by matching

--- a/runtime/evals/context_test.go
+++ b/runtime/evals/context_test.go
@@ -8,6 +8,91 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestBuildGuardrailEvalContext_EnrichesFromHistory pins the fields the
+// guardrail adapter used to leave zeroed (#1704). Every one is derivable from
+// the message history, so a handler must see the same data whether it runs as
+// an eval or as a guardrail.
+func TestBuildGuardrailEvalContext_EnrichesFromHistory(t *testing.T) {
+	toolResult := types.NewTextToolResult("c1", "lookup", "shipped")
+	messages := []types.Message{
+		types.NewUserMessage("where is my order"),
+		{
+			Role:      "assistant",
+			ToolCalls: []types.MessageToolCall{{ID: "c1", Name: "lookup", Args: []byte(`{"id":"A1"}`)}},
+			Meta:      map[string]any{"_workflow_current_state": "tracking"},
+		},
+		{Role: "tool", Content: "shipped", ToolResult: &toolResult},
+		{
+			Role:        "assistant",
+			Content:     "it shipped",
+			Validations: []types.ValidationResult{{ValidatorType: "banned_words", Passed: false}},
+		},
+	}
+	metadata := map[string]any{"total_cost": 1.25, "workflow_complete": true}
+
+	ctx := BuildGuardrailEvalContext(messages, "the message under test", metadata)
+
+	require.NotNil(t, ctx)
+	assert.Equal(t, metadata, ctx.Metadata, "Metadata must pass through untouched")
+
+	require.Len(t, ctx.ToolCalls, 1, "ToolCalls must be derived from the transcript")
+	assert.Equal(t, "lookup", ctx.ToolCalls[0].ToolName)
+	assert.Equal(t, map[string]any{"id": "A1"}, ctx.ToolCalls[0].Arguments,
+		"the call's JSON arguments must be parsed")
+	parts, ok := ctx.ToolCalls[0].Result.([]types.ContentPart)
+	require.True(t, ok, "a NewTextToolResult carries Parts, so Result is the parts slice")
+	require.Len(t, parts, 1, "the tool-role result message must be paired in by call ID")
+	require.NotNil(t, parts[0].Text)
+	assert.Equal(t, "shipped", *parts[0].Text)
+
+	assert.Equal(t, "tracking", ctx.Extras["workflow_current_state"],
+		"workflow state on message Meta must reach Extras")
+	assert.Equal(t, true, ctx.Extras["workflow_complete"],
+		"workflow keys on the metadata map must also reach Extras")
+
+	require.Len(t, ctx.PriorResults, 1, "failed validations must seed PriorResults")
+	assert.Equal(t, "banned_words", ctx.PriorResults[0].Type)
+	require.NotNil(t, ctx.PriorResults[0].Score)
+	assert.Equal(t, 0.0, *ctx.PriorResults[0].Score, "a failed validation scores 0")
+}
+
+// TestBuildGuardrailEvalContext_StatesContentInsteadOfInferringIt is the
+// difference from BuildEvalContext, and it is load-bearing: an input guardrail
+// judges the USER's message. Inferring the content under test from the last
+// assistant turn is what made banned_words a silent no-op on input (#1679).
+func TestBuildGuardrailEvalContext_StatesContentInsteadOfInferringIt(t *testing.T) {
+	messages := []types.Message{
+		types.NewAssistantMessage("how can I help?"),
+		types.NewUserMessage("please arrange a wire transfer"),
+	}
+
+	ctx := BuildGuardrailEvalContext(messages, "please arrange a wire transfer", nil)
+
+	assert.Equal(t, "please arrange a wire transfer", ctx.CurrentOutput,
+		"the caller states the content; it must not be re-derived from assistant turns")
+	assert.Equal(t, ContentScopeCurrent, ctx.ContentScope,
+		"a guardrail judges one message, so scope must be pinned to current")
+
+	// Contrast: the eval path legitimately infers the last assistant turn.
+	evalCtx := BuildEvalContext(messages, 0, "", "", nil)
+	assert.Equal(t, "how can I help?", evalCtx.CurrentOutput)
+	assert.Equal(t, ContentScopeTranscript, evalCtx.ContentScope)
+}
+
+// TestBuildGuardrailEvalContext_ToleratesNilMetadata covers the nil-map path —
+// indexing a nil map for the workflow keys is safe, and a guardrail declared in
+// a pack often has no metadata at all.
+func TestBuildGuardrailEvalContext_ToleratesNilMetadata(t *testing.T) {
+	ctx := BuildGuardrailEvalContext(nil, "text", nil)
+
+	require.NotNil(t, ctx)
+	assert.Nil(t, ctx.Metadata)
+	assert.Nil(t, ctx.Extras, "no workflow state anywhere means no Extras map")
+	assert.Empty(t, ctx.ToolCalls)
+	assert.Empty(t, ctx.PriorResults)
+	assert.Equal(t, "text", ctx.CurrentOutput)
+}
+
 func TestBuildEvalContext_ExtractsCurrentOutput(t *testing.T) {
 	messages := []types.Message{
 		types.NewUserMessage("hello"),

--- a/runtime/hooks/guardrails/adapter.go
+++ b/runtime/hooks/guardrails/adapter.go
@@ -90,14 +90,14 @@ func (a *GuardrailHookAdapter) BeforeCall(
 		return hooks.Allow
 	}
 
-	evalCtx := &evals.EvalContext{
-		CurrentOutput: lastMsg.GetContent(),
-		Messages:      req.Messages,
-		// A guardrail judges one message. For the input direction that
-		// message is the user's, which a transcript scan filtered to
-		// assistant role would never see.
-		ContentScope: evals.ContentScopeCurrent,
-	}
+	// A guardrail judges one message. For the input direction that message is
+	// the user's, which a transcript scan filtered to assistant role would
+	// never see — hence the explicit content argument rather than
+	// BuildEvalContext's last-assistant inference. See
+	// evals.BuildGuardrailEvalContext.
+	evalCtx := evals.BuildGuardrailEvalContext(
+		req.Messages, lastMsg.GetContent(), req.Metadata,
+	)
 
 	d := a.evaluate(ctx, evalCtx)
 	if !d.Allow {
@@ -123,21 +123,21 @@ func (a *GuardrailHookAdapter) AfterCall(
 
 	// Build messages list: request messages + the response being evaluated.
 	var msgs []types.Message
+	var metadata map[string]any
 	if req != nil {
 		msgs = make([]types.Message, len(req.Messages)+1)
 		copy(msgs, req.Messages)
 		msgs[len(req.Messages)] = resp.Message
+		metadata = req.Metadata
 	} else {
 		msgs = []types.Message{resp.Message}
 	}
 
-	evalCtx := &evals.EvalContext{
-		CurrentOutput: resp.Message.GetContent(),
-		Messages:      msgs,
-		// Judge this response only. Scanning the whole transcript would make
-		// one tripped turn re-block every later turn in the conversation.
-		ContentScope: evals.ContentScopeCurrent,
-	}
+	// Judge this response only. Scanning the whole transcript would make one
+	// tripped turn re-block every later turn in the conversation.
+	evalCtx := evals.BuildGuardrailEvalContext(
+		msgs, resp.Message.GetContent(), metadata,
+	)
 
 	// Apply defaults for aliased eval types, then normalize legacy param names
 	params := evals.ApplyDefaults(a.evalType, a.params)

--- a/runtime/hooks/guardrails/evalcontext_enrichment_test.go
+++ b/runtime/hooks/guardrails/evalcontext_enrichment_test.go
@@ -1,0 +1,281 @@
+package guardrails
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// These tests drive STATEFUL eval handlers through the REAL adapter, which is
+// the junction #1704 broke. factory.go documents that any registered eval
+// handler can be used as a guardrail, but the adapter built EvalContext inline
+// with 3 of its 11 fields, so every handler reading Metadata, Extras,
+// ToolCalls or PriorResults saw nothing.
+//
+// The two failure directions are opposite and both wrong, which is why one test
+// is not enough:
+//
+//   - fail-OPEN: cost_budget with no Metadata computes zero spend, scores 1.0,
+//     and never enforces. A budget guardrail that silently ignores the budget.
+//   - fail-CLOSED: state_is with no Extras reports "no workflow state
+//     available" and scores 0 — and score < 1.0 means enforce, so it blocks
+//     every single turn regardless of the actual state.
+//
+// Every pre-existing adapter test uses either a stub that ignores EvalContext
+// or a stateless content/length handler, so none of them could catch this.
+
+// toolResultMessage builds the tool-role message that ExtractToolCalls pairs
+// with an assistant tool call to produce a complete ToolCallRecord.
+func toolResultMessage(id, name, text string) types.Message {
+	result := types.NewTextToolResult(id, name, text)
+	return types.Message{Role: "tool", Content: text, ToolResult: &result}
+}
+
+// TestGuardrailEnrichment_CostBudgetSeesMetadata pins the fail-open direction.
+// The pipeline already puts per-conversation cost on ProviderRequest.Metadata;
+// the adapter has to pass it through, or a cost_budget guardrail never fires.
+func TestGuardrailEnrichment_CostBudgetSeesMetadata(t *testing.T) {
+	hook, err := NewGuardrailHook("cost_budget", map[string]any{
+		"max_cost_usd": 0.01,
+		"direction":    "output",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{{Role: "user", Content: "hello"}},
+		// Well over the $0.01 budget declared above.
+		Metadata: map[string]any{"total_cost": 5.0},
+	}
+	resp := &hooks.ProviderResponse{
+		Message: types.Message{Role: "assistant", Content: "an expensive reply"},
+	}
+
+	d := hook.AfterCall(context.Background(), req, resp)
+
+	require.False(t, d.Allow,
+		"cost_budget must fire when Metadata reports spend above the budget; "+
+			"if the adapter drops Metadata it computes zero cost and allows forever")
+	assert.True(t, d.Enforced, "guardrails enforce rather than deny")
+}
+
+// The under-budget half of that pair is deliberately absent, and this is the
+// reason: cost_budget scores a *ratio* (1.0 - spend/budget), not a verdict, so
+// any nonzero spend scores below 1.0 — and the adapter reads score < 1.0 as
+// "enforce". Spending $0.02 of a $10 budget therefore blocks the turn. That
+// is a pre-existing mismatch between continuous-score handlers and a binary
+// gate, not something enrichment introduced; before enrichment it was merely
+// unreachable, because a nil Metadata map always computed zero spend. It needs
+// its own decision (EvalResult already has a MetricValue field for metrics,
+// which is where a ratio belongs) and is tracked separately. The
+// guardrail_triggered pair below supplies the over-fire protection that this
+// missing half would otherwise have given.
+
+// TestGuardrailEnrichment_GuardrailTriggeredSeesPriorResults pins PriorResults,
+// which the adapter seeded as nil. guardrail_triggered exists to inspect
+// earlier guardrail outcomes, so as a guardrail itself it was reading an empty
+// slice and concluding nothing had run.
+func TestGuardrailEnrichment_GuardrailTriggeredSeesPriorResults(t *testing.T) {
+	hook, err := NewGuardrailHook("guardrail_triggered", map[string]any{
+		"validator_type": "banned_words",
+		"should_trigger": true,
+		"direction":      "output",
+	})
+	require.NoError(t, err)
+
+	// A failed banned_words validation on the assistant turn is what
+	// validationsToPriorResults converts into a PriorResult.
+	blocked := types.Message{
+		Role:    "assistant",
+		Content: "blocked",
+		Validations: []types.ValidationResult{
+			{ValidatorType: "banned_words", Passed: false},
+		},
+	}
+	req := &hooks.ProviderRequest{Messages: []types.Message{{Role: "user", Content: "hi"}}}
+	resp := &hooks.ProviderResponse{Message: blocked}
+
+	d := hook.AfterCall(context.Background(), req, resp)
+
+	assert.True(t, d.Allow,
+		"banned_words did trigger and should_trigger=true, so this is satisfied; "+
+			"a nil PriorResults slice makes it conclude the validator never ran")
+}
+
+// TestGuardrailEnrichment_GuardrailTriggeredFiresWhenValidatorAbsent is the
+// discriminating half: enrichment must not make guardrail_triggered pass
+// unconditionally.
+func TestGuardrailEnrichment_GuardrailTriggeredFiresWhenValidatorAbsent(t *testing.T) {
+	hook, err := NewGuardrailHook("guardrail_triggered", map[string]any{
+		"validator_type": "banned_words",
+		"should_trigger": true,
+		"direction":      "output",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{Messages: []types.Message{{Role: "user", Content: "hi"}}}
+	resp := &hooks.ProviderResponse{
+		// No Validations at all, so banned_words never ran.
+		Message: types.Message{Role: "assistant", Content: "a clean reply"},
+	}
+
+	d := hook.AfterCall(context.Background(), req, resp)
+
+	require.False(t, d.Allow,
+		"banned_words never ran, so should_trigger=true is unsatisfied")
+	assert.True(t, d.Enforced, "guardrails enforce rather than deny")
+}
+
+// TestGuardrailEnrichment_StateIsSeesWorkflowExtras pins the fail-closed
+// direction, which is the more damaging of the two: before the fix this
+// guardrail blocked every turn, because a nil Extras map reads as "no workflow
+// state available" and that scores 0.
+func TestGuardrailEnrichment_StateIsSeesWorkflowExtras(t *testing.T) {
+	hook, err := NewGuardrailHook("state_is", map[string]any{
+		"state":     "checkout",
+		"direction": "output",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "pay now"},
+			{
+				Role:    "assistant",
+				Content: "taking you to checkout",
+				Meta:    map[string]any{"_workflow_current_state": "checkout"},
+			},
+		},
+	}
+	resp := &hooks.ProviderResponse{
+		Message: types.Message{Role: "assistant", Content: "taking you to checkout"},
+	}
+
+	d := hook.AfterCall(context.Background(), req, resp)
+
+	assert.True(t, d.Allow,
+		"the workflow really is in state \"checkout\", so this guardrail must "+
+			"allow; dropping Extras makes it block every turn instead")
+}
+
+// TestGuardrailEnrichment_StateIsFiresOnWrongState is the discriminating other
+// half: enrichment must not turn state_is into an unconditional allow.
+func TestGuardrailEnrichment_StateIsFiresOnWrongState(t *testing.T) {
+	hook, err := NewGuardrailHook("state_is", map[string]any{
+		"state":     "checkout",
+		"direction": "output",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{
+			{
+				Role:    "assistant",
+				Content: "still browsing",
+				Meta:    map[string]any{"_workflow_current_state": "browsing"},
+			},
+		},
+	}
+	resp := &hooks.ProviderResponse{
+		Message: types.Message{Role: "assistant", Content: "still browsing"},
+	}
+
+	d := hook.AfterCall(context.Background(), req, resp)
+
+	require.False(t, d.Allow, "state is \"browsing\", not the required \"checkout\"")
+	assert.True(t, d.Enforced, "guardrails enforce rather than deny")
+}
+
+// TestGuardrailEnrichment_ToolsCalledSeesToolCalls covers the widest-reaching
+// field: ToolCalls is read by roughly thirty handlers, all of which were blind
+// as guardrails. ToolCalls is derivable from the message history the adapter
+// already holds, so there is no excuse for it being empty.
+func TestGuardrailEnrichment_ToolsCalledSeesToolCalls(t *testing.T) {
+	hook, err := NewGuardrailHook("tools_called", map[string]any{
+		"tools":     []any{"lookup_order"},
+		"direction": "output",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "where is my order"},
+			{
+				Role: "assistant",
+				ToolCalls: []types.MessageToolCall{
+					{ID: "c1", Name: "lookup_order", Args: []byte(`{"id":"A1"}`)},
+				},
+			},
+			toolResultMessage("c1", "lookup_order", "shipped"),
+		},
+	}
+	resp := &hooks.ProviderResponse{
+		Message: types.Message{Role: "assistant", Content: "it shipped"},
+	}
+
+	d := hook.AfterCall(context.Background(), req, resp)
+
+	assert.True(t, d.Allow,
+		"lookup_order was called in the transcript, so tools_called is satisfied; "+
+			"an empty ToolCalls slice makes this guardrail block every turn")
+}
+
+// TestGuardrailEnrichment_ToolsCalledFiresWhenToolAbsent is the discriminating
+// half of the ToolCalls pair: enrichment must not make tools_called pass for a
+// transcript in which the tool was never called.
+func TestGuardrailEnrichment_ToolsCalledFiresWhenToolAbsent(t *testing.T) {
+	hook, err := NewGuardrailHook("tools_called", map[string]any{
+		"tools":     []any{"lookup_order"},
+		"direction": "output",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{{Role: "user", Content: "where is my order"}},
+	}
+	resp := &hooks.ProviderResponse{
+		Message: types.Message{Role: "assistant", Content: "I cannot check that"},
+	}
+
+	d := hook.AfterCall(context.Background(), req, resp)
+
+	require.False(t, d.Allow, "lookup_order was never called in this transcript")
+	assert.True(t, d.Enforced, "guardrails enforce rather than deny")
+}
+
+// TestGuardrailEnrichment_PreservesCurrentMessageScope guards the fix against
+// regressing #1679. Enrichment must not start inferring CurrentOutput from the
+// last assistant turn the way BuildEvalContext does: an input guardrail judges
+// the USER's message, which a transcript scan filtered to assistant role would
+// never see. That exact inference was the #1679 bug.
+func TestGuardrailEnrichment_PreservesCurrentMessageScope(t *testing.T) {
+	hook, err := NewGuardrailHook("banned_words", map[string]any{
+		"words":     []any{"wire transfer"},
+		"direction": "input",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{
+			// An earlier clean assistant turn. If enrichment re-derived
+			// CurrentOutput from the last assistant message, or widened the
+			// scope to the whole transcript, the user's banned text below
+			// would stop being what gets judged.
+			{Role: "assistant", Content: "how can I help?"},
+			{Role: "user", Content: "please arrange a wire transfer"},
+		},
+		Metadata: map[string]any{"total_cost": 0.0},
+	}
+
+	d := hook.BeforeCall(context.Background(), req)
+
+	require.False(t, d.Allow,
+		"banned_words with direction=input must still judge the user's message "+
+			"after enrichment (#1679 must not regress)")
+	assert.True(t, d.Enforced, "guardrails enforce rather than deny")
+}


### PR DESCRIPTION
## Summary

`factory.go:31` documents "Any registered eval handler (including aliases) can be used as a guardrail." It wasn't true. `GuardrailHookAdapter.BeforeCall`/`AfterCall` each built an `evals.EvalContext` inline with **3 of its 11 exported fields**, so every handler that reads `Metadata`, `Extras`, `ToolCalls` or `PriorResults` saw nothing. `ToolCalls` alone is read by roughly thirty handlers.

Closes #1704.

## The two failure directions

Both are wrong, in opposite ways, which is why one test wouldn't have been enough:

| Handler | Missing field | Behavior as a guardrail |
|---|---|---|
| `cost_budget` | `Metadata` | **fail-OPEN** — computes zero spend, scores 1.0, never fires. A budget guardrail that silently ignores the budget. |
| `state_is`, `workflow_complete` | `Extras` | **fail-CLOSED** — reports "no workflow state available" → scores 0 → and `score < 1.0` means *enforce*, so it blocks **every turn** regardless of actual state. |
| `tools_called` and ~30 others | `ToolCalls` | **fail-CLOSED** — empty slice, so a "was this tool called" gate blocks every turn. |
| `guardrail_triggered` | `PriorResults` | concludes no validator ever ran. |

## The fix

`evals.BuildGuardrailEvalContext` derives everything the message history supports, and is single-sourced with `BuildEvalContext` (shared `workflowExtras`) so the eval and guardrail paths cannot drift apart again — which is how this arose in the first place.

**It deliberately does not reuse `BuildEvalContext` wholesale.** That function infers `CurrentOutput` from the last assistant turn, and an input guardrail judges the *user's* message. That exact inference was #1679, in this same file. `ContentScope` stays pinned to `ContentScopeCurrent`, and there is a regression test for it.

`TurnIndex`, `SessionID`, `PromptID` and `Variables` are **still absent**, and this is stated on the new function rather than left to be rediscovered: unlike the others they can't be derived from the message history, and the hook boundary doesn't carry them. Handlers depending on those remain unsuitable as guardrails.

## Scope note — no behavior change in default operation

Hook metadata comes from `turnState.ProviderRequestMetadata` (caller-supplied); the pipeline itself never sets `total_cost` or `latency_ms`. So this PR does not change what a default pipeline does — it makes the data available when a caller supplies it, and fixes the `Extras`/`ToolCalls`/`PriorResults` paths, which are derived from the transcript and so were always available and always dropped.

While writing the tests I found a **separate, pre-existing** defect and filed it as #1707 rather than widening this PR: `cost_budget` and `latency_budget` return a continuous *ratio* in `Score`, which the adapter's `score < 1.0` gate reads as failure — so `$0.02` of a `$10` budget blocks the turn, and `latency_budget` blocks every turn already, before and after this change. It needs a cross-repo decision (PromptArena may threshold on those scores), so it is deliberately not touched here. The missing "allows under budget" half of the `cost_budget` test pair is commented in the test file with this reason, rather than silently omitted.

## Tests

Eight new integration tests drive **real stateful handlers through the real adapter** — the junction that shipped broken. Every pre-existing adapter test used either a stub that ignores `EvalContext` or a stateless content/length handler (`banned_words`, `length`, `content_excludes`), so none of them could have caught this. Added beside `input_direction_integration_test.go`, which exists for #1679 — the same seam.

Each field is paired: one test proving the handler now sees the data, one proving enrichment didn't turn the guardrail into an unconditional allow.

**Mutation-verified.** Every assertion was checked by breaking the thing it claims to pin and confirming the specific test goes red:

| Mutation | Test that caught it |
|---|---|
| drop `Metadata` | `CostBudgetSeesMetadata` |
| drop `Extras` | `StateIsSeesWorkflowExtras` |
| drop `ToolCalls` | `ToolsCalledSeesToolCalls` |
| drop `PriorResults` | `GuardrailTriggeredSeesPriorResults` |
| `ContentScope` → transcript (regress #1679) | `PreservesCurrentMessageScope` |

Plus three direct unit tests on `BuildGuardrailEvalContext` in `runtime/evals`, because cross-package coverage isn't attributed and the new exported function would otherwise have shown 0% on the gate.

## Provenance

Found by `tools/seamscan seams ./runtime/hooks/... ./runtime/evals/...` — the lossy-rebuild signature from #1703 — on its first run against a real subsystem.

## Verification

- `go -C runtime test ./... -count=1` — pass
- `go -C sdk test ./... -count=1` — pass (SDK `Evaluate` shares `BuildEvalContext`)
- `golangci-lint run --new-from-rev=HEAD ./runtime/...` — 0 issues
- Coverage: `BuildGuardrailEvalContext` 100%, `workflowExtras` 88.9%

## Test plan

- [x] Real stateful handlers through the real adapter, both directions per field
- [x] Every new test mutation-verified
- [x] #1679 regression guard (input guardrails still judge the user's message)
- [x] `BuildEvalContext` behavior unchanged (extraction was pure refactor; nil-map indexing is safe, so the removed `metadata != nil` guard was redundant)
- [ ] #1707 — budget handlers' ratio `Score` vs the binary gate (separate, needs a cross-repo call)
