### PR TITLE
ci: run the weak-assertion guard on pull requests

### DIFF
--- a/.claude/skills/audit-test-seams/SKILL.md
+++ b/.claude/skills/audit-test-seams/SKILL.md
@@ -184,9 +184,15 @@ blocks the cleanup and the fix is to backfill exactly the junk you removed.
 - **No score, grade, or percentage.** A number becomes a target, and targets
   get gamed — that is the failure mode of the coverage gate this audit exists
   to supplement. Report findings, not a metric.
-- **No gating.** This audit does not block a build or a merge. (Weak, brand
-  new assertions can separately be caught by running `make check-weak-assertions`
-  locally — a different, narrower mechanism; see
-  `scripts/check-weak-assertions.sh`. It is local opt-in tooling only: it is
-  not run in pre-commit, it is not wired into
-  `.github/workflows/ci.yml`, and it is not this skill.)
+- **No gating.** *This audit* does not block a build or a merge — seam findings
+  are never gated, because "no test exists here" is not a build error and
+  gating it would produce exactly the junk tests this work exists to remove.
+
+  One narrower mechanism *is* gated, and it is not this skill: brand-new tests
+  whose assertions cannot fail are caught by `scripts/check-weak-assertions.sh`,
+  available locally as `make check-weak-assertions` and run on pull requests by
+  the `Weak Assertion Guard` job in `.github/workflows/ci.yml`. It fires only on
+  findings absent from the merge base, so the ~679 pre-existing ones never block
+  unrelated work, and it is still not run in pre-commit. Its blind spots are
+  limitations 4-6 above, and they are why it is scoped this narrowly: a guard
+  that fires on legitimate tests gets switched off.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,41 @@ jobs:
     - name: Check foundational packages are purego-free (issue #1536)
       run: ./scripts/check-no-audio-device-leak.sh
 
+  weak-assertions:
+    name: Weak Assertion Guard
+    runs-on: ubuntu-latest
+    # Pull requests only. On a push to main the merge base is HEAD itself, so
+    # the diff is empty by construction and the job would burn minutes proving
+    # nothing.
+    if: github.event_name == 'pull_request'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        # The guard scans the merge base in a throwaway worktree and diffs it
+        # against the working tree, so it needs real history — the default
+        # shallow clone cannot check out the base commit at all.
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        go-version: '1.26.0'
+        cache-dependency-path: tools/seamscan/go.sum
+
+    # Fails only on NEW tests whose assertions cannot fail. The ~679
+    # pre-existing ones are a separate, deliberate cleanup and must not block
+    # unrelated work — see scripts/check-weak-assertions.sh and
+    # .claude/skills/audit-test-seams/SKILL.md for the known limitations.
+    #
+    # The base SHA is passed explicitly rather than relying on the script's
+    # origin/main default: on a pull_request event the checkout is a detached
+    # merge commit, and depending on a remote-tracking ref existing is how this
+    # kind of guard silently ends up diffing against the wrong tree.
+    - name: Check for new tests that cannot fail (issue #1703)
+      run: ./scripts/check-weak-assertions.sh "${{ github.event.pull_request.base.sha }}"
+
   perf-regression:
     name: Performance Regression Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Wires `scripts/check-weak-assertions.sh` into CI. It shipped in #1703 as local opt-in tooling only, with the wiring left as an explicit follow-up.

The guard fails a PR that adds a test whose assertions cannot fail — one checking only `NoError`/`Nil`/`NotNil`, which passes whether or not the code produced the right answer, while still counting toward the coverage gate. Nine such tests were written during the guardrail work in #1678/#1683/#1684; one went green against a bug that had been observed minutes earlier and would have closed the issue as unreproducible.

**New findings only**, diffed against the merge base, so the ~679 pre-existing ones stay a separate deliberate cleanup and never block unrelated work. Same `--new-from-rev` convention golangci-lint already uses in the pre-commit hook.

## Why its own job, not a step in `build`

Two reasons, both load-bearing:

- The guard materializes the merge base in a throwaway worktree, so it needs `fetch-depth: 0`. The default shallow clone cannot check out the base commit at all. Imposing full history on `build` would slow a job with no use for it.
- A `pull_request` checkout is a detached merge commit, and remote-tracking refs are not guaranteed. So the base SHA is passed **explicitly** as `github.event.pull_request.base.sha` rather than relying on the script's `origin/main` default. Silently diffing against the wrong tree is exactly how a guard like this becomes decorative while still reporting green.

Skipped on push to `main`, where the merge base is `HEAD` itself and the diff is empty by construction.

## Verification

Run against the real script in a worktree, not reasoned about:

| Scenario | Result |
|---|---|
| Clean tree, explicit base SHA (the CI invocation) | `OK`, exit 0 |
| Empty base argument (push-event safety net) | falls back to `origin/main`, exit 0 |
| Injected weak test, explicit base SHA | `FAIL: runtime/hooks/zzz_ciguard_probe_test.go:9  weak-assertion  TestCIGuardProbeCannotFail`, exit 1 |
| Probe removed | `OK`, exit 0 |

`ci.yml` parses (`yaml.safe_load`), and both actions are pinned to the same SHAs already used elsewhere in the file.

## Skill correction

`.claude/skills/audit-test-seams/SKILL.md` stated the guard "is not wired into `.github/workflows/ci.yml`". This commit makes that false, so it is corrected in the same change — the skill's whole job is being accurate about what is and is not enforced, and a stale claim there is the kind that gets believed.

The revised wording also keeps the distinction that matters: **seam findings are still never gated.** Absence of a test is not a build error, and gating it would produce exactly the junk tests this work exists to remove. Only the narrow, near-zero-false-positive half blocks a build.

## Known limitation, stated rather than buried

The guard's false-positive rate measured **1 PR in 20** on the last 20 merged PRs: `NotNil` on a field whose zero value is genuinely reachable is falsifiable, but gets flagged anyway because the heuristic doesn't check whether the specific call can actually fail (skill limitation 6, tracked there). Two other blind spots bias it toward *under*-reporting on purpose — locally-defined `assert*`/`must*` helpers, and a closure a subtest-hosting parent invokes itself.

That ratio is why this is scoped to new findings only and nothing else. If it starts firing on tests a reviewer would wave through, tighten the classifier rather than living with it — a guard people learn to bypass is worse than no guard.

## Test plan

- [x] All four script scenarios exercised with the explicit base SHA CI uses
- [x] `ci.yml` parses; actions pinned to existing SHAs
- [x] `SKILL.md` no longer claims the guard is unwired
- [ ] Confirm the job appears and passes on this PR itself (visible in the checks below)
- [ ] Decide whether to make it a required check in branch protection — deliberately not done here
