### PR TITLE
ci(release): drop sdk pkg replace before tagging, and guard the cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,8 +226,15 @@ jobs:
           return 1
         }
         
-        # Check leaf modules (runtime and pkg have no replace directives)
-        # server/a2a and sdk are tagged later in update-tools after go.mod cleanup
+        # runtime is a true leaf. pkg is NOT — it replaces runtime locally and
+        # is tagged straight from this tree with no go.mod cleanup, so pkg tags
+        # ship both that replace and a stale `require runtime v1.3.5`. Consumers
+        # ignore the replace but honor the require, so a pkg-only dependant
+        # resolves an old runtime. Tracked separately; fixing it means giving pkg
+        # the same release-branch treatment sdk and server/a2a get, which
+        # reorders this phase and is not a drive-by change.
+        #
+        # server/a2a and sdk are tagged later in update-tools after go.mod cleanup.
         check_module "runtime" "$VERSION" &
         PID_RUNTIME=$!
 
@@ -317,6 +324,13 @@ jobs:
         # Remove local replace directives
         go mod edit -dropreplace=github.com/AltairaLabs/PromptKit/runtime
 
+        # Same guard as the sdk step below.
+        if grep -q '^replace' go.mod; then
+          echo "::error::server/a2a/go.mod still has replace directives after cleanup:"
+          grep '^replace' go.mod
+          exit 1
+        fi
+
         cd ../..
         echo "✓ Updated server/a2a go.mod to $VERSION"
 
@@ -333,9 +347,24 @@ jobs:
         go mod edit -require="github.com/AltairaLabs/PromptKit/pkg@$VERSION"
         go mod edit -require="github.com/AltairaLabs/PromptKit/server/a2a@$VERSION"
 
-        # Remove local replace directives
+        # Remove local replace directives. All three must go: sdk replaces
+        # runtime, server/a2a AND pkg locally, and a published module carrying a
+        # relative-path replace is at best confusing to read. pkg was missing
+        # here through v1.5.7, so every sdk tag up to that point shipped
+        # `replace github.com/AltairaLabs/PromptKit/pkg => ../pkg`.
         go mod edit -dropreplace=github.com/AltairaLabs/PromptKit/runtime
         go mod edit -dropreplace=github.com/AltairaLabs/PromptKit/server/a2a
+        go mod edit -dropreplace=github.com/AltairaLabs/PromptKit/pkg
+
+        # Fail loudly rather than shipping another tag with a dangling relative
+        # path: this is exactly the class of defect that stayed invisible for
+        # five releases, because Go ignores replace in a dependency module so
+        # nothing downstream ever complained.
+        if grep -q '^replace' go.mod; then
+          echo "::error::sdk/go.mod still has replace directives after cleanup:"
+          grep '^replace' go.mod
+          exit 1
+        fi
 
         cd ..
         echo "✓ Updated sdk go.mod to $VERSION"


### PR DESCRIPTION
## Summary

The sdk cleanup step in `release.yml` dropped the `runtime` and `server/a2a` replace directives but **not `pkg`**, while the tagging step immediately after logged *"replace directives removed"*. So every published sdk tag through v1.5.7 ships:

```
replace github.com/AltairaLabs/PromptKit/pkg => ../pkg
```

a relative path that resolves to nothing outside this repo. It survived five releases because Go ignores `replace` in dependency modules, so no downstream build ever complained.

## What changed

- Added the missing `go mod edit -dropreplace=github.com/AltairaLabs/PromptKit/pkg`.
- Added a `grep '^replace'` guard after **both** cleanup steps (sdk and server/a2a), so the next omission fails the release instead of shipping quietly. This defect class is invisible downstream by construction, so the release job is the only place it can be caught.
- Corrected a comment asserting *"runtime and pkg have no replace directives"*. `pkg` does have one, and that false claim is the likely reason its own cleanup was never written.

## Verification

Replayed both command sequences against real `go.mod` content — a guard is only worth adding if it actually catches the bug it exists for:

| Sequence | Result |
|---|---|
| fixed (all three dropreplace) | zero `replace` lines; requires pinned to the release version; **guard passes** |
| pre-fix (pkg omitted) | `replace .../pkg => ../pkg` remains; **guard fails** |
| server/a2a | zero `replace` lines; guard passes |

`release.yml` parses (`yaml.safe_load`). Diff touches only that file.

Already-published tags are immutable; this takes effect from the next release.

## Deliberately not fixed here — see #1713

Checking this turned up something worse, and consumer-affecting. `pkg` is tagged straight from the main tree with **no `go mod edit` at all**, so published pkg tags carry a stale `require`:

```
pkg/v1.5.7  ->  require github.com/AltairaLabs/PromptKit/runtime v1.3.5
```

Consumers ignore `replace` but **honor `require`**, so anything depending on `pkg` alone resolves runtime v1.3.5 against a pkg compiled for v1.5.7. The local `replace` in `pkg/go.mod` is what hides it: every workspace build resolves runtime from the tree, so that require line is never exercised.

Fixing it means giving `pkg` the release-branch treatment `sdk` and `server/a2a` get, which reorders the libs phase and interacts with the ordering guard there. That needs a dry run and shouldn't ride along with a one-line fix, so it is #1713.

## Test plan

- [x] Fixed sequence leaves no replace directives; requires correctly pinned
- [x] Guard fails on the pre-fix sequence (proves it catches the v1.5.7 defect)
- [x] server/a2a sequence still clean under the new guard
- [x] YAML parses; diff scoped to `release.yml`
- [ ] Next real release confirms the guard passes end to end
- [ ] #1713 — pkg's stale require (separate; reorders the libs phase)
