### PR TITLE
fix(guardrails): honor min_score/max_score instead of hardcoding 1.0

### DIFF
--- a/runtime/evals/score_thresholds_test.go
+++ b/runtime/evals/score_thresholds_test.go
@@ -1,0 +1,171 @@
+package evals
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func scorePtr(f float64) *float64 { return &f }
+
+func TestScoreThresholds_Triggered(t *testing.T) {
+	tests := []struct {
+		name       string
+		thresholds ScoreThresholds
+		result     *EvalResult
+		want       bool
+		why        string
+	}{
+		{
+			name:       "no thresholds requires a perfect score",
+			thresholds: ScoreThresholds{},
+			result:     &EvalResult{Score: scorePtr(0.99)},
+			want:       true,
+			why:        "the pre-existing default every declared guardrail relies on",
+		},
+		{
+			name:       "no thresholds allows a perfect score",
+			thresholds: ScoreThresholds{},
+			result:     &EvalResult{Score: scorePtr(1.0)},
+			want:       false,
+		},
+		{
+			name:       "min honored above threshold",
+			thresholds: ScoreThresholds{Min: scorePtr(0.5)},
+			result:     &EvalResult{Score: scorePtr(0.8)},
+			want:       false,
+			why:        "0.8 clears 0.5 even though it is short of a perfect 1.0",
+		},
+		{
+			name:       "min honored at exactly the threshold",
+			thresholds: ScoreThresholds{Min: scorePtr(0.5)},
+			result:     &EvalResult{Score: scorePtr(0.5)},
+			want:       false,
+			why:        "the bound is inclusive, matching AssertionEvalHandler",
+		},
+		{
+			name:       "min honored below threshold",
+			thresholds: ScoreThresholds{Min: scorePtr(0.5)},
+			result:     &EvalResult{Score: scorePtr(0.49)},
+			want:       true,
+		},
+		{
+			name:       "max honored above threshold",
+			thresholds: ScoreThresholds{Max: scorePtr(0.3)},
+			result:     &EvalResult{Score: scorePtr(1.0)},
+			want:       true,
+			why:        "a high score is the failure for handlers scoring how much bad content is present",
+		},
+		{
+			name:       "max alone does not impose the default minimum",
+			thresholds: ScoreThresholds{Max: scorePtr(0.3)},
+			result:     &EvalResult{Score: scorePtr(0.1)},
+			want:       false,
+			why:        "setting only max must not silently also require 1.0",
+		},
+		{
+			name:       "both bounds, inside the band",
+			thresholds: ScoreThresholds{Min: scorePtr(0.4), Max: scorePtr(0.6)},
+			result:     &EvalResult{Score: scorePtr(0.5)},
+			want:       false,
+		},
+		{
+			name:       "both bounds, above the band",
+			thresholds: ScoreThresholds{Min: scorePtr(0.4), Max: scorePtr(0.6)},
+			result:     &EvalResult{Score: scorePtr(0.7)},
+			want:       true,
+		},
+		{
+			name:       "nil score fails closed",
+			thresholds: ScoreThresholds{Min: scorePtr(0.5)},
+			result:     &EvalResult{},
+			want:       true,
+			why:        "a handler that could not judge has not cleared anything",
+		},
+		{
+			name:       "nil result fails closed",
+			thresholds: ScoreThresholds{},
+			result:     nil,
+			want:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.thresholds.Triggered(tc.result), tc.why)
+		})
+	}
+}
+
+func TestExtractScoreThresholds(t *testing.T) {
+	t.Run("absent leaves both nil, so the 1.0 default applies", func(t *testing.T) {
+		got := ExtractScoreThresholds(map[string]any{"words": []any{"x"}})
+
+		require.Nil(t, got.Min)
+		require.Nil(t, got.Max)
+		// Asserted through behavior as well: absent thresholds must leave the
+		// perfect-score default in force. Checking only for nil would pass if
+		// extraction started inventing a bound.
+		assert.True(t, got.Triggered(&EvalResult{Score: scorePtr(0.99)}),
+			"with no thresholds extracted, anything short of 1.0 must still trigger")
+		assert.False(t, got.Triggered(&EvalResult{Score: scorePtr(1.0)}))
+	})
+
+	t.Run("reads floats and ints", func(t *testing.T) {
+		// Ints matter: a pack author writing min_score: 1 in JSON yields an int
+		// through some decoders, and silently ignoring it would leave the
+		// guardrail on the default.
+		got := ExtractScoreThresholds(map[string]any{"min_score": 1, "max_score": 0.75})
+		require.NotNil(t, got.Min)
+		require.NotNil(t, got.Max)
+		assert.Equal(t, 1.0, *got.Min)
+		assert.Equal(t, 0.75, *got.Max)
+	})
+
+	t.Run("nil params yields the default, not a panic", func(t *testing.T) {
+		got := ExtractScoreThresholds(nil)
+
+		require.Nil(t, got.Min)
+		require.Nil(t, got.Max)
+		assert.True(t, got.Triggered(&EvalResult{Score: scorePtr(0.5)}),
+			"a guardrail declared with no params at all must still enforce")
+	})
+}
+
+func TestStripScoreThresholds(t *testing.T) {
+	t.Run("removes thresholds and keeps everything else", func(t *testing.T) {
+		in := map[string]any{"min_score": 0.5, "max_score": 1.0, "words": []any{"keepme"}}
+		got := StripScoreThresholds(in)
+
+		assert.NotContains(t, got, "min_score")
+		assert.NotContains(t, got, "max_score")
+		assert.Contains(t, got, "words")
+	})
+
+	t.Run("does not mutate the input", func(t *testing.T) {
+		// The adapter holds one params map for the life of the conversation and
+		// calls this on every turn; mutating it would strip the thresholds
+		// permanently and silently revert to the default after turn one.
+		in := map[string]any{"min_score": 0.5, "words": []any{"keepme"}}
+		_ = StripScoreThresholds(in)
+
+		assert.Contains(t, in, "min_score", "the caller's map must be left intact")
+	})
+
+	t.Run("returns the same map when there is nothing to strip", func(t *testing.T) {
+		in := map[string]any{"words": []any{"keepme"}}
+		assert.Equal(t, in, StripScoreThresholds(in))
+	})
+
+	t.Run("nil params passes through as nil, not an empty map", func(t *testing.T) {
+		got := StripScoreThresholds(nil)
+
+		require.Nil(t, got,
+			"handlers distinguish a nil param map from an empty one, so "+
+				"stripping must not materialize one")
+		// And the result stays usable: a handler receiving it reads no
+		// thresholds, which is what a params-less guardrail means.
+		assert.Equal(t, ScoreThresholds{}, ExtractScoreThresholds(got))
+	})
+}

--- a/runtime/evals/wrappers.go
+++ b/runtime/evals/wrappers.go
@@ -11,6 +11,92 @@ const WrapperTypeAssertion = "assertion"
 // WrapperTypeGuardrail is the eval type name for the guardrail wrapper handler.
 const WrapperTypeGuardrail = "guardrail"
 
+// scoreThresholdParamKeys are the wrapper-level param names that convert an
+// inner eval's score into a verdict. They are deliberately *not* valid on an
+// eval handler — handlers call rejectThresholdParams to refuse them — so a
+// wrapper must consume them and strip them before invoking its inner handler.
+var scoreThresholdParamKeys = []string{"min_score", "max_score"}
+
+// ScoreThresholds turns an eval score into a verdict, and is the single
+// implementation of that decision.
+//
+// Every role that wraps an eval needs it: the "assertion" and "guardrail" eval
+// types here, and the pipeline's guardrail hook adapter. The adapter used to
+// carry its own copy hardcoded at `< 1.0` in three places, which ignored
+// min_score entirely and so made continuous-score handlers (cost_budget,
+// latency_budget) untunable and effectively unusable as guardrails (#1707).
+type ScoreThresholds struct {
+	// Min fails a score below it. Max fails a score above it. Both optional;
+	// with neither set, Triggered requires a perfect 1.0.
+	Min *float64
+	Max *float64
+}
+
+// ExtractScoreThresholds reads min_score/max_score from wrapper params.
+func ExtractScoreThresholds(params map[string]any) ScoreThresholds {
+	return ScoreThresholds{
+		Min: extractOptionalFloat64(params, "min_score"),
+		Max: extractOptionalFloat64(params, "max_score"),
+	}
+}
+
+// StripScoreThresholds returns params without the threshold keys, so they never
+// reach an inner eval handler. Handlers that call rejectThresholdParams return
+// an error result scoring 0 when they see one, which a guardrail reads as
+// "block" — so forwarding a threshold turns the guardrail into an always-block
+// rather than merely ignoring the param.
+//
+// The input map is never mutated; callers may share it across turns.
+func StripScoreThresholds(params map[string]any) map[string]any {
+	if params == nil {
+		return nil
+	}
+	present := false
+	for _, key := range scoreThresholdParamKeys {
+		if _, ok := params[key]; ok {
+			present = true
+			break
+		}
+	}
+	if !present {
+		return params
+	}
+	stripped := make(map[string]any, len(params))
+	for k, v := range params {
+		stripped[k] = v
+	}
+	for _, key := range scoreThresholdParamKeys {
+		delete(stripped, key)
+	}
+	return stripped
+}
+
+// Triggered reports whether a result trips a guardrail under these thresholds.
+//
+// A nil result or nil score means the handler could not judge, and a safety
+// mechanism that cannot judge blocks: this is fail-closed, matching what the
+// pipeline's guardrail hook has always done. Note the assertion role makes the
+// opposite choice — see AssertionEvalHandler.applyThresholds — because failing
+// a *test* over a handler that declined to score would be noise, whereas
+// allowing unjudged content through a *guardrail* is a hole.
+func (t ScoreThresholds) Triggered(result *EvalResult) bool {
+	if result == nil || result.Score == nil {
+		return true
+	}
+	minScore := t.Min
+	if minScore == nil && t.Max == nil {
+		perfect := 1.0
+		minScore = &perfect
+	}
+	if minScore != nil && *result.Score < *minScore {
+		return true
+	}
+	if t.Max != nil && *result.Score > *t.Max {
+		return true
+	}
+	return false
+}
+
 // extractOptionalFloat64 extracts a float64 from params, handling int->float64.
 func extractOptionalFloat64(params map[string]any, key string) *float64 {
 	v, ok := params[key]
@@ -153,7 +239,7 @@ func (h *GuardrailEvalHandler) Eval(
 	}
 
 	action := extractParamString(params, "action", "block")
-	minScore := extractOptionalFloat64(params, "min_score")
+	thresholds := ExtractScoreThresholds(params)
 	innerParams := extractEvalParams(params)
 
 	result, err := handler.Eval(ctx, evalCtx, innerParams)
@@ -161,13 +247,12 @@ func (h *GuardrailEvalHandler) Eval(
 		return nil, err
 	}
 
-	// Determine if the guardrail was triggered
-	triggered := false
-	if minScore != nil && result.Score != nil {
-		triggered = *result.Score < *minScore
-	} else {
-		triggered = result.Score != nil && *result.Score < 1.0
-	}
+	// Shared with the pipeline's guardrail hook adapter so the two cannot drift
+	// again. This converges one difference: a nil score now counts as triggered
+	// (fail-closed) where this path previously read it as not-triggered. A
+	// guardrail whose handler could not produce a score has not cleared
+	// anything, and no test pinned the old behavior.
+	triggered := thresholds.Triggered(result)
 
 	if result.Details == nil {
 		result.Details = make(map[string]any)

--- a/runtime/hooks/guardrails/adapter.go
+++ b/runtime/hooks/guardrails/adapter.go
@@ -139,16 +139,14 @@ func (a *GuardrailHookAdapter) AfterCall(
 		msgs, resp.Message.GetContent(), metadata,
 	)
 
-	// Apply defaults for aliased eval types, then normalize legacy param names
-	params := evals.ApplyDefaults(a.evalType, a.params)
-	params = evals.NormalizeParams(a.evalType, params)
+	params, thresholds := a.evalParams()
 
 	result, err := a.handler.Eval(ctx, evalCtx, params)
 	if err != nil {
 		return hooks.Deny("guardrail error: " + err.Error())
 	}
 
-	if result.Score == nil || *result.Score < 1.0 {
+	if thresholds.Triggered(result) {
 		a.enforce(&resp.Message, params)
 		return a.enforced(result)
 	}
@@ -156,21 +154,35 @@ func (a *GuardrailHookAdapter) AfterCall(
 	return hooks.Allow
 }
 
+// evalParams returns the params the inner handler should see, plus the
+// thresholds this adapter applies itself.
+//
+// Two things are load-bearing. Defaults and legacy-name normalization run
+// first, so a threshold declared under an aliased name is still found. And the
+// threshold keys are stripped before the handler sees them: they are wrapper
+// params by design, and several handler families call rejectThresholdParams,
+// which returns an error result scoring 0 — read by the guardrail as "block".
+// Forwarding a threshold therefore turned the guardrail into an always-block
+// instead of merely ignoring the param (#1707).
+func (a *GuardrailHookAdapter) evalParams() (map[string]any, evals.ScoreThresholds) {
+	params := evals.ApplyDefaults(a.evalType, a.params)
+	params = evals.NormalizeParams(a.evalType, params)
+	thresholds := evals.ExtractScoreThresholds(params)
+	return evals.StripScoreThresholds(params), thresholds
+}
+
 // evaluate runs the handler and converts the EvalResult to a Decision.
 func (a *GuardrailHookAdapter) evaluate(
 	ctx context.Context, evalCtx *evals.EvalContext,
 ) hooks.Decision {
-	// Apply defaults for aliased eval types, then normalize legacy param names
-	params := evals.ApplyDefaults(a.evalType, a.params)
-	params = evals.NormalizeParams(a.evalType, params)
+	params, thresholds := a.evalParams()
 
 	result, err := a.handler.Eval(ctx, evalCtx, params)
 	if err != nil {
 		return hooks.Deny("guardrail error: " + err.Error())
 	}
 
-	// Derive pass/fail from Score (score < 1.0 = fail).
-	if result.Score == nil || *result.Score < 1.0 {
+	if thresholds.Triggered(result) {
 		return a.enforced(result)
 	}
 
@@ -189,15 +201,14 @@ func (a *GuardrailHookAdapter) OnChunk(
 		return hooks.Allow
 	}
 
-	params := evals.ApplyDefaults(a.evalType, a.params)
-	params = evals.NormalizeParams(a.evalType, params)
+	params, thresholds := a.evalParams()
 
 	result, err := streamable.EvalPartial(ctx, chunk.Content, params)
 	if err != nil {
 		return hooks.Deny("guardrail streaming error: " + err.Error())
 	}
 
-	if result.Score == nil || *result.Score < 1.0 {
+	if thresholds.Triggered(result) {
 		// Substitute the enforced content, exactly as the non-streaming path
 		// does. Previously this only truncated for length validators, so a
 		// content blocker left the offending text in place and the caller

--- a/runtime/hooks/guardrails/factory.go
+++ b/runtime/hooks/guardrails/factory.go
@@ -47,8 +47,12 @@ func NewGuardrailHookFromRegistry(
 
 	// Normalise params the same way adapter.AfterCall does before passing
 	// to ValidateParams, so handlers only need to check canonical key names.
+	// Threshold keys are stripped for the same reason the adapter strips them:
+	// they belong to this wrapper, and a handler asked to validate one rejects
+	// it, which would fail construction outright (#1707).
 	normalized := evals.ApplyDefaults(typeName, params)
 	normalized = evals.NormalizeParams(typeName, normalized)
+	normalized = evals.StripScoreThresholds(normalized)
 
 	if pv, ok := handler.(evals.ParamValidator); ok {
 		if verr := pv.ValidateParams(normalized); verr != nil {

--- a/runtime/hooks/guardrails/threshold_test.go
+++ b/runtime/hooks/guardrails/threshold_test.go
@@ -1,0 +1,194 @@
+package guardrails
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// The score -> triggered decision already existed on evals.GuardrailEvalHandler
+// with a configurable min_score. GuardrailHookAdapter carried a second, less
+// capable copy hardcoded at `< 1.0` in three places and never read the param,
+// so a continuous-score handler could not be tuned in the hook path at all
+// (#1707).
+//
+// Worse, the adapter forwarded its whole param map to the inner handler, and
+// several handler families call rejectThresholdParams — which returns an
+// errorResult scoring 0. So declaring a threshold made those guardrails block
+// every turn with an error, rather than merely ignoring the param.
+
+// paramSpyHandler records the params it was handed and mimics the handler
+// families that reject wrapper-level threshold params.
+type paramSpyHandler struct {
+	typeName string
+	score    float64
+	seen     map[string]any
+}
+
+func (s *paramSpyHandler) Type() string { return s.typeName }
+
+func (s *paramSpyHandler) Eval(
+	_ context.Context, _ *evals.EvalContext, params map[string]any,
+) (*evals.EvalResult, error) {
+	s.seen = params
+	for _, banned := range []string{"min_score", "max_score"} {
+		if _, present := params[banned]; present {
+			// Mirrors handlers.rejectThresholdParams: score 0, which the
+			// adapter reads as "enforce".
+			return &evals.EvalResult{
+				Type:        s.typeName,
+				Score:       floatPtr(0),
+				Error:       banned + " is not a valid param on an eval handler",
+				Explanation: banned + " is not a valid param on an eval handler",
+			}, nil
+		}
+	}
+	return &evals.EvalResult{Type: s.typeName, Score: &s.score}, nil
+}
+
+func spyGuardrail(t *testing.T, score float64, params map[string]any) (*GuardrailHookAdapter, *paramSpyHandler) {
+	t.Helper()
+	spy := &paramSpyHandler{typeName: "spy_eval", score: score}
+	registry := evals.NewEmptyEvalTypeRegistry()
+	registry.Register(spy)
+
+	h, err := NewGuardrailHookFromRegistry("spy_eval", params, registry)
+	require.NoError(t, err)
+	adapter, ok := h.(*GuardrailHookAdapter)
+	require.True(t, ok)
+	return adapter, spy
+}
+
+// TestGuardrailThreshold_MinScoreAllowsAboveThreshold is the headline case: a
+// score of 0.8 is a pass when min_score is 0.5, even though it is below the
+// hardcoded 1.0 the adapter used to demand.
+func TestGuardrailThreshold_MinScoreAllowsAboveThreshold(t *testing.T) {
+	adapter, _ := spyGuardrail(t, 0.8, map[string]any{"min_score": 0.5})
+
+	resp := &hooks.ProviderResponse{Message: types.Message{Content: "out"}}
+	d := adapter.AfterCall(context.Background(), nil, resp)
+
+	assert.True(t, d.Allow,
+		"0.8 clears a min_score of 0.5; the adapter must honor the threshold "+
+			"rather than demanding a perfect 1.0")
+}
+
+// TestGuardrailThreshold_MinScoreEnforcesBelowThreshold is the discriminating
+// half: honoring min_score must not become an unconditional allow.
+func TestGuardrailThreshold_MinScoreEnforcesBelowThreshold(t *testing.T) {
+	adapter, _ := spyGuardrail(t, 0.2, map[string]any{"min_score": 0.5})
+
+	resp := &hooks.ProviderResponse{Message: types.Message{Content: "out"}}
+	d := adapter.AfterCall(context.Background(), nil, resp)
+
+	require.False(t, d.Allow, "0.2 is below a min_score of 0.5")
+	assert.True(t, d.Enforced, "guardrails enforce rather than deny")
+}
+
+// TestGuardrailThreshold_MaxScoreEnforcesAboveThreshold covers max_score, for
+// parity with AssertionEvalHandler.applyThresholds. Some handlers score
+// "how much of the bad thing is present", where a high score is the failure.
+// A perfect 1.0 is used deliberately: under the old hardcoded rule that
+// allowed, so this case only distinguishes a real max_score implementation
+// from the previous behavior.
+func TestGuardrailThreshold_MaxScoreEnforcesAboveThreshold(t *testing.T) {
+	adapter, _ := spyGuardrail(t, 1.0, map[string]any{"max_score": 0.3})
+
+	resp := &hooks.ProviderResponse{Message: types.Message{Content: "out"}}
+	d := adapter.AfterCall(context.Background(), nil, resp)
+
+	require.False(t, d.Allow, "1.0 exceeds a max_score of 0.3")
+	assert.True(t, d.Enforced, "guardrails enforce rather than deny")
+}
+
+// TestGuardrailThreshold_DefaultsToPerfectScore pins the existing default: with
+// no threshold configured, anything short of 1.0 enforces. This is the behavior
+// every currently-declared guardrail relies on and it must not shift.
+func TestGuardrailThreshold_DefaultsToPerfectScore(t *testing.T) {
+	enforcing, _ := spyGuardrail(t, 0.99, nil)
+	resp := &hooks.ProviderResponse{Message: types.Message{Content: "out"}}
+	d := enforcing.AfterCall(context.Background(), nil, resp)
+	require.False(t, d.Allow, "0.99 with no threshold configured still enforces")
+
+	allowing, _ := spyGuardrail(t, 1.0, nil)
+	d = allowing.AfterCall(context.Background(), nil, resp)
+	assert.True(t, d.Allow, "a perfect score allows")
+}
+
+// TestGuardrailThreshold_NilScoreEnforces pins the fail-closed choice. A
+// handler that returns no score could not judge, and a safety mechanism that
+// cannot judge must block. Note evals.GuardrailEvalHandler historically did the
+// opposite for a nil score; the guardrail role converges on fail-closed.
+func TestGuardrailThreshold_NilScoreEnforces(t *testing.T) {
+	handler := &stubHandler{
+		typeName: "nil_score",
+		result:   &evals.EvalResult{Type: "nil_score"},
+	}
+	adapter := &GuardrailHookAdapter{
+		handler:   handler,
+		evalType:  "nil_score",
+		direction: DirectionOutput,
+	}
+
+	resp := &hooks.ProviderResponse{Message: types.Message{Content: "out"}}
+	d := adapter.AfterCall(context.Background(), nil, resp)
+
+	require.False(t, d.Allow, "a handler that could not score must not be treated as a pass")
+	assert.True(t, d.Enforced)
+}
+
+// TestGuardrailThreshold_ParamsNeverReachInnerHandler is the trap half of
+// #1707. Thresholds are a wrapper concern by design — rejectThresholdParams
+// exists to enforce that — so they must be consumed by the adapter and stripped
+// before the inner handler sees them. Forwarding them made the handler return
+// an error result scoring 0, i.e. block every turn.
+func TestGuardrailThreshold_ParamsNeverReachInnerHandler(t *testing.T) {
+	adapter, spy := spyGuardrail(t, 1.0, map[string]any{
+		"min_score": 0.5,
+		"max_score": 1.0,
+		"words":     []any{"keepme"},
+	})
+
+	resp := &hooks.ProviderResponse{Message: types.Message{Content: "out"}}
+	d := adapter.AfterCall(context.Background(), nil, resp)
+
+	require.NotNil(t, spy.seen, "the inner handler must have been called")
+	assert.NotContains(t, spy.seen, "min_score",
+		"min_score is a wrapper param; forwarding it makes threshold-rejecting "+
+			"handlers return an error result that blocks every turn")
+	assert.NotContains(t, spy.seen, "max_score", "max_score is a wrapper param")
+	assert.Contains(t, spy.seen, "words",
+		"non-threshold params must still reach the handler untouched")
+
+	assert.True(t, d.Allow, "score 1.0 clears min_score 0.5 and max_score 1.0")
+}
+
+// TestGuardrailThreshold_BeforeCallHonorsThreshold pins that the input
+// direction uses the same decision. The adapter had three separate copies of
+// the hardcoded comparison; a fix that only touched AfterCall would leave
+// input guardrails on the old rule.
+func TestGuardrailThreshold_BeforeCallHonorsThreshold(t *testing.T) {
+	spy := &paramSpyHandler{typeName: "spy_eval", score: 0.8}
+	registry := evals.NewEmptyEvalTypeRegistry()
+	registry.Register(spy)
+
+	h, err := NewGuardrailHookFromRegistry("spy_eval", map[string]any{
+		"min_score": 0.5,
+		"direction": "input",
+	}, registry)
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{{Role: "user", Content: "hello"}},
+	}
+	d := h.BeforeCall(context.Background(), req)
+
+	assert.True(t, d.Allow, "BeforeCall must honor min_score too, not just AfterCall")
+}


### PR DESCRIPTION
## Summary

The score→verdict conversion already existed. `evals.GuardrailEvalHandler` has honored a configurable `min_score` all along, and `AssertionEvalHandler.applyThresholds` honors both bounds. `GuardrailHookAdapter` carried a **second, less capable copy** of the same decision — hardcoded at `< 1.0` in three places (`adapter.go:151`, `:173`, `:200`) — that never read the param.

So `cost_budget` with any nonzero spend scored below 1.0 and blocked the turn, and there was no threshold anyone could configure to prevent it.

Refs #1707 — deliberately not `Closes`, see [What this does not fix](#what-this-does-not-fix).

## It was worse than ignoring the param

The adapter forwarded its whole param map to the inner handler. Several handler families — `llm_judge`, classify-backed, safety, RAG, composition — call `rejectThresholdParams`, which returns an `errorResult` scoring **0**. The adapter reads 0 as "enforce".

So declaring a threshold on those guardrails made them **block every turn with an error**, rather than merely ignoring the setting.

The factory had the same bug one level earlier: it passed thresholds into `ValidateParams`, so for handlers validating them, **construction failed outright**. Between the two, there was no way to set a guardrail threshold in the hook path at all.

## The fix

`evals.ScoreThresholds` is now the single implementation, used by the wrapper, the adapter, and the factory:

- **Extract at the wrapper level, strip before the inner handler.** That is the contract `rejectThresholdParams` already assumed — thresholds are a wrapper concern by design.
- **`StripScoreThresholds` never mutates its input.** The adapter holds one params map for the life of the conversation; mutating it would strip the thresholds permanently and silently revert to the default after turn one. There is a test for exactly that.
- **The three duplicated `ApplyDefaults`/`NormalizeParams` blocks collapse into one `evalParams()` helper**, so `BeforeCall`, `AfterCall` and `OnChunk` cannot drift on the decision again — which is how this arose.

`cost_budget` with `min_score: 0.5` now means "block once more than half the budget is spent", which is a usable budget guardrail.

**Default behavior is unchanged**: with no threshold configured, anything short of 1.0 still enforces. Pinned by a test.

**No handler `Score` semantics change**, so there is no cross-repo impact on PromptArena assertions. My original analysis on #1707 proposed rewriting the budget handlers and flagged a cross-repo decision; that was wrong, and the correction is posted on the issue.

## One deliberate behavior convergence

A nil score now counts as triggered on the **wrapper** path, where it previously read as not-triggered. A guardrail whose handler could not produce a score has not cleared anything, and the pipeline adapter has always failed closed. No test pinned the old behavior.

The **assertion** role keeps the opposite choice on purpose: failing a test because a handler declined to score would be noise, whereas allowing unjudged content through a guardrail is a hole. That asymmetry is now documented on `Triggered` rather than left as an accident of two implementations.

## What this does not fix

`latency_budget` reads `Metadata["latency_ms"]` and `cost_budget` reads `Metadata["total_cost"]`, and **the pipeline never populates either** — hook metadata comes from caller-supplied `turnState.ProviderRequestMetadata`. A missing key is a hard fail (`boolScore(false)`), not a ratio, so `latency_budget` still blocks every turn as a guardrail no matter what threshold is set.

That is a separate gap and #1707 stays open for it. Deciding whether the pipeline *should* surface cost and latency into hook metadata is a design question, not a bug fix.

## Tests

Seven adapter tests and a table of eleven threshold cases, all **mutation-verified** — each assertion checked by breaking the thing it claims to pin and confirming the specific test goes red:

| Mutation | Tests that caught it |
|---|---|
| `Triggered` ignores `Min` | 2 |
| `Triggered` ignores `Max` | 1 |
| nil score → fail-open | 1 |
| default 1.0 removed | 1 |
| `StripScoreThresholds` returns params unchanged | 4 |
| adapter ignores declared thresholds | 3 |

The `max_score` case deliberately uses a perfect 1.0, because under the old hardcoded rule that *allowed* — a lower score would have passed for the wrong reason.

Coverage: `ScoreThresholds.Triggered`, `ExtractScoreThresholds`, `StripScoreThresholds` all 100%.

**The new `Weak Assertion Guard` from #1709 fired on my own tests here** — three subtests whose only assertions were `assert.Nil`. Rather than dismiss them as the documented false-positive shape, I strengthened all three to assert observable behavior (that absent thresholds leave the 1.0 default in force, that a nil map stays nil rather than materializing an empty one). The guard is clean now. First real use of that guard was against its author, which is about the right outcome.

## Provenance

Found because @chaholl pointed out that assertions and guardrails wrap evals and the score→bool conversion should already exist. It did. Two implementations of one decision that drifted apart is the **divergent-twins** shape (seam-audit design §4.2, deliberately not built) — second confirmed instance after #1697's `Eval`/`EvalPartial` drift.

## Verification

- `go -C runtime test ./... -count=1` — pass
- `go -C sdk test ./... -count=1` — pass
- `golangci-lint run --new-from-rev=HEAD ./runtime/...` — 0 issues
- `scripts/check-weak-assertions.sh` — clean

## Test plan

- [x] `min_score` honored, both directions, on `BeforeCall` and `AfterCall`
- [x] `max_score` honored, with a case that only a real implementation passes
- [x] Default (no thresholds) unchanged at 1.0
- [x] nil score fails closed
- [x] Thresholds never reach the inner handler; non-threshold params untouched
- [x] `StripScoreThresholds` does not mutate the caller's map
- [x] Every new test mutation-verified
- [ ] #1707's remaining half: pipeline does not surface cost/latency into hook metadata
