### PR TITLE
fix(sdk): carry FinishReason through the streaming response

### DIFF
--- a/sdk/examples/hooks/README.md
+++ b/sdk/examples/hooks/README.md
@@ -112,7 +112,7 @@ call.
 Every eval-backed and func-backed guardrail in this example (`Input`,
 `InputFunc`, `Output`, and the pack validator) answers with `hooks.Enforced`
 on a hit: `Send()` succeeds, the turn is replaced with a canned message, and
-it's marked internally with `types.FinishReasonSafety` plus a
+it's marked with `types.FinishReasonSafety` plus a
 `types.ValidationResult` naming the guardrail. The pipeline is **not**
 aborted — downstream stages still run.
 
@@ -153,15 +153,20 @@ func blockedByGuardrail(resp *sdk.Response) (validatorType string, blocked bool)
 }
 ```
 
-**A note on the SDK's public API surface:** the pipeline internally marks a
-blocked turn's message with `FinishReason == types.FinishReasonSafety`, but
-that doesn't reach the caller today — `sdk.Response` has no `FinishReason()`
-accessor, and `Response.Message()` returns a message rebuilt from a narrower
-internal struct that doesn't carry `FinishReason` either. `resp.Validations()`
-is the reliable signal, and only when the firing guardrail's
-`hooks.Enforced(...)` call includes a `"validator_type"` key in its metadata
-— `guardrails.Input`/`Output` always do; a bespoke `InputFunc`/`OutputFunc`
-only does if you add it yourself, same as the `no-ssn` example above.
+**The two signals, and when to use which.** The pipeline marks a blocked turn's
+message with `FinishReason == types.FinishReasonSafety`, and that now reaches
+the caller on both paths — `resp.Message().FinishReason` after `Send()` (#1681)
+and after the terminal `ChunkDone` of `Stream()` (#1715). There is no dedicated
+`Response.FinishReason()` accessor; go through `Message()`. That's the cheapest
+check for *whether* a turn was blocked, and it also surfaces other terminal
+states such as `max_output_tokens` and `refusal`.
+
+`resp.Validations()` is the only signal that names *which* guardrail fired, so
+the helper above stays the right tool when you want to log or branch on the
+specific policy. It is populated only when the firing guardrail's
+`hooks.Enforced(...)` call includes a `"validator_type"` key in its metadata —
+`guardrails.Input`/`Output` always do; a bespoke `InputFunc`/`OutputFunc` only
+does if you add it yourself, same as the `no-ssn` example above.
 
 ## Next Steps
 

--- a/sdk/examples/hooks/main_interactive.go
+++ b/sdk/examples/hooks/main_interactive.go
@@ -123,13 +123,11 @@ func hookDenialReason(err error) (string, bool) {
 // resp.Validations() for a failed entry, not by comparing resp.Text() against
 // known blocked-message strings.
 //
-// This is the most reliable detection the public SDK offers today. The
-// pipeline internally marks a blocked turn's *types.Message with
-// FinishReason == types.FinishReasonSafety, but that doesn't reach the
-// caller: sdk.Response has no FinishReason accessor, and Response.Message()
-// returns a message rebuilt from the pipeline's narrow Response struct, which
-// doesn't carry FinishReason either — so it's always empty here, blocked or
-// not. See README.md for more on this gap.
+// A blocked turn is also visible through resp.Message().FinishReason, which
+// the pipeline sets to types.FinishReasonSafety — on both the Send() and the
+// Stream() path (#1681, #1715). Use that when all you need is "was this turn
+// blocked?". Validations() is the complementary signal, and the only one that
+// names WHICH guardrail fired, which is what this helper returns.
 //
 // A caveat on Validations(): it's only populated when the firing guardrail's
 // Decision.Metadata carries a "validator_type" key. guardrails.Input/Output

--- a/sdk/guardrail_e2e_test.go
+++ b/sdk/guardrail_e2e_test.go
@@ -75,6 +75,76 @@ func TestGuardrail_NormalTurnIsNotMarkedBlocked(t *testing.T) {
 	assert.NotEmpty(t, resp.Text(), "a clean turn must carry the provider's reply")
 }
 
+// collectStreamDone drains a Stream channel and returns the Response carried by
+// the terminal ChunkDone, failing the test if the stream errored or never
+// finished.
+func collectStreamDone(t *testing.T, ch <-chan StreamChunk) *Response {
+	t.Helper()
+
+	var done *Response
+	for chunk := range ch {
+		require.NoError(t, chunk.Error, "the stream must not error")
+		if chunk.Type == ChunkDone {
+			done = chunk.Message
+		}
+	}
+	require.NotNil(t, done, "the stream must terminate with a ChunkDone carrying a Response")
+	return done
+}
+
+// TestGuardrail_InputBlockIsVisibleToStreamCaller mirrors
+// TestGuardrail_InputBlockIsVisibleToCaller on the streaming path. Send and
+// Stream are different code paths — executePipeline/buildResponse versus
+// executeStreamingPipeline/buildStreamingResponse — and only the latter dropped
+// FinishReason, so a guardrail-blocked turn was invisible to a streaming caller
+// short of matching the canned text (#1715).
+func TestGuardrail_InputBlockIsVisibleToStreamCaller(t *testing.T) {
+	conv, err := Open(guardrailTestPack, "chat",
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithSkipSchemaValidation(),
+		WithGuardrail(
+			guardrails.Input("banned_words", map[string]any{
+				"words": []any{"wire transfer"},
+			}, guardrails.WithMessage("I can't help with transfers.")),
+		),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	resp := collectStreamDone(t, conv.Stream(context.Background(), "please arrange a wire transfer"))
+
+	assert.Equal(t, "I can't help with transfers.", resp.Text(),
+		"the canned message must reach the streaming caller")
+	require.NotNil(t, resp.Message())
+	assert.Equal(t, types.FinishReasonSafety, resp.Message().FinishReason,
+		"a blocked streaming turn must be detectable via FinishReason, not by matching text")
+}
+
+// TestGuardrail_StreamNormalTurnIsNotMarkedBlocked is the discriminating half of
+// the test above: a clean streaming turn must NOT report the safety finish
+// reason. Without it, a fix that hardcoded types.FinishReasonSafety in
+// buildStreamingResponse would pass.
+func TestGuardrail_StreamNormalTurnIsNotMarkedBlocked(t *testing.T) {
+	conv, err := Open(guardrailTestPack, "chat",
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithSkipSchemaValidation(),
+		WithGuardrail(
+			guardrails.Input("banned_words", map[string]any{
+				"words": []any{"wire transfer"},
+			}),
+		),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	resp := collectStreamDone(t, conv.Stream(context.Background(), "what is the capital of France?"))
+
+	require.NotNil(t, resp.Message())
+	assert.NotEqual(t, types.FinishReasonSafety, resp.Message().FinishReason,
+		"a clean streaming turn must not be reported as safety-blocked")
+	assert.NotEmpty(t, resp.Text(), "a clean streaming turn must carry the provider's reply")
+}
+
 // TestGuardrail_InputBlockRecordsValidation pins the other observable signal —
 // the ValidationResult naming the guardrail that fired — so an application can
 // report *which* policy blocked the turn, not merely that one did.

--- a/sdk/streaming.go
+++ b/sdk/streaming.go
@@ -90,6 +90,17 @@ func (s *streamState) accumulatedContent() string {
 	return s.contentBuilder.String()
 }
 
+// finishReason recovers the assistant FinishReason from the captured final
+// result, or "" when no result was captured. The streamed chunks and the
+// pipeline's Response type both drop the field; ExecutionResult.Messages keeps
+// it.
+func (s *streamState) finishReason() string {
+	if s.finalResult == nil {
+		return ""
+	}
+	return lastAssistantFinishReason(s.finalResult.Messages)
+}
+
 // Stream sends a message and returns a channel of response chunks.
 //
 // Use this for real-time streaming of LLM responses:
@@ -449,6 +460,13 @@ func (c *Conversation) buildStreamingResponse(
 			resp.toolCalls = state.lastToolCalls
 		}
 	}
+
+	// Neither the streamed chunks nor the pipeline's narrower Response type
+	// carry FinishReason, so recover it from the final result exactly as
+	// buildResponse does for Send. Without this a streaming caller cannot
+	// distinguish a guardrail-blocked turn (marked types.FinishReasonSafety)
+	// from a real model reply, nor see max_output_tokens or refusal (#1715).
+	resp.message.FinishReason = state.finishReason()
 
 	// Populate pending client tools from stream state
 	if len(state.pendingTools) > 0 {


### PR DESCRIPTION
## Problem

`#1681` restored `Response.Message().FinishReason` on the `Send()` path only. `buildStreamingResponse` (`sdk/streaming.go`) rebuilds the assistant message from the pipeline's narrower `Response` struct and never set `FinishReason` — on either the `result != nil` branch or the accumulated-content fallback. A guardrail-blocked turn was therefore detectable through `Send()` but invisible through `Stream()`, short of string-matching the canned block message.

`Send()` and `Stream()` are genuinely different code paths (`executePipeline`/`buildResponse` vs `executeStreamingPipeline`/`buildStreamingResponse`), which is why the existing `Send()` regression test did not cover this.

## Fix

`buildStreamingResponse` now recovers the field from the captured `ExecutionResult` via a small `streamState.finishReason()` helper that reuses the existing `lastAssistantFinishReason(result.Messages)` — the same recovery `buildResponse` performs. It is applied after both branches, so the accumulated-content fallback gets it too. No exported API change.

## Docs

The rationale above `blockedByGuardrail` in `sdk/examples/hooks/main_interactive.go` and the matching README section both claimed `sdk.Response` surfaces no `FinishReason` and that `Response.Message()` never carries it "blocked or not". That has been false for `Send()` since #1681 and is false for `Stream()` as of this PR. Rewritten to describe the two complementary signals accurately: `Message().FinishReason` answers *whether* a turn was blocked (and also surfaces `max_output_tokens`/`refusal`); `Validations()` remains the only signal that names *which* guardrail fired, so the helper stays.

## Tests

`sdk/guardrail_e2e_test.go` gains a `Stream()` mirror of `TestGuardrail_InputBlockIsVisibleToCaller` plus its discriminating half:

- `TestGuardrail_InputBlockIsVisibleToStreamCaller` — an enforcing input guardrail's blocked turn reports `types.FinishReasonSafety` on the terminal `ChunkDone`. Verified to fail on `main`'s behavior (`expected: "safety", actual: ""`).
- `TestGuardrail_StreamNormalTurnIsNotMarkedBlocked` — a clean streaming turn must NOT report `safety`. Verified to fail against a mutant that hardcodes `types.FinishReasonSafety` in `buildStreamingResponse`.

Full `go -C sdk test ./... -count=1` passes; no new lint findings in the touched lines.

Closes #1715
