### PR TITLE
fix(sdk): update stale OpenAI/Gemini defaults and document Close

### DIFF
--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -1394,6 +1394,8 @@ Close releases resources associated with the conversation.
 
 After Close is called, Send and Stream will return [ErrConversationClosed](<#ErrConversationClosed>). It's safe to call Close multiple times.
 
+Close cancels the session context; it does not drain work already in flight. On the streaming ingestion path in particular, turns are processed asynchronously after the last chunk is queued, so calling Close immediately can cancel a turn mid\-pipeline and drop its response. Wait for the responses you expect before closing.
+
 <a name="Conversation.Continue"></a>
 ### func \(\*Conversation\) Continue
 

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -1259,6 +1259,12 @@ func (c *Conversation) startOTelSession(ctx context.Context) {
 //
 // After Close is called, Send and Stream will return [ErrConversationClosed].
 // It's safe to call Close multiple times.
+//
+// Close cancels the session context; it does not drain work already in
+// flight. On the streaming ingestion path in particular, turns are processed
+// asynchronously after the last chunk is queued, so calling Close immediately
+// can cancel a turn mid-pipeline and drop its response. Wait for the
+// responses you expect before closing.
 func (c *Conversation) Close() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/sdk/internal/provider/detect.go
+++ b/sdk/internal/provider/detect.go
@@ -31,14 +31,19 @@ const (
 
 // Default model per provider, used when the caller supplies no model and the
 // provider is auto-detected from the environment.
+// Each is the vendor's current balance-intelligence-and-cost tier, matching
+// what the previous defaults were when they were chosen. Callers who want a
+// frontier or budget model pass one explicitly.
 const (
-	defaultOpenAIModel = "gpt-4o"
-	// claude-sonnet-5 is the documented drop-in successor to the previous
-	// default (claude-sonnet-4-20250514), which is deprecated. Same tier, so
-	// auto-detected callers keep their cost profile; pass an explicit model to
-	// opt into claude-opus-5.
+	// Replaces gpt-4o, which OpenAI now lists as deprecated.
+	defaultOpenAIModel = "gpt-5.6-terra"
+	// Replaces claude-sonnet-4-20250514, which is deprecated. claude-sonnet-5
+	// is its documented drop-in successor; pass a model to opt into
+	// claude-opus-5.
 	defaultAnthropicModel = "claude-sonnet-5"
-	defaultGeminiModel    = "gemini-1.5-pro"
+	// Replaces gemini-1.5-pro, long retired. gemini-3.6-flash is GA and the
+	// current speed/intelligence balance; there is no current Pro-tier ID.
+	defaultGeminiModel = "gemini-3.6-flash"
 )
 
 // Environment variables consulted during provider auto-detection.
@@ -90,7 +95,7 @@ func Detect(apiKey, model string) (providers.Provider, error) {
 	// If apiKey provided but no provider-specific env var detected, default to OpenAI.
 	// Log a warning so the caller knows this is an implicit assumption.
 	if info == nil {
-		slog.Warn("no provider detected from environment; defaulting to OpenAI gpt-4o",
+		slog.Warn("no provider detected from environment; defaulting to OpenAI "+defaultOpenAIModel,
 			"hint", "set OPENAI_API_KEY, ANTHROPIC_API_KEY, or GOOGLE_API_KEY to be explicit")
 		info = &Info{Name: providerOpenAI, APIKey: apiKey, Model: defaultOpenAIModel}
 	}

--- a/sdk/internal/provider/detect_test.go
+++ b/sdk/internal/provider/detect_test.go
@@ -42,7 +42,7 @@ func TestDetectInfo(t *testing.T) {
 		require.NotNil(t, info)
 		assert.Equal(t, "openai", info.Name)
 		assert.Equal(t, "sk-test-key", info.APIKey)
-		assert.Equal(t, "gpt-4o", info.Model)
+		assert.Equal(t, "gpt-5.6-terra", info.Model)
 	})
 
 	t.Run("anthropic key set", func(t *testing.T) {
@@ -73,7 +73,7 @@ func TestDetectInfo(t *testing.T) {
 		require.NotNil(t, info)
 		assert.Equal(t, "gemini", info.Name)
 		assert.Equal(t, "google-key", info.APIKey)
-		assert.Equal(t, "gemini-1.5-pro", info.Model)
+		assert.Equal(t, "gemini-3.6-flash", info.Model)
 	})
 
 	t.Run("gemini key set", func(t *testing.T) {
@@ -260,9 +260,14 @@ func TestInferProviderFromModel(t *testing.T) {
 		{"gemini-2.0-flash-exp", "gemini"},
 		{"gemini-1.5-pro", "gemini"},
 		{"Gemini-Pro", "gemini"},
+		// The current auto-detect default: if a new generation ever stopped
+		// matching the prefix rule, detection would silently pick the wrong
+		// provider, so pin it here alongside the default itself.
+		{defaultGeminiModel, "gemini"},
 
 		// OpenAI models
 		{"gpt-4o", "openai"},
+		{defaultOpenAIModel, "openai"},
 		{"gpt-4-turbo", "openai"},
 		{"GPT-3.5-Turbo", "openai"},
 		{"o1-preview", "openai"},
@@ -273,6 +278,7 @@ func TestInferProviderFromModel(t *testing.T) {
 		{"claude-3-opus", "anthropic"},
 		{"claude-sonnet-4-20250514", "anthropic"},
 		{"Claude-3-Haiku", "anthropic"},
+		{defaultAnthropicModel, "anthropic"},
 
 		// Ollama models (detected by ":" in name)
 		{"llava:7b", "ollama"},


### PR DESCRIPTION
Finishes the auto-detect default refresh started for Anthropic in #1706.

## The defaults

Both remaining defaults pointed at models the vendors have moved on from. **Verified against their own docs rather than guessed** — which is why I left them out of #1706:

| | was | now | why |
|---|---|---|---|
| OpenAI | `gpt-4o` | `gpt-5.6-terra` | OpenAI's model list marks `gpt-4o` **deprecated** |
| Gemini | `gemini-1.5-pro` | `gemini-3.6-flash` | `1.5-pro` long retired; `3.6-flash` is GA |

Both replacements are the vendor's current *balance intelligence and cost* tier — matching what the previous defaults were when they were chosen. Auto-detected callers keep their cost profile rather than being silently moved to a frontier tier. Note there is **no current Gemini Pro-tier ID** to map `1.5-pro` onto, so the Flash tier is the honest landing spot.

## Tests

Both defaults are now pinned with `assert.Equal`, the same way the Anthropic one is, and **mutation-checked**:

```
# OpenAI constant reverted:
expected: "gpt-5.6-terra"   actual: "gpt-4o"
# Gemini constant reverted:
expected: "gemini-3.6-flash"  actual: "gemini-1.5-pro"
```

Also added each default to the `inferProviderFromModel` table. That covers a real gap: provider detection is prefix-based, so if a future generation ever stopped matching the rule, auto-detection would silently pick the **wrong provider**. Nothing tested that.

**Left alone deliberately:** the `gpt-4o` / `gemini-1.5-pro` strings still in `TestCreateProvider` and the inference table are opaque fixtures, not defaults — they exercise construction and prefix matching with historical IDs, which is still valid coverage.

## The `Close` comment

You asked me to fix the comment rather than chase the behaviour — agreed, and this is the comment that actually mattered. `Close`'s own doc said only that it *"releases resources"*, which is what led the `multitrack-ingestion` example to call it expecting a drain (the flake fixed in #1705).

It now states what `Close` does: cancels the session context, does not wait for in-flight turns, so on the streaming ingestion path an immediate `Close` can cancel a turn mid-pipeline and drop its response. **Behaviour is unchanged** — only the documentation, which was the misleading part. The generated SDK reference is regenerated to match (the pre-commit drift gate caught this).

## Verification

```
pre-commit hook            lint 0 issues, build, tests, coverage, reference drift — all pass
detect.go coverage         98.0%
conversation.go coverage   87.8%
```

**One note:** `golangci-lint` reports a pre-existing `gocognit` finding on `buildPipelineConfig` (complexity 35) in `conversation.go`. I confirmed it's pre-existing by running against unmodified `main` with a cleared lint cache — an earlier "main is clean" reading turned out to be a stale-cache artifact. Not touched here; refactoring the pipeline builder is unrelated to a doc comment.
