### PR TITLE
fix(hooks): log an enforced provider decision at INFO, not as a denial

### DIFF
--- a/docs/src/content/docs/runtime/reference/hooks.md
+++ b/docs/src/content/docs/runtime/reference/hooks.md
@@ -541,7 +541,7 @@ IsEmpty returns true if no hooks are registered.
 func (r *Registry) RunAfterProviderCall(ctx context.Context, req *ProviderRequest, resp *ProviderResponse) Decision
 ```
 
-RunAfterProviderCall executes all provider hooks' AfterCall in order. First deny wins and short\-circuits.
+RunAfterProviderCall executes all provider hooks' AfterCall in order. The first non\-Allow decision wins and short\-circuits.
 
 <a name="Registry.RunAfterToolExecution"></a>
 ### func \(\*Registry\) RunAfterToolExecution
@@ -559,7 +559,7 @@ RunAfterToolExecution executes all tool hooks' AfterExecution in order. First de
 func (r *Registry) RunBeforeProviderCall(ctx context.Context, req *ProviderRequest) Decision
 ```
 
-RunBeforeProviderCall executes all provider hooks' BeforeCall in order. First deny wins and short\-circuits.
+RunBeforeProviderCall executes all provider hooks' BeforeCall in order. The first non\-Allow decision wins and short\-circuits.
 
 <details><summary>Example</summary>
 <p>

--- a/runtime/hooks/registry.go
+++ b/runtime/hooks/registry.go
@@ -63,16 +63,38 @@ func (r *Registry) IsEmpty() bool {
 
 // --- Provider hooks ---
 
+// Log messages for a non-Allow provider hook decision. Enforced and Deny are
+// different outcomes and must not read alike: Enforced is a guardrail doing its
+// job — the provider call is skipped (before-call) or the response is replaced
+// (after-call), the round loop stops, and the pipeline continues. Deny aborts
+// the pipeline with a HookDeniedError.
+const (
+	msgEnforcedBeforeCall = "provider hook enforced before-call: provider call skipped, canned turn substituted"
+	msgDeniedBeforeCall   = "provider hook denied before-call"
+	msgEnforcedAfterCall  = "provider hook enforced after-call: response replaced, pipeline continues"
+	msgDeniedAfterCall    = "provider hook denied after-call"
+)
+
+// logProviderHookDecision logs a non-Allow provider hook decision at the level
+// its outcome warrants. A graceful enforcement is routine policy work, so it
+// logs at INFO; only a genuine denial — which aborts the pipeline — is a WARN.
+func logProviderHookDecision(h ProviderHook, d Decision, enforcedMsg, deniedMsg string) {
+	if d.Enforced {
+		logger.Info(enforcedMsg, "hook", fmt.Sprintf("%T", h), "reason", d.Reason)
+		return
+	}
+	logger.Warn(deniedMsg, "hook", fmt.Sprintf("%T", h), "reason", d.Reason)
+}
+
 // RunBeforeProviderCall executes all provider hooks' BeforeCall in order.
-// First deny wins and short-circuits.
+// The first non-Allow decision wins and short-circuits.
 func (r *Registry) RunBeforeProviderCall(ctx context.Context, req *ProviderRequest) Decision {
 	if r == nil {
 		return Allow
 	}
 	for _, h := range r.providerHooks {
 		if d := h.BeforeCall(ctx, req); !d.Allow {
-			logger.Warn("provider hook denied before-call",
-				"hook", fmt.Sprintf("%T", h), "reason", d.Reason)
+			logProviderHookDecision(h, d, msgEnforcedBeforeCall, msgDeniedBeforeCall)
 			return d
 		}
 	}
@@ -80,15 +102,14 @@ func (r *Registry) RunBeforeProviderCall(ctx context.Context, req *ProviderReque
 }
 
 // RunAfterProviderCall executes all provider hooks' AfterCall in order.
-// First deny wins and short-circuits.
+// The first non-Allow decision wins and short-circuits.
 func (r *Registry) RunAfterProviderCall(ctx context.Context, req *ProviderRequest, resp *ProviderResponse) Decision {
 	if r == nil {
 		return Allow
 	}
 	for _, h := range r.providerHooks {
 		if d := h.AfterCall(ctx, req, resp); !d.Allow {
-			logger.Warn("provider hook denied after-call",
-				"hook", fmt.Sprintf("%T", h), "reason", d.Reason)
+			logProviderHookDecision(h, d, msgEnforcedAfterCall, msgDeniedAfterCall)
 			return d
 		}
 	}

--- a/runtime/hooks/registry_test.go
+++ b/runtime/hooks/registry_test.go
@@ -1,10 +1,14 @@
 package hooks
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 
+	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 )
 
@@ -252,6 +256,131 @@ type countingProviderHook struct {
 func (h *countingProviderHook) AfterCall(ctx context.Context, req *ProviderRequest, resp *ProviderResponse) Decision {
 	*h.count++
 	return h.providerHookOnly.AfterCall(ctx, req, resp)
+}
+
+// --- decision logging ---
+
+// captureHookLogs redirects the package logger into a buffer for the duration
+// of fn and returns everything written. Debug level so nothing under WARN is
+// filtered out before the assertions can see it.
+func captureHookLogs(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	logger.SetLogger(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { logger.SetLogger(nil) })
+	fn()
+	return buf.String()
+}
+
+// TestProviderHooks_EnforcedLogsInfoNotDenial pins issue #1720: an Enforced
+// decision is a guardrail doing exactly its job on a blocked turn, so it must
+// not be reported at WARN, and it must not be worded as a denial. The provider
+// call is skipped and a canned turn substituted (before-call) or the response
+// replaced (after-call) — the pipeline continues either way.
+func TestProviderHooks_EnforcedLogsInfoNotDenial(t *testing.T) {
+	const reason = "forbidden content found"
+	tests := []struct {
+		name     string
+		hook     *providerHookOnly
+		run      func(*Registry) Decision
+		wantText string
+	}{
+		{
+			name: "before-call",
+			hook: &providerHookOnly{name: "guard", before: Enforced(reason, nil), after: Allow},
+			run: func(r *Registry) Decision {
+				return r.RunBeforeProviderCall(context.Background(), &ProviderRequest{})
+			},
+			wantText: "provider call skipped, canned turn substituted",
+		},
+		{
+			name: "after-call",
+			hook: &providerHookOnly{name: "guard", before: Allow, after: Enforced(reason, nil)},
+			run: func(r *Registry) Decision {
+				return r.RunAfterProviderCall(context.Background(), &ProviderRequest{}, &ProviderResponse{})
+			},
+			wantText: "response replaced, pipeline continues",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var d Decision
+			out := captureHookLogs(t, func() { d = tc.run(NewRegistry(WithProviderHook(tc.hook))) })
+
+			if !d.Enforced {
+				t.Fatalf("decision must stay Enforced, got %+v", d)
+			}
+			if !strings.Contains(out, reason) {
+				t.Fatalf("enforced decision logged nothing about %q; output: %q", reason, out)
+			}
+			if strings.Contains(out, "level=WARN") {
+				t.Errorf("enforced decision logged at WARN; output: %q", out)
+			}
+			if !strings.Contains(out, "level=INFO") {
+				t.Errorf("enforced decision should log at INFO; output: %q", out)
+			}
+			if strings.Contains(out, "denied") {
+				t.Errorf("enforced decision must not be worded as a denial; output: %q", out)
+			}
+			if !strings.Contains(out, tc.wantText) {
+				t.Errorf("log should say %q; output: %q", tc.wantText, out)
+			}
+		})
+	}
+}
+
+// TestProviderHooks_DenyLogsWarn is the other half of #1720: a genuine Deny
+// aborts the pipeline with a HookDeniedError, so it keeps WARN and the
+// "denied" wording. Without this, downgrading everything to INFO would pass.
+func TestProviderHooks_DenyLogsWarn(t *testing.T) {
+	const reason = "policy violation"
+	tests := []struct {
+		name    string
+		hook    *providerHookOnly
+		run     func(*Registry) Decision
+		wantMsg string
+	}{
+		{
+			name: "before-call",
+			hook: &providerHookOnly{name: "denier", before: Deny(reason), after: Allow},
+			run: func(r *Registry) Decision {
+				return r.RunBeforeProviderCall(context.Background(), &ProviderRequest{})
+			},
+			wantMsg: "provider hook denied before-call",
+		},
+		{
+			name: "after-call",
+			hook: &providerHookOnly{name: "denier", before: Allow, after: Deny(reason)},
+			run: func(r *Registry) Decision {
+				return r.RunAfterProviderCall(context.Background(), &ProviderRequest{}, &ProviderResponse{})
+			},
+			wantMsg: "provider hook denied after-call",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var d Decision
+			out := captureHookLogs(t, func() { d = tc.run(NewRegistry(WithProviderHook(tc.hook))) })
+
+			if d.Allow || d.Enforced {
+				t.Fatalf("decision must be a hard deny, got %+v", d)
+			}
+			if !strings.Contains(out, tc.wantMsg) {
+				t.Errorf("deny should log %q; output: %q", tc.wantMsg, out)
+			}
+			if !strings.Contains(out, "level=WARN") {
+				t.Errorf("deny should log at WARN; output: %q", out)
+			}
+			if strings.Contains(out, "level=INFO") {
+				t.Errorf("deny must not be downgraded to INFO; output: %q", out)
+			}
+			if !strings.Contains(out, reason) {
+				t.Errorf("deny log should carry the reason %q; output: %q", reason, out)
+			}
+		})
+	}
 }
 
 // --- chunk interceptor ---


### PR DESCRIPTION
## Problem

`RunBeforeProviderCall` / `RunAfterProviderCall` logged the same line for every non-`Allow` decision:

```
level=WARN msg="provider hook denied before-call" hook=*guardrails.GuardrailHookAdapter reason="forbidden content found: ..."
```

But `hooks.Enforced(...)` sets `Allow=false` too, so a graceful guardrail block — the normal, intended operation of the pre/post-call guardrail seam — was reported as a *denial* at WARN on every blocked turn. Wrong wording and wrong level: routine policy enforcement looked like a fault in logs and dashboards.

The two outcomes are genuinely different:
- **`Deny`** aborts the pipeline with a `HookDeniedError`.
- **`Enforced`** skips the provider call and substitutes a canned assistant turn (before-call), or picks up the hook-rewritten response and drops its tool calls (after-call). The round loop stops; **the pipeline continues** and every downstream stage still runs.

## Change

Both chains now branch on `Decision.Enforced` via a shared `logProviderHookDecision` helper:

| Decision | Level | Message |
|---|---|---|
| `Enforced` (before-call) | INFO | `provider hook enforced before-call: provider call skipped, canned turn substituted` |
| `Enforced` (after-call) | INFO | `provider hook enforced after-call: response replaced, pipeline continues` |
| `Deny` (either) | WARN | `provider hook denied before-call` / `... after-call` (unchanged) |

Wording follows `stages_provider.go`'s `runBeforeCallHooks` / `runAfterCallHooks` (`blockedMessage`, `applyEnforcedResponse`) and `PRE_LLM_GUARDRAILS_DESIGN.md` §4.1.1 — nothing implies the turn or pipeline is aborted.

No behavior change beyond logging: the decision returned to the stage is untouched.

## Tests

`TestProviderHooks_EnforcedLogsInfoNotDenial` and `TestProviderHooks_DenyLogsWarn` capture the package logger into a buffer via a `slog` text handler and assert level + wording for both the before-call and after-call chains.

Each assertion was mutation-checked against the implementation:

- `logger.Info` → `logger.Warn` for the enforced branch: the "logged at WARN" and "should log at INFO" assertions fail.
- enforced branch reusing the denial wording: the "must not be worded as a denial" and "log should say ..." assertions fail.
- `Deny` downgraded to INFO: both `TestProviderHooks_DenyLogsWarn` subtests fail.

`go -C runtime test ./hooks/... ./pipeline/... -count=1 -race` passes; changed-file coverage on `runtime/hooks/registry.go` is 96.2%.

`docs/src/content/docs/runtime/reference/hooks.md` is regenerated (`make docs-reference`) for the two touched doc comments.

Closes #1720
