### PR TITLE
fix(guardrails): derive spend and latency for the budget handlers

### DIFF
--- a/runtime/evals/budget_metadata_test.go
+++ b/runtime/evals/budget_metadata_test.go
@@ -1,0 +1,91 @@
+package evals
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+func costMessage(cost float64, in, out, cached int) types.Message {
+	return types.Message{
+		Role: "assistant",
+		CostInfo: &types.CostInfo{
+			TotalCost:    cost,
+			InputTokens:  in,
+			OutputTokens: out,
+			CachedTokens: cached,
+		},
+	}
+}
+
+func TestSeedBudgetMetadata_DerivesFromCostInfo(t *testing.T) {
+	latency := int64(250)
+	messages := []types.Message{
+		types.NewUserMessage("no cost on a user turn"),
+		costMessage(1.5, 100, 50, 10),
+		costMessage(2.5, 200, 80, 20),
+	}
+
+	got := SeedBudgetMetadata(nil, messages, &latency)
+
+	assert.InDelta(t, 4.0, got["total_cost"], 1e-9, "spend accumulates across the transcript")
+	assert.Equal(t, 300, got["input_tokens"])
+	assert.Equal(t, 130, got["output_tokens"])
+	assert.Equal(t, 30, got["cached_tokens"])
+	assert.InDelta(t, 250.0, got["latency_ms"], 1e-9,
+		"latency is seeded as a float because extractFloat64 is what reads it")
+}
+
+func TestSeedBudgetMetadata_NilLatencyOmitsTheKey(t *testing.T) {
+	got := SeedBudgetMetadata(nil, []types.Message{costMessage(1, 1, 1, 0)}, nil)
+
+	assert.NotContains(t, got, "latency_ms",
+		"no completed call means no latency; seeding zero would report every "+
+			"prospective request as instant")
+	// The spend keys are still present — only latency is conditional.
+	assert.Contains(t, got, "total_cost")
+}
+
+func TestSeedBudgetMetadata_CallerValuesWin(t *testing.T) {
+	latency := int64(10)
+	caller := map[string]any{
+		"total_cost": 99.0,
+		"unrelated":  "kept",
+	}
+
+	got := SeedBudgetMetadata(caller, []types.Message{costMessage(0.01, 5, 5, 0)}, &latency)
+
+	assert.InDelta(t, 99.0, got["total_cost"], 1e-9,
+		"a host tracking session-wide spend must not have it replaced by this "+
+			"turn's derivation")
+	assert.Equal(t, "kept", got["unrelated"], "unrelated caller keys survive")
+	assert.Equal(t, 5, got["input_tokens"],
+		"keys the caller did not set are still derived")
+}
+
+func TestSeedBudgetMetadata_DoesNotMutateCallerMap(t *testing.T) {
+	// The adapter holds one request metadata map per turn and other hooks read
+	// it too; writing derived values into it would leak this guardrail's view
+	// into everything downstream.
+	caller := map[string]any{"unrelated": "kept"}
+
+	_ = SeedBudgetMetadata(caller, []types.Message{costMessage(1, 1, 1, 0)}, nil)
+
+	assert.Len(t, caller, 1, "the caller's map must be left exactly as it was")
+	assert.NotContains(t, caller, "total_cost")
+}
+
+func TestSeedBudgetMetadata_NoCostInfoYieldsZeros(t *testing.T) {
+	got := SeedBudgetMetadata(nil, []types.Message{
+		types.NewUserMessage("hi"),
+		types.NewAssistantMessage("no CostInfo attached"),
+	}, nil)
+
+	// Zero rather than absent, which matches what cost_budget already does with
+	// a missing key — so a transcript without cost data behaves identically
+	// before and after seeding.
+	assert.InDelta(t, 0.0, got["total_cost"], 1e-9)
+	assert.Equal(t, 0, got["input_tokens"])
+}

--- a/runtime/evals/context.go
+++ b/runtime/evals/context.go
@@ -82,6 +82,63 @@ func BuildGuardrailEvalContext(
 	}
 }
 
+// SeedBudgetMetadata fills in the spend, token and latency values the budget
+// eval handlers read, deriving them from data the caller already holds.
+//
+// cost_budget reads total_cost/input_tokens/output_tokens and latency_budget
+// reads latency_ms, all off EvalContext.Metadata. Nothing populated those on the
+// guardrail hook path, so cost_budget computed zero spend and never fired, while
+// latency_budget treated its missing key as a hard fail — scoring 0, which a
+// guardrail reads as enforce — and therefore blocked every turn regardless of
+// actual latency (#1707).
+//
+// Neither value needs threading through the pipeline. Spend and tokens
+// accumulate on per-message CostInfo (the same source sumHistoryCost totals for
+// the tool loop's own budget check), and latency arrives on the hook's
+// ProviderResponse. Pass latencyMs as nil where no call has completed yet — an
+// input-direction guardrail has no latency to judge, and inventing a zero there
+// would silently report every prospective call as instant.
+//
+// Caller-supplied values win: a host tracking session-wide spend across turns
+// puts its own total_cost on the request metadata, and per-request derivation
+// must not quietly replace it. The input map is never mutated.
+func SeedBudgetMetadata(
+	metadata map[string]any, messages []types.Message, latencyMs *int64,
+) map[string]any {
+	var totalCost float64
+	var inputTokens, outputTokens, cachedTokens int
+	for i := range messages {
+		cost := messages[i].CostInfo
+		if cost == nil {
+			continue
+		}
+		totalCost += cost.TotalCost
+		inputTokens += cost.InputTokens
+		outputTokens += cost.OutputTokens
+		cachedTokens += cost.CachedTokens
+	}
+
+	seeded := map[string]any{
+		"total_cost":    totalCost,
+		"input_tokens":  inputTokens,
+		"output_tokens": outputTokens,
+		"cached_tokens": cachedTokens,
+	}
+	if latencyMs != nil {
+		seeded["latency_ms"] = float64(*latencyMs)
+	}
+
+	out := make(map[string]any, len(seeded)+len(metadata))
+	for k, v := range seeded {
+		out[k] = v
+	}
+	// Copied second so anything the caller set overrides the derived value.
+	for k, v := range metadata {
+		out[k] = v
+	}
+	return out
+}
+
 // workflowMetadataKeys are the workflow fields an engine sets on the metadata
 // map for workflow scenarios, rather than on message Meta.
 var workflowMetadataKeys = []string{

--- a/runtime/hooks/guardrails/adapter.go
+++ b/runtime/hooks/guardrails/adapter.go
@@ -95,8 +95,12 @@ func (a *GuardrailHookAdapter) BeforeCall(
 	// never see — hence the explicit content argument rather than
 	// BuildEvalContext's last-assistant inference. See
 	// evals.BuildGuardrailEvalContext.
+	//
+	// nil latency: no call has completed, so there is nothing to judge. A
+	// latency guardrail is output-only by nature.
+	metadata := evals.SeedBudgetMetadata(req.Metadata, req.Messages, nil)
 	evalCtx := evals.BuildGuardrailEvalContext(
-		req.Messages, lastMsg.GetContent(), req.Metadata,
+		req.Messages, lastMsg.GetContent(), metadata,
 	)
 
 	d := a.evaluate(ctx, evalCtx)
@@ -123,15 +127,20 @@ func (a *GuardrailHookAdapter) AfterCall(
 
 	// Build messages list: request messages + the response being evaluated.
 	var msgs []types.Message
-	var metadata map[string]any
+	var reqMetadata map[string]any
 	if req != nil {
 		msgs = make([]types.Message, len(req.Messages)+1)
 		copy(msgs, req.Messages)
 		msgs[len(req.Messages)] = resp.Message
-		metadata = req.Metadata
+		reqMetadata = req.Metadata
 	} else {
 		msgs = []types.Message{resp.Message}
 	}
+
+	// Spend and tokens come off the transcript's CostInfo — including this
+	// response, which is why seeding happens after msgs is assembled. Latency is
+	// the completed call's, which only exists on this side of the provider.
+	metadata := evals.SeedBudgetMetadata(reqMetadata, msgs, &resp.LatencyMs)
 
 	// Judge this response only. Scanning the whole transcript would make one
 	// tripped turn re-block every later turn in the conversation.

--- a/runtime/hooks/guardrails/budget_metadata_test.go
+++ b/runtime/hooks/guardrails/budget_metadata_test.go
@@ -1,0 +1,235 @@
+package guardrails
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// The budget handlers read spend and latency off EvalContext.Metadata, which
+// nothing populated on the hook path. cost_budget therefore computed zero spend
+// and never fired, and latency_budget treated its missing key as a hard fail —
+// scoring 0, which the adapter reads as enforce — so it blocked every turn
+// regardless of actual latency (#1707).
+//
+// Both values are already available to the adapter: latency arrives on
+// ProviderResponse.LatencyMs, and per-message CostInfo carries tokens and spend.
+// Nothing needs threading through the pipeline.
+
+func costMsg(role, content string, cost float64, in, out int) types.Message {
+	return types.Message{
+		Role:    role,
+		Content: content,
+		CostInfo: &types.CostInfo{
+			TotalCost:    cost,
+			InputTokens:  in,
+			OutputTokens: out,
+		},
+	}
+}
+
+// TestBudgetMetadata_LatencyBudgetAllowsFastCall is the discriminating case for
+// latency. Before the fix this enforced — not because the call was slow, but
+// because the key was absent — so a passing test had to be one that only a real
+// implementation satisfies.
+func TestBudgetMetadata_LatencyBudgetAllowsFastCall(t *testing.T) {
+	hook, err := NewGuardrailHook("latency_budget", map[string]any{
+		"max_ms":    1000.0,
+		"direction": "output",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{Messages: []types.Message{{Role: "user", Content: "hi"}}}
+	resp := &hooks.ProviderResponse{
+		Message:   types.Message{Role: "assistant", Content: "quick reply"},
+		LatencyMs: 50,
+	}
+
+	d := hook.AfterCall(context.Background(), req, resp)
+
+	assert.True(t, d.Allow,
+		"50ms is far inside a 1000ms budget; a missing latency_ms key made this "+
+			"guardrail block every turn instead")
+}
+
+// TestBudgetMetadata_LatencyBudgetEnforcesSlowCall is the other half: seeding
+// latency must not turn the guardrail into an unconditional allow.
+func TestBudgetMetadata_LatencyBudgetEnforcesSlowCall(t *testing.T) {
+	hook, err := NewGuardrailHook("latency_budget", map[string]any{
+		"max_ms":    100.0,
+		"direction": "output",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{Messages: []types.Message{{Role: "user", Content: "hi"}}}
+	resp := &hooks.ProviderResponse{
+		Message:   types.Message{Role: "assistant", Content: "slow reply"},
+		LatencyMs: 5000,
+	}
+
+	d := hook.AfterCall(context.Background(), req, resp)
+
+	require.False(t, d.Allow, "5000ms blows a 100ms budget")
+	assert.True(t, d.Enforced, "guardrails enforce rather than deny")
+}
+
+// TestBudgetMetadata_CostBudgetEnforcesOverspend pins the fail-open half:
+// without derived spend, cost_budget saw $0 and allowed forever.
+func TestBudgetMetadata_CostBudgetEnforcesOverspend(t *testing.T) {
+	hook, err := NewGuardrailHook("cost_budget", map[string]any{
+		"max_cost_usd": 0.01,
+		"direction":    "output",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "hi"},
+			costMsg("assistant", "expensive", 3.0, 1000, 500),
+			{Role: "user", Content: "again"},
+			costMsg("assistant", "also expensive", 2.0, 900, 400),
+		},
+	}
+	resp := &hooks.ProviderResponse{Message: types.Message{Role: "assistant", Content: "reply"}}
+
+	d := hook.AfterCall(context.Background(), req, resp)
+
+	require.False(t, d.Allow,
+		"$5 of accumulated CostInfo blows a $0.01 budget; without derived spend "+
+			"this guardrail computed $0 and never fired")
+	assert.True(t, d.Enforced)
+}
+
+// TestBudgetMetadata_CostBudgetAllowsUnderBudgetWithThreshold is the half that
+// was impossible before #1711 and is only reachable now that both fixes are in.
+// cost_budget scores a ratio, so being inside budget still scores below 1.0 —
+// it needs min_score to express "within budget is acceptable".
+func TestBudgetMetadata_CostBudgetAllowsUnderBudgetWithThreshold(t *testing.T) {
+	hook, err := NewGuardrailHook("cost_budget", map[string]any{
+		"max_cost_usd": 10.0,
+		"min_score":    0.9, // tolerate spending up to 10% of the budget
+		"direction":    "output",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "hi"},
+			costMsg("assistant", "cheap", 0.02, 100, 50),
+		},
+	}
+	resp := &hooks.ProviderResponse{Message: types.Message{Role: "assistant", Content: "reply"}}
+
+	d := hook.AfterCall(context.Background(), req, resp)
+
+	assert.True(t, d.Allow,
+		"$0.02 of a $10 budget scores 0.998, which clears min_score 0.9")
+}
+
+// TestBudgetMetadata_CostBudgetSeesTokenTotals covers the token thresholds,
+// which are separate params reading separate derived keys.
+func TestBudgetMetadata_CostBudgetSeesTokenTotals(t *testing.T) {
+	hook, err := NewGuardrailHook("cost_budget", map[string]any{
+		"max_total_tokens": 500.0,
+		"direction":        "output",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{
+			costMsg("assistant", "one", 0, 400, 300),
+		},
+	}
+	resp := &hooks.ProviderResponse{Message: types.Message{Role: "assistant", Content: "reply"}}
+
+	d := hook.AfterCall(context.Background(), req, resp)
+
+	require.False(t, d.Allow, "700 total tokens exceeds a 500 cap")
+	assert.True(t, d.Enforced)
+}
+
+// TestBudgetMetadata_CallerMetadataWins keeps the escape hatch: a caller that
+// puts its own session-wide totals on ProviderRequestMetadata must not have them
+// silently replaced by per-request derivation. Arena threading cross-turn spend
+// is the motivating case.
+func TestBudgetMetadata_CallerMetadataWins(t *testing.T) {
+	// min_score is load-bearing for this test, not decoration: cost_budget
+	// scores a ratio, so at the default 1.0 threshold *any* nonzero spend
+	// enforces and the assertion below would hold even if the caller's value
+	// were discarded. With a threshold, "under budget" genuinely allows, so the
+	// test can only pass when the caller's $99 is what gets read.
+	hook, err := NewGuardrailHook("cost_budget", map[string]any{
+		"max_cost_usd": 1.0,
+		"min_score":    0.5,
+		"direction":    "output",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{
+			// Derived spend from CostInfo is trivial and would be under budget.
+			costMsg("assistant", "cheap", 0.01, 10, 10),
+		},
+		// The caller knows the run has already spent far more than this turn.
+		Metadata: map[string]any{"total_cost": 99.0},
+	}
+	resp := &hooks.ProviderResponse{Message: types.Message{Role: "assistant", Content: "reply"}}
+
+	d := hook.AfterCall(context.Background(), req, resp)
+
+	require.False(t, d.Allow,
+		"the caller's $99 must win over $0.01 derived from this turn's messages")
+	assert.True(t, d.Enforced)
+}
+
+// TestBudgetMetadata_InputDirectionSeesSpend covers the BeforeCall path, which
+// needs its own seeding call. A spend guardrail on the input side is the useful
+// case — refusing to send another expensive request is cheaper than judging the
+// reply after paying for it.
+func TestBudgetMetadata_InputDirectionSeesSpend(t *testing.T) {
+	hook, err := NewGuardrailHook("cost_budget", map[string]any{
+		"max_cost_usd": 0.01,
+		"direction":    "input",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{
+		Messages: []types.Message{
+			costMsg("assistant", "expensive earlier turn", 5.0, 1000, 500),
+			// BeforeCall only evaluates when the last message is the user's.
+			{Role: "user", Content: "and another thing"},
+		},
+	}
+
+	d := hook.BeforeCall(context.Background(), req)
+
+	require.False(t, d.Allow,
+		"$5 already spent blows a $0.01 budget before this call is even sent; "+
+			"BeforeCall needs its own seeding, not just AfterCall")
+	assert.True(t, d.Enforced)
+}
+
+// TestBudgetMetadata_InputDirectionHasNoLatency documents the asymmetry: there is
+// no latency before the call, so an input-direction latency guardrail cannot be
+// satisfied and must not be silently treated as passing.
+func TestBudgetMetadata_InputDirectionHasNoLatency(t *testing.T) {
+	hook, err := NewGuardrailHook("latency_budget", map[string]any{
+		"max_ms":    1000.0,
+		"direction": "input",
+	})
+	require.NoError(t, err)
+
+	req := &hooks.ProviderRequest{Messages: []types.Message{{Role: "user", Content: "hi"}}}
+
+	d := hook.BeforeCall(context.Background(), req)
+
+	require.False(t, d.Allow,
+		"no call has happened yet, so there is no latency to judge; failing "+
+			"closed is correct and latency_budget is an output-only guardrail")
+}


### PR DESCRIPTION
## Summary

Closes #1707, the half #1711 left open.

`cost_budget` reads `total_cost`/`input_tokens`/`output_tokens` off `EvalContext.Metadata`; `latency_budget` reads `latency_ms`. Nothing populated those on the guardrail hook path, with opposite consequences:

- **`cost_budget` failed open** — computed zero spend, so a budget guardrail never fired.
- **`latency_budget` failed closed** — a missing key is a hard fail (`boolScore(false)`, score 0), and a guardrail reads score 0 as enforce. **It blocked every turn regardless of actual latency**, before and after #1711, no threshold able to help.

## Neither value needed threading through the pipeline

My original #1707 write-up assumed this needed the pipeline to surface cost and latency. It didn't — both were already in reach of the adapter:

| Key | Source |
|---|---|
| `total_cost`, `input_tokens`, `output_tokens`, `cached_tokens` | per-message `CostInfo`, the same source `sumHistoryCost` totals for the tool loop's own budget check |
| `latency_ms` | `hooks.ProviderResponse.LatencyMs`, handed straight to `AfterCall` |

`evals.SeedBudgetMetadata` derives them, in the same spirit as the `ToolCalls`/`Extras`/`PriorResults` derivation added in #1708.

## Two deliberate choices

**Caller values win.** A host tracking session-wide spend across turns puts its own `total_cost` on the request metadata, and per-request derivation must not quietly replace it. Keys the caller didn't set are still derived.

**The caller's map is never mutated.** Other hooks read that same request metadata; writing derived values into it would leak one guardrail's view downstream, and the adapter holds it across the turn. There's a test for this specifically.

**Latency is seeded only where a call has completed.** `BeforeCall` passes `nil`, not zero — inventing a zero would report every prospective request as instant. `latency_budget` is output-only by nature, and there's a test asserting the input direction fails closed rather than silently passing.

## Interaction worth knowing

`ToolPolicy.MaxCostUSD` already enforces a cost ceiling imperatively inside the tool loop, and remains the hard stop. The eval-handler path is the declarative, pack-configurable alternative. Both can be active at once; this PR doesn't change the policy path.

## Tests

Eight adapter tests through real handlers, plus five `SeedBudgetMetadata` unit tests (100% coverage on the new function). Every derived field is paired: one test proving the handler now sees it, one proving seeding didn't turn the guardrail into an unconditional allow.

One test only became possible because #1711 landed first: `cost_budget` scores a *ratio*, so being inside budget still scores below 1.0 and needs `min_score` to express "within budget is acceptable". `$0.02` of a `$10` budget scoring 0.998 against `min_score: 0.9` is the first case where both halves of #1707 are exercised together.

**Mutation testing caught two of my own tests passing for the wrong reason**, and both are worth naming because the failure mode is the one this whole line of work exists to prevent:

- `CallerMetadataWins` originally passed even with caller precedence removed — cost_budget's ratio score enforces at the default threshold regardless, so the assertion held for a reason unrelated to what it claimed to test. Fixed by adding an explicit `min_score`, which is now commented as load-bearing rather than decorative.
- **Nothing covered the `BeforeCall` seeding path at all.** Deleting that seeding call left the suite green. Fixed by adding a spend-on-input test — which is also the more useful guardrail in practice, since refusing to send an expensive request beats paying for the reply and judging it afterwards.

Final mutation table, all confirmed red then reverted:

| Mutation | Caught by |
|---|---|
| drop `total_cost` accumulation | 1 |
| drop `input_tokens` accumulation | 1 |
| drop `output_tokens` accumulation | 1 |
| drop `latency_ms` seeding | 1 |
| caller metadata no longer overrides | 1 |
| `AfterCall` stops seeding | 3 |
| `BeforeCall` stops seeding | 1 |

## Verification

- `go -C runtime test ./... -count=1` — pass
- `go -C sdk test ./... -count=1` — pass
- `golangci-lint run --new-from-rev=HEAD ./runtime/...` — 0 issues
- `scripts/check-weak-assertions.sh` — clean
- `SeedBudgetMetadata` coverage 100%

## Test plan

- [x] `latency_budget` allows a fast call and enforces a slow one
- [x] `cost_budget` enforces overspend, and allows under-budget when a threshold says so
- [x] Token totals derived and enforced separately from spend
- [x] Caller-supplied metadata wins; unrelated caller keys survive
- [x] Caller's map not mutated
- [x] `BeforeCall` seeds spend; input-direction latency fails closed
- [x] Every new test mutation-verified, including two that initially could not fail
