### PR TITLE
fix(guardrails): dereference the score in ValidationResult.Details and share the firing stamp

### DIFF
--- a/runtime/pipeline/stage/guardrail_validation_details_test.go
+++ b/runtime/pipeline/stage/guardrail_validation_details_test.go
@@ -1,0 +1,158 @@
+package stage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/guardrails"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+)
+
+// enforcingChunkInterceptor fires once from OnChunk with a caller-owned
+// metadata map, so a test can mutate that map after the run and observe
+// whether the recorded validation aliased it.
+type enforcingChunkInterceptor struct {
+	meta  map[string]any
+	fired bool
+}
+
+func (h *enforcingChunkInterceptor) Name() string { return "enforcing_chunk_test" }
+
+func (h *enforcingChunkInterceptor) BeforeCall(
+	_ context.Context, _ *hooks.ProviderRequest,
+) hooks.Decision {
+	return hooks.Allow
+}
+
+func (h *enforcingChunkInterceptor) AfterCall(
+	_ context.Context, _ *hooks.ProviderRequest, _ *hooks.ProviderResponse,
+) hooks.Decision {
+	return hooks.Allow
+}
+
+func (h *enforcingChunkInterceptor) OnChunk(
+	_ context.Context, _ *providers.StreamChunk,
+) hooks.Decision {
+	if h.fired {
+		return hooks.Allow
+	}
+	h.fired = true
+	// Enforced rather than Deny: the stage stops reading the stream but returns
+	// the message normally, so the stamped validation is observable.
+	return hooks.Enforced("streaming guardrail fired", h.meta)
+}
+
+// TestChunkInterceptorFiring_StampedLikeEveryOtherFiring pins that a streaming
+// chunk-interceptor firing is recorded through the same builder as a
+// before/after-call firing.
+//
+// The chunk path used to hand-roll its types.ValidationResult. Each assertion
+// below catches one concrete way that hand-rolled struct differed:
+//
+//   - Details["direction"] — the hand-rolled stamp never set it, so an assertion
+//     could not tell a streaming firing from an input one.
+//   - Timestamp — the hand-rolled stamp left it at the zero value.
+//   - Details["score"] — copied verbatim it is the adapter's *float64, so
+//     Details["score"].(float64) yielded 0, false for every consumer of
+//     sdk.Response.Validations().
+//   - the post-run mutation — the hand-rolled stamp aliased d.Metadata, so a
+//     hook holding its own map could rewrite an already-recorded validation.
+func TestChunkInterceptorFiring_StampedLikeEveryOtherFiring(t *testing.T) {
+	score := 0.75
+	meta := map[string]any{
+		"validator_type": "streaming_guard",
+		"score":          &score,
+	}
+	interceptor := &enforcingChunkInterceptor{meta: meta}
+
+	stage := NewProviderStageWithHooks(
+		mock.NewProvider("p", "m", false), nil, nil,
+		&ProviderConfig{MaxTokens: 100}, nil,
+		hooks.NewRegistry(hooks.WithProviderHook(interceptor)),
+	)
+
+	elems, err := runProviderStage(t, stage, "tell me a long story")
+	require.NoError(t, err, "an enforced chunk decision stops the stream, it does not fail the turn")
+	require.True(t, interceptor.fired, "the interceptor must have fired for this test to mean anything")
+
+	msgs := assistantMessages(elems)
+	require.Len(t, msgs, 1)
+	require.Len(t, msgs[0].Validations, 1, "the streaming firing must be stamped on the message")
+	v := msgs[0].Validations[0]
+
+	assert.Equal(t, "streaming_guard", v.ValidatorType)
+	assert.False(t, v.Passed)
+	assert.Equal(t, "output", v.Details["direction"],
+		"a streaming firing is an output firing; the hand-rolled stamp omitted direction entirely")
+	assert.False(t, v.Timestamp.IsZero(),
+		"the hand-rolled stamp left Timestamp at the zero value")
+
+	// The hook still owns meta. Mutating it must not reach the recorded
+	// validation — the builder copies precisely to prevent that. Checked before
+	// the score assertion so a score regression cannot mask an aliasing one.
+	meta["validator_type"] = "tampered"
+	meta["injected"] = true
+	assert.Equal(t, "streaming_guard", v.Details["validator_type"],
+		"the stamp must copy the decision metadata, not alias it")
+	assert.NotContains(t, v.Details, "injected",
+		"a key added to the hook's map after the fact must not appear in a recorded validation")
+
+	got, ok := v.Details["score"].(float64)
+	require.True(t, ok, "Details is public API; score must be a plain float64, not the adapter's *float64")
+	assert.InDelta(t, 0.75, got, 1e-9)
+}
+
+// TestGuardrailFiring_DetailsScoreIsAPlainFloat64 pins the score shape in
+// ValidationResult.Details through the REAL guardrail adapter.
+//
+// This must drive the real adapter rather than a test hook: the adapter stores
+// evals.EvalResult.Score, which is a *float64, and a test hook putting a plain
+// float64 in decision metadata could not reproduce the pointer that leaked into
+// Details (rendered as `score:0x40adf566cc0` in a live Response.Validations()).
+// metadataScore already fixed this for the event payload; the mutation this
+// assertion catches is leaving Details untouched, where a consumer doing
+// Details["score"].(float64) gets 0, false.
+func TestGuardrailFiring_DetailsScoreIsAPlainFloat64(t *testing.T) {
+	// max_characters far below the mock's reply length, so the guardrail fires
+	// with a fractional score rather than a pass.
+	guard, err := guardrails.NewGuardrailHook("length", map[string]any{
+		"max_characters": 5,
+	})
+	require.NoError(t, err)
+
+	elems, getEvents := runStageCollectingValidations(t,
+		mock.NewProvider("p", "m", false),
+		hooks.NewRegistry(hooks.WithProviderHook(guard)),
+		"hello",
+	)
+
+	msgs := assistantMessages(elems)
+	require.Len(t, msgs, 1)
+	require.NotEmpty(t, msgs[0].Validations, "the guardrail firing must be stamped on the message")
+
+	// This configuration fires on both recording paths — the chunk interceptor
+	// mid-stream and the AfterCall check on the assembled message — so every
+	// entry is checked rather than only the first.
+	for i, v := range msgs[0].Validations {
+		score, ok := v.Details["score"].(float64)
+		require.Truef(t, ok,
+			"validation %d: Details[\"score\"] must type-assert to float64; "+
+				"the adapter's *float64 must be dereferenced on copy (got %T)", i, v.Details["score"])
+		assert.Greaterf(t, score, 0.0,
+			"validation %d: the dereferenced score must be the eval's real score, not a zero placeholder", i)
+		assert.LessOrEqualf(t, score, 1.0, "validation %d: score is a 0..1 ratio", i)
+	}
+
+	// The event payload already carried the dereferenced score. It must still
+	// agree with Details, so the two observability surfaces cannot drift.
+	got := getEvents()
+	require.NotEmpty(t, got)
+	assert.InDelta(t, got[0].Score, msgs[0].Validations[0].Details["score"], 1e-9,
+		"the event score and the Details score describe the same firing")
+}

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -1435,12 +1435,13 @@ func (s *ProviderStage) processStreamChunks(
 				// Without this, streaming-only guardrails produce no
 				// observable Validations entry and the guardrail_triggered
 				// assertion would silently miss them.
-				if vType, _ := d.Metadata["validator_type"].(string); vType != "" {
-					pendingValidations = append(pendingValidations, types.ValidationResult{
-						ValidatorType: vType,
-						Passed:        false,
-						Details:       d.Metadata,
-					})
+				//
+				// The stamp goes through the same builder recordGuardrailFiring
+				// uses so a streaming firing carries direction and a timestamp
+				// like every other firing, and copies the decision metadata
+				// rather than aliasing it.
+				if v, ok := guardrailValidation(d, hooks.DirectionOutput); ok {
+					pendingValidations = append(pendingValidations, v)
 				}
 				if d.Enforced {
 					// Hook enforced (e.g., truncated content) — use the
@@ -1916,18 +1917,10 @@ func (s *ProviderStage) recordGuardrailFiring(
 ) {
 	vType, _ := d.Metadata["validator_type"].(string)
 
-	if msg != nil && vType != "" {
-		details := make(map[string]any, len(d.Metadata)+1)
-		for k, v := range d.Metadata {
-			details[k] = v
+	if msg != nil {
+		if v, ok := guardrailValidation(d, direction); ok {
+			msg.Validations = append(msg.Validations, v)
 		}
-		details["direction"] = direction
-		msg.Validations = append(msg.Validations, types.ValidationResult{
-			ValidatorType: vType,
-			Passed:        false,
-			Details:       details,
-			Timestamp:     timeNow(),
-		})
 	}
 
 	if s.emitter == nil {
@@ -1945,6 +1938,49 @@ func (s *ProviderStage) recordGuardrailFiring(
 		data.Violations = []string{d.Reason}
 	}
 	s.emitter.GuardrailResult(data)
+}
+
+// guardrailValidation builds the ValidationResult recorded for a guardrail
+// firing. Every path that records a firing goes through here — the before/after
+// call phases via recordGuardrailFiring, and the streaming chunk interceptor,
+// which cannot use recordGuardrailFiring for the stamp because no message
+// exists yet at that point. Sharing the construction is what keeps a streaming
+// firing shaped like every other one: same direction tag, same timestamp, same
+// copied details map (§4.5 observability parity).
+//
+// ok is false when the decision carries no validator_type — there is no
+// validation to record without a validator identity.
+//
+// The details map is copied, never aliased: a hook that holds a reference to
+// the metadata map it returned must not be able to mutate an already-recorded
+// validation afterwards (mirrors blockedMessage and applyEnforcedResponse).
+func guardrailValidation(d hooks.Decision, direction string) (types.ValidationResult, bool) {
+	vType, _ := d.Metadata["validator_type"].(string)
+	if vType == "" {
+		return types.ValidationResult{}, false
+	}
+
+	details := make(map[string]any, len(d.Metadata)+1)
+	for k, v := range d.Metadata {
+		details[k] = v
+	}
+	// Details is public API via sdk.Response.Validations(), and the guardrail
+	// adapter stores evals.EvalResult.Score — a *float64. Copied verbatim, a
+	// consumer doing Details["score"].(float64) gets 0, false, and the map
+	// renders as an address. Dereference to the same plain float64 the event
+	// payload already carries via metadataScore. Any other shape (a
+	// hand-written hook's own type) is left untouched.
+	if _, isPtr := details["score"].(*float64); isPtr {
+		details["score"] = metadataScore(d.Metadata)
+	}
+	details["direction"] = direction
+
+	return types.ValidationResult{
+		ValidatorType: vType,
+		Passed:        false,
+		Details:       details,
+		Timestamp:     timeNow(),
+	}, true
 }
 
 // metadataScore extracts a guardrail's eval score from decision metadata.


### PR DESCRIPTION
Closes #1719

Two inconsistencies in `types.ValidationResult`, both residue of a fix applied to one path and not its sibling.

## 1. `Details["score"]` was a raw `*float64`

`recordGuardrailFiring` copied `Decision.Metadata` verbatim into `Details`. The guardrail adapter stores `evals.EvalResult.Score`, a `*float64`, so a live `Response.Validations()` payload rendered `score:0x40adf566cc0` and a consumer doing `Details["score"].(float64)` got `0, false`. `Details` is public API via `sdk.Response.Validations()`.

This is exactly what `metadataScore` was added to fix — but that fix only reached the **event payload**. The copy now dereferences, accepting both `*float64` and `float64` shapes as `metadataScore` already does. Any other type a hand-written hook puts there is left untouched. **Event payload behavior is unchanged.**

## 2. The chunk interceptor hand-rolled its stamp

`processStreamChunks` built its own `types.ValidationResult` inline. Versus the shared helper it omitted `Details["direction"]`, omitted `Timestamp`, and **aliased** `d.Metadata` instead of copying it — so a hook holding a reference to the metadata map it returned could mutate an already-recorded validation after the fact.

The stamping half of `recordGuardrailFiring` is factored into `guardrailValidation(d, direction)`, used by both callers, so a streaming firing is shaped like every other guardrail firing (design §4.5, observability parity). The chunk path keeps its existing `recordGuardrailFiring(nil, d, ...)` call for the event half — no message exists at that point.

## Tests

New `runtime/pipeline/stage/guardrail_validation_details_test.go`. Every assertion was verified against the pre-fix code; each one fails on the mutation it is written to catch:

**`TestChunkInterceptorFiring_StampedLikeEveryOtherFiring`** — an enforcing chunk interceptor holding its own metadata map. Reverting to the hand-rolled stamp fails all five:
- `Details["direction"] == "output"` → catches the dropped direction tag
- `!Timestamp.IsZero()` → catches the zero-value timestamp
- `Details["validator_type"]` unchanged, and `injected` absent, after the test mutates the hook's map post-run → catches the alias
- `Details["score"].(float64) == 0.75` → catches the pointer

**`TestGuardrailFiring_DetailsScoreIsAPlainFloat64`** — drives the **real** `guardrails.NewGuardrailHook("length", …)` adapter, because a test hook putting a plain `float64` in metadata cannot reproduce a pointer-type defect. This configuration fires on both recording paths (chunk interceptor mid-stream and `AfterCall` on the assembled message), so every entry in `Validations` is checked, not only the first. Also pins that the event score and the `Details` score agree, so the two observability surfaces cannot drift. Removing the dereference fails it with `got *float64`.

`go -C runtime test ./... -count=1` green; `./pipeline/... ./hooks/...` green under `-race`. No new lint findings on the changed lines.
