### PR TITLE
fix(guardrails): let a custom eval registry back a guardrail

### DIFF
--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -3300,6 +3300,8 @@ conv, _ := sdk.Open("./chat.pack.json", "assistant",
 
 Construction errors \(unknown eval type, invalid params\) are returned from Open rather than at the call site. For a hook implementing the full hooks.ProviderHook interface, use WithProviderHook.
 
+An eval\-backed guardrail resolves its type against the registry supplied by WithEvalRegistry, if any. Resolution happens after every option has been applied, so the two options may be passed in either order.
+
 <a name="WithImagePreprocessing"></a>
 ### func WithImagePreprocessing
 

--- a/runtime/hooks/guardrails/custom_registry_test.go
+++ b/runtime/hooks/guardrails/custom_registry_test.go
@@ -1,0 +1,172 @@
+package guardrails
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// Coverage for https://github.com/AltairaLabs/PromptKit/issues/1717: a handler
+// that exists only in a caller-supplied registry must be usable as a guardrail
+// through both entry points. Every case asserts the built hook *enforces*, not
+// merely that construction returned no error — the failure mode being fixed is
+// a guardrail that quietly is not there.
+
+// customOnlyType is registered nowhere by default, so any test that gets a
+// working hook for it proves the caller's registry was consulted.
+const customOnlyType = "custom_registry_only_1717"
+
+// registryWithCustomType returns a default registry plus a handler that always
+// scores 0.0 — below the guardrail's implicit 1.0 threshold, so it enforces.
+func registryWithCustomType() *evals.EvalTypeRegistry {
+	r := evals.NewEvalTypeRegistry()
+	r.Register(&stubHandler{
+		typeName: customOnlyType,
+		result:   &evals.EvalResult{Score: floatPtr(0.0), Explanation: "custom handler fired"},
+	})
+	return r
+}
+
+// enforcesOnOutput runs the hook's AfterCall over a canned response and reports
+// whether the guardrail acted. Enforcement (not Allow) is the observable that a
+// dropped guardrail cannot produce.
+func enforcesOnOutput(t *testing.T, h hooks.ProviderHook) bool {
+	t.Helper()
+	resp := &hooks.ProviderResponse{
+		Message: types.Message{Role: "assistant", Content: "some assistant output"},
+	}
+	d := h.AfterCall(context.Background(), &hooks.ProviderRequest{}, resp)
+	return !d.Allow
+}
+
+func TestCompileValidatorsWithRegistry_ResolvesCustomType(t *testing.T) {
+	enabled := true
+	built, err := CompileValidatorsWithRegistry([]prompt.ValidatorConfig{
+		{Type: customOnlyType, Enabled: &enabled, Params: map[string]any{}},
+	}, registryWithCustomType())
+
+	require.NoError(t, err, "a custom type in the supplied registry is not an unknown type")
+	require.Len(t, built, 1)
+	assert.True(t, enforcesOnOutput(t, built[0]),
+		"the compiled hook must run the custom handler and enforce")
+}
+
+// TestCompileValidatorsWithRegistry_UnknownToTheSuppliedRegistryIsFatal pins
+// that supplying a registry narrows resolution rather than disabling the
+// unknown-type check: a type absent from *the caller's* registry is still fatal.
+func TestCompileValidatorsWithRegistry_UnknownToTheSuppliedRegistryIsFatal(t *testing.T) {
+	enabled := true
+	built, err := CompileValidatorsWithRegistry([]prompt.ValidatorConfig{
+		{Type: "no_such_eval_type_anywhere", Enabled: &enabled, Params: map[string]any{}},
+	}, registryWithCustomType())
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnknownGuardrailType))
+	assert.Empty(t, built)
+}
+
+// TestCompileValidatorsWithRegistry_NilRegistryUsesDefaults pins the
+// nil-means-default contract that keeps CompileValidators (which passes nil)
+// working unchanged.
+func TestCompileValidatorsWithRegistry_NilRegistryUsesDefaults(t *testing.T) {
+	enabled := true
+	built, err := CompileValidatorsWithRegistry([]prompt.ValidatorConfig{
+		{Type: "length", Enabled: &enabled, Params: map[string]any{"max_characters": 100}},
+	}, nil)
+
+	require.NoError(t, err)
+	require.Len(t, built, 1, "a nil registry must still resolve built-in types")
+	assert.Equal(t, "length", built[0].Name())
+}
+
+func TestValidatorsToHooksWithRegistry_ResolvesCustomType(t *testing.T) {
+	enabled := true
+	built := ValidatorsToHooksWithRegistry([]prompt.ValidatorConfig{
+		{Type: customOnlyType, Enabled: &enabled, Params: map[string]any{}},
+	}, registryWithCustomType())
+
+	require.Len(t, built, 1,
+		"the lenient form must not skip a type the supplied registry knows")
+	assert.True(t, enforcesOnOutput(t, built[0]))
+}
+
+// TestValidatorsToHooksWithRegistry_StillSkipsTrulyUnknownType pins that the
+// lenient path keeps its #1680 behavior for a genuinely unknown type — the
+// registry parameter changes *which* types are known, not the failure policy.
+func TestValidatorsToHooksWithRegistry_StillSkipsTrulyUnknownType(t *testing.T) {
+	enabled := true
+	built := ValidatorsToHooksWithRegistry([]prompt.ValidatorConfig{
+		{Type: "no_such_eval_type_anywhere", Enabled: &enabled, Params: map[string]any{}},
+		{Type: customOnlyType, Enabled: &enabled, Params: map[string]any{}},
+	}, registryWithCustomType())
+
+	assert.Len(t, built, 1, "one bad entry must not break the others")
+}
+
+func TestSpecHookWithRegistry_ResolvesCustomType(t *testing.T) {
+	spec := Output(customOnlyType, nil)
+
+	h, err := spec.HookWithRegistry(registryWithCustomType())
+
+	require.NoError(t, err)
+	assert.True(t, enforcesOnOutput(t, h))
+}
+
+// TestSpecHook_DefaultRegistryDoesNotKnowCustomType is the contrast case: the
+// same Spec built without a registry fails. It pins that the custom type is
+// genuinely absent from the defaults, so the test above cannot pass by
+// accident, and that Hook() still means "default registry".
+func TestSpecHook_DefaultRegistryDoesNotKnowCustomType(t *testing.T) {
+	_, err := Output(customOnlyType, nil).Hook()
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnknownGuardrailType))
+}
+
+// TestSpecHookWithRegistry_NilMatchesHook pins that HookWithRegistry(nil) and
+// Hook() are the same path, which is what lets Hook() keep working for every
+// existing caller.
+func TestSpecHookWithRegistry_NilMatchesHook(t *testing.T) {
+	spec := Output("length", map[string]any{"max_characters": 10})
+
+	fromNil, errNil := spec.HookWithRegistry(nil)
+	fromHook, errHook := spec.Hook()
+
+	require.NoError(t, errNil)
+	require.NoError(t, errHook)
+	assert.Equal(t, fromHook.Name(), fromNil.Name())
+}
+
+// TestSpecHookWithRegistry_FuncSpecIgnoresRegistry pins that func-backed
+// guardrails do not consult the registry at all: they must build against an
+// empty one, since there is no eval type to look up.
+func TestSpecHookWithRegistry_FuncSpecIgnoresRegistry(t *testing.T) {
+	spec := OutputFunc("no-op", func(context.Context, *hooks.OutputRequest) hooks.Decision {
+		return hooks.Enforced("always", nil)
+	})
+
+	h, err := spec.HookWithRegistry(evals.NewEmptyEvalTypeRegistry())
+
+	require.NoError(t, err)
+	require.Equal(t, "no-op", h.Name())
+	assert.True(t, enforcesOnOutput(t, h))
+}
+
+// TestSpecHookWithRegistry_ZeroValueSpec pins that the zero-Spec guard survives
+// on the registry-aware entry point too — it must not nil-deref.
+func TestSpecHookWithRegistry_ZeroValueSpec(t *testing.T) {
+	var spec Spec
+
+	_, err := spec.HookWithRegistry(registryWithCustomType())
+
+	require.ErrorIs(t, err, ErrEmptySpec)
+}

--- a/runtime/hooks/guardrails/factory.go
+++ b/runtime/hooks/guardrails/factory.go
@@ -97,6 +97,18 @@ func NewGuardrailHook(typeName string, params map[string]any, opts ...GuardrailO
 	return NewGuardrailHookFromRegistry(typeName, params, evals.NewEvalTypeRegistry(), opts...)
 }
 
+// registryOrDefault resolves an optional caller-supplied registry. nil means
+// "the caller expressed no preference", which is the default registry of
+// built-in handlers — the behavior every caller had before registries could be
+// threaded through. A caller that *does* supply one gets exactly that registry,
+// so a custom eval type can back a guardrail (#1717).
+func registryOrDefault(registry *evals.EvalTypeRegistry) *evals.EvalTypeRegistry {
+	if registry != nil {
+		return registry
+	}
+	return evals.NewEvalTypeRegistry()
+}
+
 // CompileValidators turns pack-declared validators into ProviderHooks suitable
 // for prepending to a hook registry. Both SDK.Open and Arena's per-turn
 // pipeline use this so guardrails run identically in production and in tests.
@@ -123,7 +135,21 @@ func NewGuardrailHook(typeName string, params map[string]any, opts ...GuardrailO
 // On a fatal error no hooks are returned, so a caller cannot accidentally
 // proceed with a partial guardrail set.
 func CompileValidators(validators []prompt.ValidatorConfig) ([]hooks.ProviderHook, error) {
-	return compileValidators(validators, true)
+	return compileValidators(validators, true, nil)
+}
+
+// CompileValidatorsWithRegistry is CompileValidators resolving each validator's
+// eval type against the supplied registry instead of the built-in default. Pass
+// the registry a caller configured (sdk.WithEvalRegistry) so a custom handler
+// can back a pack validator; a nil registry means the default one.
+//
+// Without this the default registry does not know a custom type, construction
+// fails, and — on the lenient path — the guardrail is logged and dropped, which
+// leaves the conversation unprotected while load appears to succeed (#1717).
+func CompileValidatorsWithRegistry(
+	validators []prompt.ValidatorConfig, registry *evals.EvalTypeRegistry,
+) ([]hooks.ProviderHook, error) {
+	return compileValidators(validators, true, registry)
 }
 
 // ValidatorsToHooks is the lenient form: every unusable validator — including
@@ -135,19 +161,38 @@ func CompileValidators(validators []prompt.ValidatorConfig) ([]hooks.ProviderHoo
 // unprotected. Retained unchanged so existing callers keep their behavior.
 func ValidatorsToHooks(validators []prompt.ValidatorConfig) []hooks.ProviderHook {
 	// The lenient path never returns an error.
-	out, _ := compileValidators(validators, false)
+	out, _ := compileValidators(validators, false, nil)
+	return out
+}
+
+// ValidatorsToHooksWithRegistry is the lenient form of
+// CompileValidatorsWithRegistry: every unusable validator — including an
+// unknown eval type — is logged and skipped. A nil registry means the default
+// one.
+//
+// Deprecated: use CompileValidatorsWithRegistry. This form cannot report an
+// unknown eval type, so a typo'd validator is silently dropped and the caller
+// proceeds unprotected.
+func ValidatorsToHooksWithRegistry(
+	validators []prompt.ValidatorConfig, registry *evals.EvalTypeRegistry,
+) []hooks.ProviderHook {
+	out, _ := compileValidators(validators, false, registry)
 	return out
 }
 
 // compileValidators builds hooks from validator specs. When fatalUnknownType is
 // true an unregistered eval type aborts the whole set (no partial guardrails);
-// when false it is logged and skipped like any other unusable entry.
+// when false it is logged and skipped like any other unusable entry. registry
+// resolves the eval types; nil selects the default registry.
 func compileValidators(
-	validators []prompt.ValidatorConfig, fatalUnknownType bool,
+	validators []prompt.ValidatorConfig, fatalUnknownType bool, registry *evals.EvalTypeRegistry,
 ) ([]hooks.ProviderHook, error) {
 	if len(validators) == 0 {
 		return nil, nil
 	}
+	// Resolved once: every validator in a set must see the same handlers, and
+	// the default constructor is not free.
+	reg := registryOrDefault(registry)
 	out := make([]hooks.ProviderHook, 0, len(validators))
 	for _, v := range validators {
 		if v.Enabled != nil && !*v.Enabled {
@@ -162,7 +207,7 @@ func compileValidators(
 			opts = append(opts, WithMessage(msg))
 		}
 
-		hook, err := NewGuardrailHook(v.Type, v.Params, opts...)
+		hook, err := NewGuardrailHookFromRegistry(v.Type, v.Params, reg, opts...)
 		if err != nil {
 			if fatalUnknownType && errors.Is(err, ErrUnknownGuardrailType) {
 				return nil, fmt.Errorf("pack validator: %w", err)

--- a/runtime/hooks/guardrails/spec.go
+++ b/runtime/hooks/guardrails/spec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 )
@@ -20,16 +21,29 @@ var ErrEmptySpec = errors.New(
 // declare guardrails inline and report all failures at one point — typically
 // sdk.Open.
 type Spec struct {
-	build func() (hooks.ProviderHook, error)
+	build func(*evals.EvalTypeRegistry) (hooks.ProviderHook, error)
 }
 
-// Hook builds the ProviderHook this Spec describes. A zero-value Spec returns
-// ErrEmptySpec rather than panicking.
+// Hook builds the ProviderHook this Spec describes against the default eval
+// registry. A zero-value Spec returns ErrEmptySpec rather than panicking.
 func (s Spec) Hook() (hooks.ProviderHook, error) {
+	return s.HookWithRegistry(nil)
+}
+
+// HookWithRegistry builds the ProviderHook resolving an eval-backed guardrail's
+// type against registry. A nil registry means the default one, so
+// HookWithRegistry(nil) and Hook() are equivalent.
+//
+// Callers that let a user supply their own evals.EvalTypeRegistry — the SDK's
+// WithEvalRegistry — must use this form. Building against the default registry
+// makes a custom eval type unknown, and the guardrail is then dropped rather
+// than enforced (#1717). Func-backed Specs (InputFunc, OutputFunc) ignore the
+// registry: they carry their own logic.
+func (s Spec) HookWithRegistry(registry *evals.EvalTypeRegistry) (hooks.ProviderHook, error) {
 	if s.build == nil {
 		return nil, ErrEmptySpec
 	}
-	return s.build()
+	return s.build(registry)
 }
 
 // Input declares an eval-backed guardrail that gates the user's input before
@@ -55,8 +69,8 @@ func evalSpec(
 		merged[k] = v
 	}
 	merged["direction"] = direction
-	return Spec{build: func() (hooks.ProviderHook, error) {
-		return NewGuardrailHook(evalType, merged, opts...)
+	return Spec{build: func(registry *evals.EvalTypeRegistry) (hooks.ProviderHook, error) {
+		return NewGuardrailHookFromRegistry(evalType, merged, registryOrDefault(registry), opts...)
 	}}
 }
 
@@ -74,7 +88,7 @@ func evalSpec(
 func InputFunc(
 	name string, fn func(context.Context, *hooks.InputRequest) hooks.Decision,
 ) Spec {
-	return Spec{build: func() (hooks.ProviderHook, error) {
+	return Spec{build: func(*evals.EvalTypeRegistry) (hooks.ProviderHook, error) {
 		return &funcGuardrail{name: name, input: fn}, nil
 	}}
 }
@@ -86,7 +100,7 @@ func InputFunc(
 func OutputFunc(
 	name string, fn func(context.Context, *hooks.OutputRequest) hooks.Decision,
 ) Spec {
-	return Spec{build: func() (hooks.ProviderHook, error) {
+	return Spec{build: func(*evals.EvalTypeRegistry) (hooks.ProviderHook, error) {
 		return &funcGuardrail{name: name, output: fn}, nil
 	}}
 }

--- a/sdk/guardrail_custom_registry_test.go
+++ b/sdk/guardrail_custom_registry_test.go
@@ -1,0 +1,241 @@
+package sdk_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/guardrails"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+// Regression coverage for https://github.com/AltairaLabs/PromptKit/issues/1717.
+//
+// A handler registered only in a caller-supplied evals.EvalTypeRegistry could
+// not back a guardrail by either entry point: both resolved eval types against
+// a freshly built default registry, so the custom type was unknown. The
+// programmatic path failed Open outright and the pack path — which logs and
+// skips a validator it cannot construct — silently ran the conversation with no
+// guardrail at all.
+//
+// Every test here therefore asserts on the *enforced content of a real turn*.
+// Asserting only that Open succeeds cannot fail for the pack path, because the
+// bug there is a silent no-op.
+
+// customGuardrailType is deliberately absent from evals.NewEvalTypeRegistry's
+// built-in set. If a future built-in claims this name these tests stop proving
+// anything, so keep it obviously bespoke.
+const customGuardrailType = "test_forbidden_token_1717"
+
+// forbiddenToken is the substring the custom handler scores against.
+const forbiddenToken = "kumquat"
+
+// forbiddenTokenHandler is a custom eval handler that exists only in this test.
+// It scores 1.0 for clean content and 0.0 when the forbidden token appears —
+// zero trips the guardrail's default "requires a perfect 1.0" threshold.
+type forbiddenTokenHandler struct{}
+
+func (h *forbiddenTokenHandler) Type() string { return customGuardrailType }
+
+func (h *forbiddenTokenHandler) Eval(
+	_ context.Context, evalCtx *evals.EvalContext, _ map[string]any,
+) (*evals.EvalResult, error) {
+	score := 1.0
+	explanation := "clean"
+	if strings.Contains(strings.ToLower(evalCtx.CurrentOutput), forbiddenToken) {
+		score = 0.0
+		explanation = "forbidden token present"
+	}
+	return &evals.EvalResult{
+		Type:        customGuardrailType,
+		Score:       &score,
+		Explanation: explanation,
+	}, nil
+}
+
+// customEvalRegistry returns a default registry with the bespoke handler added,
+// mirroring what a caller of sdk.WithEvalRegistry builds.
+func customEvalRegistry() *evals.EvalTypeRegistry {
+	r := evals.NewEvalTypeRegistry()
+	r.Register(&forbiddenTokenHandler{})
+	return r
+}
+
+// packWithCustomValidator returns promptpack JSON declaring the custom eval
+// type as a prompt validator. Schema validation is skipped when opening it —
+// the type is intentionally not one the published schema knows.
+func packWithCustomValidator(blockedMessage string) []byte {
+	return []byte(`{
+  "id": "test-pack-1717",
+  "version": "1.0.0",
+  "description": "issue #1717 regression",
+  "prompts": {
+    "default": {
+      "id": "default",
+      "name": "Default",
+      "system_template": "You are helpful.",
+      "validators": [
+        {
+          "type": "` + customGuardrailType + `",
+          "enabled": true,
+          "params": {"message": "` + blockedMessage + `"}
+        }
+      ]
+    }
+  }
+}`)
+}
+
+// packWithoutValidators is the same pack with no validators declared, used by
+// the programmatic (WithGuardrail) cases.
+func packWithoutValidators() []byte {
+	return []byte(`{
+  "id": "test-pack-1717-plain",
+  "version": "1.0.0",
+  "description": "issue #1717 regression",
+  "prompts": {
+    "default": {
+      "id": "default",
+      "name": "Default",
+      "system_template": "You are helpful."
+    }
+  }
+}`)
+}
+
+// sendOnce opens a conversation over a mock provider returning cannedResponse,
+// sends one turn, and returns the assistant text the caller receives.
+func sendOnce(t *testing.T, packJSON []byte, cannedResponse string, opts ...sdk.Option) string {
+	t.Helper()
+	packPath := writeTestPack(t, packJSON)
+
+	repo := mock.NewInMemoryMockRepository(cannedResponse)
+	provider := mock.NewProviderWithRepository("mock-1717", "mock-model", false, repo)
+
+	all := append([]sdk.Option{
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+	}, opts...)
+
+	conv, err := sdk.Open(packPath, "default", all...)
+	require.NoError(t, err, "open must succeed with the custom handler supplied via WithEvalRegistry")
+	t.Cleanup(func() { _ = conv.Close() })
+
+	resp, err := conv.Send(context.Background(), "Hello")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	return resp.Text()
+}
+
+// TestCustomEvalRegistry_GuardrailOptionEnforces covers the programmatic
+// WithGuardrail path. Both option orders are exercised because the fix defers
+// guardrail construction until every option has been applied: building eagerly
+// inside WithGuardrail works only when WithEvalRegistry happens to come first.
+func TestCustomEvalRegistry_GuardrailOptionEnforces(t *testing.T) {
+	const blocked = "blocked by the custom guardrail"
+	const dirty = "Here is a kumquat for you."
+
+	guardrailOpt := sdk.WithGuardrail(
+		guardrails.Output(customGuardrailType, nil, guardrails.WithMessage(blocked)),
+	)
+
+	cases := []struct {
+		name string
+		opts []sdk.Option
+	}{
+		{
+			name: "registry declared first",
+			opts: []sdk.Option{sdk.WithEvalRegistry(customEvalRegistry()), guardrailOpt},
+		},
+		{
+			name: "guardrail declared first",
+			opts: []sdk.Option{guardrailOpt, sdk.WithEvalRegistry(customEvalRegistry())},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Enforcement: the canned response trips the custom handler, so the
+			// caller must receive the guardrail's message instead. Mutations
+			// caught: resolving against the default registry (Open errors on an
+			// unknown type), and building the hook but never registering it
+			// (the raw response comes back).
+			got := sendOnce(t, packWithoutValidators(), dirty, tc.opts...)
+			assert.Equal(t, blocked, got,
+				"custom-registry guardrail must block the offending response")
+			assert.NotContains(t, got, forbiddenToken)
+		})
+	}
+}
+
+// TestCustomEvalRegistry_GuardrailOptionAllowsCleanTurn is the negative control
+// for the case above. Without it, a guardrail that blocked unconditionally —
+// for example one whose handler always scores nil, which the threshold treats
+// as fail-closed — would satisfy the enforcement assertion for the wrong
+// reason.
+func TestCustomEvalRegistry_GuardrailOptionAllowsCleanTurn(t *testing.T) {
+	const clean = "Here is a perfectly ordinary answer."
+
+	got := sendOnce(t, packWithoutValidators(), clean,
+		sdk.WithEvalRegistry(customEvalRegistry()),
+		sdk.WithGuardrail(
+			guardrails.Output(customGuardrailType, nil, guardrails.WithMessage("blocked")),
+		),
+	)
+
+	assert.Equal(t, clean, got, "clean content must pass the custom guardrail untouched")
+}
+
+// TestCustomEvalRegistry_PackValidatorEnforces covers the pack `validators:`
+// path. This is the case the fail-open policy hid: an unusable validator is
+// logged and skipped, so before the fix Open() succeeded and the turn came back
+// unmodified. Asserting the enforced text is what makes this test able to fail.
+func TestCustomEvalRegistry_PackValidatorEnforces(t *testing.T) {
+	const blocked = "blocked by the custom pack validator"
+	const dirty = "Have a kumquat, on the house."
+
+	got := sendOnce(t, packWithCustomValidator(blocked), dirty,
+		sdk.WithEvalRegistry(customEvalRegistry()),
+	)
+
+	assert.Equal(t, blocked, got,
+		"a pack validator naming a custom eval type must enforce, not be skipped")
+	assert.NotContains(t, got, forbiddenToken)
+}
+
+// TestCustomEvalRegistry_PackValidatorAllowsCleanTurn is the negative control
+// for the pack path: the validator must be discriminating, not an always-block.
+func TestCustomEvalRegistry_PackValidatorAllowsCleanTurn(t *testing.T) {
+	const clean = "Nothing controversial here at all."
+
+	got := sendOnce(t, packWithCustomValidator("blocked"), clean,
+		sdk.WithEvalRegistry(customEvalRegistry()),
+	)
+
+	assert.Equal(t, clean, got, "clean content must pass the custom pack validator untouched")
+}
+
+// TestCustomEvalRegistry_PackValidatorWithoutRegistryStillFatal pins that
+// threading the registry through did not weaken the unknown-type policy: with
+// no custom registry supplied the type really is unknown, and CompileValidators
+// must still fail Open rather than drop the guardrail.
+func TestCustomEvalRegistry_PackValidatorWithoutRegistryStillFatal(t *testing.T) {
+	packPath := writeTestPack(t, packWithCustomValidator("blocked"))
+
+	repo := mock.NewInMemoryMockRepository("anything")
+	provider := mock.NewProviderWithRepository("mock-1717", "mock-model", false, repo)
+
+	_, err := sdk.Open(packPath, "default",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, guardrails.ErrUnknownGuardrailType)
+	assert.Contains(t, err.Error(), customGuardrailType)
+}

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -156,6 +156,13 @@ type config struct {
 	toolHooks     []hooks.ToolHook
 	sessionHooks  []hooks.SessionHook
 
+	// Guardrail specs declared via WithGuardrail, not yet built. Building is
+	// deferred to resolveGuardrails so an eval-backed guardrail sees the eval
+	// registry from WithEvalRegistry regardless of the order the two options
+	// were passed in (#1717). Each entry remembers the providerHooks index it
+	// was declared at so the built hooks land in declaration order.
+	pendingGuardrails []pendingGuardrail
+
 	// Schema validation
 	skipSchemaValidation bool
 
@@ -1468,19 +1475,67 @@ func WithProviderHook(h hooks.ProviderHook) Option {
 // Construction errors (unknown eval type, invalid params) are returned from
 // Open rather than at the call site. For a hook implementing the full
 // hooks.ProviderHook interface, use WithProviderHook.
+//
+// An eval-backed guardrail resolves its type against the registry supplied by
+// WithEvalRegistry, if any. Resolution happens after every option has been
+// applied, so the two options may be passed in either order.
 func WithGuardrail(specs ...guardrails.Spec) Option {
 	return func(c *config) error {
-		built := make([]hooks.ProviderHook, 0, len(specs))
+		at := len(c.providerHooks)
 		for _, spec := range specs {
-			h, err := spec.Hook()
-			if err != nil {
-				return fmt.Errorf("guardrail: %w", err)
-			}
-			built = append(built, h)
+			c.pendingGuardrails = append(c.pendingGuardrails, pendingGuardrail{spec: spec, at: at})
 		}
-		c.providerHooks = append(c.providerHooks, built...)
 		return nil
 	}
+}
+
+// pendingGuardrail is a WithGuardrail spec awaiting construction, tagged with
+// the providerHooks position it was declared at. Hooks run in registration
+// order, so a guardrail declared between two WithProviderHook calls has to end
+// up between them once built.
+type pendingGuardrail struct {
+	spec guardrails.Spec
+	at   int
+}
+
+// resolveGuardrails builds every deferred WithGuardrail spec against the
+// configured eval registry and splices the hooks into providerHooks at the
+// positions they were declared at.
+//
+// Deferred rather than built inside the option because WithEvalRegistry may be
+// passed after WithGuardrail: building eagerly would resolve a custom eval type
+// against the default registry, fail, and — since the pack path logs and skips
+// unusable validators — leave the conversation unprotected (#1717).
+//
+// All specs are built before any hook is spliced in, so one failing spec
+// registers nothing rather than a partial guardrail set.
+func (c *config) resolveGuardrails() error {
+	if len(c.pendingGuardrails) == 0 {
+		return nil
+	}
+	built := make([]hooks.ProviderHook, 0, len(c.pendingGuardrails))
+	for _, pending := range c.pendingGuardrails {
+		h, err := pending.spec.HookWithRegistry(c.evalRegistry)
+		if err != nil {
+			return fmt.Errorf("guardrail: %w", err)
+		}
+		built = append(built, h)
+	}
+
+	merged := make([]hooks.ProviderHook, 0, len(c.providerHooks)+len(built))
+	next := 0
+	for i := 0; i <= len(c.providerHooks); i++ {
+		for next < len(built) && c.pendingGuardrails[next].at == i {
+			merged = append(merged, built[next])
+			next++
+		}
+		if i < len(c.providerHooks) {
+			merged = append(merged, c.providerHooks[i])
+		}
+	}
+	c.providerHooks = merged
+	c.pendingGuardrails = nil
+	return nil
 }
 
 // WithSandboxFactory registers a sandbox factory for the given mode name.

--- a/sdk/options_guardrail_test.go
+++ b/sdk/options_guardrail_test.go
@@ -14,10 +14,24 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
-func TestWithGuardrail_RegistersProviderHooks(t *testing.T) {
+// applyGuardrailOption applies opt to a fresh config and resolves the deferred
+// guardrail specs, which is what applyOptions does at Open() time. Guardrails
+// are built after every option has been seen so WithEvalRegistry can be passed
+// in any position (#1717), so a test asserting on the built hooks has to run
+// that second step too.
+func applyGuardrailOption(t *testing.T, opts ...Option) (*config, error) {
+	t.Helper()
 	c := &config{}
+	for _, opt := range opts {
+		if err := opt(c); err != nil {
+			return c, err
+		}
+	}
+	return c, c.resolveGuardrails()
+}
 
-	err := WithGuardrail(
+func TestWithGuardrail_RegistersProviderHooks(t *testing.T) {
+	c, err := applyGuardrailOption(t, WithGuardrail(
 		guardrails.Input("length", map[string]any{"max_characters": 100}),
 		guardrails.OutputFunc("no-secrets", func(_ context.Context, out *hooks.OutputRequest) hooks.Decision {
 			if strings.Contains(out.Content, "sk-") {
@@ -25,7 +39,7 @@ func TestWithGuardrail_RegistersProviderHooks(t *testing.T) {
 			}
 			return hooks.Allow
 		}),
-	)(c)
+	))
 
 	require.NoError(t, err)
 	assert.Len(t, c.providerHooks, 2)
@@ -36,13 +50,42 @@ func TestWithGuardrail_RegistersProviderHooks(t *testing.T) {
 }
 
 func TestWithGuardrail_SurfacesConstructionError(t *testing.T) {
-	c := &config{}
-
-	err := WithGuardrail(guardrails.Input("no_such_eval_type_anywhere", nil))(c)
+	c, err := applyGuardrailOption(t, WithGuardrail(
+		guardrails.Input("no_such_eval_type_anywhere", nil),
+	))
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no_such_eval_type_anywhere")
 	assert.Empty(t, c.providerHooks, "a failed spec must register nothing")
+}
+
+// TestWithGuardrail_ErrorSurfacesFromApplyOptions pins that the deferred build
+// is actually wired into the option-application path. Without the
+// resolveGuardrails call in applyOptions, an unknown eval type would no longer
+// fail Open at all — the specs would simply never be built, which is the exact
+// fail-open shape #1717 is about.
+func TestWithGuardrail_ErrorSurfacesFromApplyOptions(t *testing.T) {
+	_, err := applyOptions("assistant", []Option{
+		WithGuardrail(guardrails.Input("no_such_eval_type_anywhere", nil)),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no_such_eval_type_anywhere")
+}
+
+// TestApplyOptions_BuildsGuardrailHooks is the positive counterpart: a valid
+// spec must reach cfg.providerHooks through applyOptions, so the pipeline sees
+// it. A resolveGuardrails call that silently produced nothing would pass the
+// error test above but fail this one.
+func TestApplyOptions_BuildsGuardrailHooks(t *testing.T) {
+	cfg, err := applyOptions("assistant", []Option{
+		WithGuardrail(guardrails.Input("length", map[string]any{"max_characters": 100})),
+	})
+
+	require.NoError(t, err)
+	require.Len(t, cfg.providerHooks, 1)
+	assert.Equal(t, "length", cfg.providerHooks[0].Name())
+	assert.Empty(t, cfg.pendingGuardrails, "resolved specs must not be left pending")
 }
 
 // TestWithGuardrail_ValidThenInvalidRegistersNothing pins the "build all specs
@@ -51,12 +94,10 @@ func TestWithGuardrail_SurfacesConstructionError(t *testing.T) {
 // nothing to have appended before the failure either way — this test puts a
 // valid spec first so a partial-registration bug would leave one hook behind.
 func TestWithGuardrail_ValidThenInvalidRegistersNothing(t *testing.T) {
-	c := &config{}
-
-	err := WithGuardrail(
+	c, err := applyGuardrailOption(t, WithGuardrail(
 		guardrails.Input("length", map[string]any{"max_characters": 100}),
 		guardrails.Input("no_such_eval_type_anywhere", nil),
-	)(c)
+	))
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no_such_eval_type_anywhere")
@@ -68,12 +109,11 @@ func TestWithGuardrail_ValidThenInvalidRegistersNothing(t *testing.T) {
 // and forgetting to fill an entry. That config mistake must surface as an Open()
 // error, not a nil-deref panic inside the SDK.
 func TestWithGuardrail_ZeroValueSpecErrors(t *testing.T) {
-	c := &config{}
 	specs := make([]guardrails.Spec, 2)
 	specs[0] = guardrails.Input("length", map[string]any{"max_characters": 100})
 	// specs[1] left unassigned
 
-	err := WithGuardrail(specs...)(c)
+	c, err := applyGuardrailOption(t, WithGuardrail(specs...))
 
 	require.ErrorIs(t, err, guardrails.ErrEmptySpec)
 	assert.Empty(t, c.providerHooks, "a failed spec must register nothing")
@@ -83,14 +123,12 @@ func TestWithGuardrail_ZeroValueSpecErrors(t *testing.T) {
 // directional constructor is authoritative: a stray params["direction"] cannot
 // silently flip an Output guardrail into an input one.
 func TestWithGuardrail_ConstructorOverridesParamsDirection(t *testing.T) {
-	c := &config{}
-
-	err := WithGuardrail(
+	c, err := applyGuardrailOption(t, WithGuardrail(
 		guardrails.Output("length", map[string]any{
 			"max_characters": 5,
 			"direction":      "input", // ignored: Output() wins
 		}),
-	)(c)
+	))
 
 	require.NoError(t, err)
 	require.Len(t, c.providerHooks, 1)
@@ -100,4 +138,41 @@ func TestWithGuardrail_ConstructorOverridesParamsDirection(t *testing.T) {
 		Messages: []types.Message{{Role: "user", Content: "way too long to pass"}},
 	})
 	assert.True(t, d.Allow, "Output() must not gate input regardless of params")
+}
+
+// namedHook is a do-nothing ProviderHook used to pin registration order.
+type namedHook struct{ name string }
+
+func (h *namedHook) Name() string { return h.name }
+
+func (h *namedHook) BeforeCall(context.Context, *hooks.ProviderRequest) hooks.Decision {
+	return hooks.Allow
+}
+
+func (h *namedHook) AfterCall(
+	context.Context, *hooks.ProviderRequest, *hooks.ProviderResponse,
+) hooks.Decision {
+	return hooks.Allow
+}
+
+// TestWithGuardrail_PreservesDeclarationOrder pins that deferring the build does
+// not reorder hooks. Hooks execute in registration order and the first deny
+// short-circuits, so a guardrail declared between two WithProviderHook calls has
+// to stay between them. A resolveGuardrails that simply appended the built hooks
+// would put "guard" last and this test would catch it.
+func TestWithGuardrail_PreservesDeclarationOrder(t *testing.T) {
+	c, err := applyGuardrailOption(t,
+		WithProviderHook(&namedHook{name: "first"}),
+		WithGuardrail(guardrails.Input("length", map[string]any{"max_characters": 100})),
+		WithProviderHook(&namedHook{name: "last"}),
+	)
+
+	require.NoError(t, err)
+	require.Len(t, c.providerHooks, 3)
+	names := []string{
+		c.providerHooks[0].Name(),
+		c.providerHooks[1].Name(),
+		c.providerHooks[2].Name(),
+	}
+	assert.Equal(t, []string{"first", "length", "last"}, names)
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -327,6 +327,13 @@ func applyOptions(promptName string, opts []Option) (*config, error) {
 		}
 	}
 
+	// Build WithGuardrail specs now that every option has been seen — in
+	// particular WithEvalRegistry, which an eval-backed guardrail resolves its
+	// type against (#1717).
+	if err := cfg.resolveGuardrails(); err != nil {
+		return nil, err
+	}
+
 	// Validate RAG context option dependencies
 	if cfg.contextWindow > 0 && cfg.stateStore == nil {
 		return nil, fmt.Errorf("WithContextWindow requires WithStateStore")
@@ -1222,9 +1229,12 @@ func resolveA2AHeaders(cfg *tools.A2AConfig) map[string]string {
 
 // convertPackValidatorsToHooks auto-converts pack prompt validators into
 // provider hooks, prepending them before any user-registered hooks. The
-// per-validator translation lives in guardrails.ValidatorsToHooks so SDK and
-// Arena exercise identical conversion semantics — same defaults, same
-// skip-and-warn behavior, same enforcement.
+// per-validator translation lives in guardrails.CompileValidatorsWithRegistry
+// so SDK and Arena exercise identical conversion semantics — same defaults,
+// same skip-and-warn behavior, same enforcement.
+//
+// Validator types resolve against the registry from WithEvalRegistry when one
+// was supplied, so a custom handler can back a pack `validators:` entry (#1717).
 func convertPackValidatorsToHooks(p *pack.Prompt, cfg *config) error {
 	if len(p.Validators) == 0 {
 		return nil
@@ -1238,7 +1248,7 @@ func convertPackValidatorsToHooks(p *pack.Prompt, cfg *config) error {
 			Enabled: &enabled,
 		})
 	}
-	packHooks, err := guardrails.CompileValidators(specs)
+	packHooks, err := guardrails.CompileValidatorsWithRegistry(specs, cfg.evalRegistry)
 	if err != nil {
 		// An unknown eval type is fatal: dropping it would leave the
 		// conversation silently unprotected. Unusable params are still


### PR DESCRIPTION
Closes #1717

## Problem

`sdk.WithEvalRegistry` lets a caller supply a custom `evals.EvalTypeRegistry`. Those handlers worked as evals and assertions, but could not back a guardrail by either entry point — both resolved eval types against a freshly built default registry:

- programmatic: `guardrails.Input`/`Output` → `evalSpec` → `NewGuardrailHook` → `NewGuardrailHookFromRegistry(..., evals.NewEvalTypeRegistry(), ...)`
- pack YAML: `ValidatorsToHooks` / `CompileValidators` took no registry at all

A custom type is unknown to the default registry, so construction fails. On the lenient compile path (the #1680 "one bad entry does not break the others" policy) that means the validator is logged and skipped — a warning line and an **unprotected conversation**.

## Changes

### `runtime/hooks/guardrails`

| before | after |
|---|---|
| `Spec.build func() (hooks.ProviderHook, error)` | `Spec.build func(*evals.EvalTypeRegistry) (hooks.ProviderHook, error)` (unexported field) |
| — | **new** `Spec.HookWithRegistry(reg *evals.EvalTypeRegistry)` |
| `Spec.Hook()` | unchanged signature; now `HookWithRegistry(nil)` |
| — | **new** `CompileValidatorsWithRegistry(validators, reg)` |
| — | **new** `ValidatorsToHooksWithRegistry(validators, reg)` |
| `compileValidators(validators, fatal bool)` | `compileValidators(validators, fatal bool, reg *evals.EvalTypeRegistry)` (unexported) |

`nil` registry means "the default set", so `Hook()`, `CompileValidators`, `ValidatorsToHooks` and `NewGuardrailHook` are behaviorally unchanged for every existing caller (runtime pipeline tests, `sdk/validate_pack.go`, Arena). No exported signature was broken.

`compileValidators` also now resolves the registry once per set instead of building a fresh default registry per validator.

### `sdk`

- `WithGuardrail` no longer builds eagerly. It records the specs, and `applyOptions` calls the new `config.resolveGuardrails()` once every option has been applied — so `WithEvalRegistry` and `WithGuardrail` may be passed **in either order**. Building eagerly would have made the fix work only when the registry option happened to come first.
- Each pending spec remembers the `providerHooks` index it was declared at, and the built hooks are spliced back at those positions. Hooks run in registration order and the first deny short-circuits, so a guardrail declared between two `WithProviderHook` calls stays between them.
- Construction errors still surface from `Open()` (via `applyOptions`), and all specs are built before any hook is registered, so one failing spec registers nothing.
- `convertPackValidatorsToHooks` now calls `CompileValidatorsWithRegistry(specs, cfg.evalRegistry)` — the pack `validators:` path.

## What the tests pin

New `sdk/guardrail_custom_registry_test.go` registers a bespoke handler **only** in a caller-supplied registry and asserts the **enforced assistant text of a real turn** through `sdk.Open` + `Send` over a mock provider. A test that only asserted `require.NoError` on construction could not fail for the pack path, where the bug is a silent no-op.

- programmatic path, **both option orders** — response containing the forbidden token comes back as the guardrail's message. Mutations caught: resolving against the default registry (Open errors, unknown type); building but never registering the hook (raw response returns).
- pack `validators:` path — same, via a pack declaring the custom type.
- negative controls on both paths — clean content passes through untouched, so an unconditional block (e.g. a nil score, which the threshold treats as fail-closed) cannot satisfy the enforcement assertions for the wrong reason.
- no-registry control — the same pack without `WithEvalRegistry` must still fail `Open` with `ErrUnknownGuardrailType`; threading a registry narrows *which* types are known, it does not weaken the fatal-unknown-type policy.

New `runtime/hooks/guardrails/custom_registry_test.go` covers the runtime seam directly: `CompileValidatorsWithRegistry` / `ValidatorsToHooksWithRegistry` / `HookWithRegistry` each build a hook that **enforces** on `AfterCall`; `nil` falls back to the defaults; the lenient form still skips a genuinely unknown type; func-backed specs build against an *empty* registry (they must not consult it); zero-value `Spec` still returns `ErrEmptySpec`.

`sdk/options_guardrail_test.go` was updated for the deferred build (the option is now applied *and* resolved), plus two additions:
- `TestWithGuardrail_ErrorSurfacesFromApplyOptions` / `TestApplyOptions_BuildsGuardrailHooks` — pin that `resolveGuardrails` is actually wired into `applyOptions`. Without that call the specs would never be built, which is the same fail-open shape.
- `TestWithGuardrail_PreservesDeclarationOrder` — catches a `resolveGuardrails` that appends instead of splicing.

Each mutation above was verified to fail the relevant test before being reverted.

## Verification

- `go -C runtime test ./... -count=1` and `go -C runtime test ./hooks/... -count=1 -race` — pass
- `go -C sdk test ./... -count=1` — pass
- `golangci-lint` clean on `runtime/hooks/guardrails` and on the changed `sdk` lines
- `make docs-reference-check` clean; `make docs-sdk-reference` regenerated (`WithGuardrail` doc comment) and committed

## Known follow-up (not in scope here)

`sdk.ValidatePack` still dry-runs validators against `evals.NewEvalTypeRegistry()`, so the preflight tool reports a custom-typed validator as an issue even though `Open()` now accepts it. Giving it a registry means changing its exported signature, so it is left alone.
