### PR TITLE
fix(evals): carry validation details into PriorResults and add direction matching

### DIFF
--- a/docs/src/content/docs/reference/checks.md
+++ b/docs/src/content/docs/reference/checks.md
@@ -923,10 +923,23 @@ evals:
 
 | Type | Params | Surfaces |
 |------|--------|----------|
-| `guardrail_triggered` | `guardrail` (string), `should_trigger` (bool) | A E |
+| `guardrail_triggered` | `guardrail` (string), `should_trigger` (bool), `direction` (string, optional) | A E |
 | `invariant_fields_preserved` | `tool` (string), `fields` (string[]) | E |
 
-`guardrail_triggered` inspects prior eval results in the same batch, verifying that a specific guardrail did (or did not) fire.
+`guardrail_triggered` inspects prior eval results in the same batch, verifying that a specific guardrail did (or did not) fire. Pipeline-level guardrail firings are seeded into those prior results from the assistant message's validations, so a guardrail that fired during the turn is visible here without any extra wiring.
+
+`direction` narrows the match to the side the guardrail judged — `input` (the user's message, before the LLM call) or `output` (the assistant response) — mirroring the [`direction` param on the guardrail declaration](#guardrail-direction):
+
+```yaml
+assertions:
+  - type: guardrail_triggered
+    params:
+      validator: pii_leakage
+      direction: input
+      should_trigger: true
+```
+
+Omit it (or pass `both`) to match a firing from either side — the default, and what you want unless the same check is declared as an input guardrail *and* an output guardrail, in which case only `direction` can tell you which one fired. A firing recorded without a direction never satisfies a direction-qualified assertion, and an unrecognized value is rejected when the eval definitions are validated rather than silently matching nothing.
 
 ---
 

--- a/runtime/evals/context.go
+++ b/runtime/evals/context.go
@@ -261,6 +261,14 @@ func parseJSONArgs(data []byte) map[string]any {
 // assistant message into EvalResult entries. This seeds PriorResults so that
 // evals like guardrail_triggered can inspect pipeline-level guardrail outcomes
 // without coupling to message.Validations directly.
+//
+// Details are carried across. The guardrail recorder stamps the firing's
+// "direction" ("input" or "output") into ValidationResult.Details, and dropping
+// the map here left that distinction unreadable on the eval side — the assertion
+// could see that a guardrail of some type fired but not which side it judged,
+// which is the distinction PRE_LLM_GUARDRAILS_DESIGN §4.5 exists to serve
+// (#1718). Everything else a guardrail put in its decision metadata rides along
+// for the same reason: PriorResults is the only channel between the two.
 func validationsToPriorResults(messages []types.Message) []EvalResult {
 	for i := len(messages) - 1; i >= 0; i-- {
 		if messages[i].Role != roleAssistant {
@@ -276,11 +284,29 @@ func validationsToPriorResults(messages []types.Message) []EvalResult {
 				score = 0.0
 			}
 			results[j] = EvalResult{
-				Type:  v.ValidatorType,
-				Score: &score,
+				Type:    v.ValidatorType,
+				Score:   &score,
+				Details: copyDetails(v.Details),
 			}
 		}
 		return results
 	}
 	return nil
+}
+
+// copyDetails shallow-copies a validation's details map.
+//
+// PriorResults is handed to arbitrary eval handlers, including third-party
+// ones; aliasing the map would let any of them mutate the recorded message's
+// Validations. Returns nil for an empty map so a validation without details
+// produces an EvalResult that still marshals without a "details" key.
+func copyDetails(details map[string]any) map[string]any {
+	if len(details) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(details))
+	for k, v := range details {
+		out[k] = v
+	}
+	return out
 }

--- a/runtime/evals/context_test.go
+++ b/runtime/evals/context_test.go
@@ -293,6 +293,68 @@ func TestValidationsToPriorResults_SeedsFromLastAssistant(t *testing.T) {
 	assert.Equal(t, 1.0, *results[1].Score)
 }
 
+// TestValidationsToPriorResults_CarriesDetails pins the half of the eval bridge
+// that was missing: the guardrail recorder stamps which side it judged into
+// ValidationResult.Details, and dropping the map made that unreadable to
+// guardrail_triggered (#1718).
+func TestValidationsToPriorResults_CarriesDetails(t *testing.T) {
+	messages := []types.Message{
+		types.NewUserMessage("hello"),
+		{
+			Role: "assistant",
+			Validations: []types.ValidationResult{{
+				ValidatorType: "pii_leakage",
+				Passed:        false,
+				Details:       map[string]any{"direction": "input", "reason": "ssn"},
+			}},
+		},
+	}
+
+	results := validationsToPriorResults(messages)
+	require.Len(t, results, 1)
+	assert.Equal(t, "input", results[0].Details["direction"])
+	assert.Equal(t, "ssn", results[0].Details["reason"],
+		"the whole detail map rides across, not just the direction key")
+}
+
+// TestValidationsToPriorResults_DetailsAreCopied pins that PriorResults does not
+// alias message state. PriorResults is handed to arbitrary eval handlers; an
+// aliased map lets any of them rewrite the recorded validation on the message.
+func TestValidationsToPriorResults_DetailsAreCopied(t *testing.T) {
+	messages := []types.Message{
+		{
+			Role: "assistant",
+			Validations: []types.ValidationResult{{
+				ValidatorType: "pii_leakage",
+				Details:       map[string]any{"direction": "input"},
+			}},
+		},
+	}
+
+	results := validationsToPriorResults(messages)
+	require.Len(t, results, 1)
+	results[0].Details["direction"] = "output"
+
+	assert.Equal(t, "input", messages[0].Validations[0].Details["direction"],
+		"mutating a prior result must not rewrite the message's validation")
+}
+
+// TestValidationsToPriorResults_NoDetailsStaysNil keeps a validation without
+// details from gaining an empty map, which would marshal a "details" key onto
+// every result that never had one.
+func TestValidationsToPriorResults_NoDetailsStaysNil(t *testing.T) {
+	messages := []types.Message{
+		{
+			Role:        "assistant",
+			Validations: []types.ValidationResult{{ValidatorType: "max_length", Passed: true}},
+		},
+	}
+
+	results := validationsToPriorResults(messages)
+	require.Len(t, results, 1)
+	assert.Nil(t, results[0].Details)
+}
+
 func TestValidationsToPriorResults_NoValidations(t *testing.T) {
 	messages := []types.Message{
 		types.NewAssistantMessage("hi"),

--- a/runtime/evals/handlers/guardrail_triggered.go
+++ b/runtime/evals/handlers/guardrail_triggered.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 )
 
 // GuardrailTriggeredHandler checks if a specific eval or guardrail
@@ -16,8 +17,27 @@ import (
 // PriorResults by BuildEvalContext, so all guardrail outcomes are
 // available through a single lookup path.
 //
-// Params: validator_type string, should_trigger bool (default true).
+// Params: validator_type string, should_trigger bool (default true),
+// direction string (optional).
+//
+// direction narrows the search to firings the guardrail recorder stamped with
+// that side: "input" (judged the user's message, before the call) or "output"
+// (judged the assistant response). Omitted — or "both" — matches a firing in
+// either direction, which is the historical behavior and stays byte-identical.
+// Set it when an input and an output guardrail of the same eval type are both
+// declared: without it only the last recorded firing is reachable, so neither
+// can be targeted (#1718).
 type GuardrailTriggeredHandler struct{}
+
+const (
+	// keyDirection is both the param name this handler filters on and the key
+	// the guardrail recorder stamps into a ValidationResult's details. They are
+	// deliberately the same word: the assertion names the side the same way the
+	// guardrail declaration does.
+	keyDirection = "direction"
+	// keyTriggered is the reported key naming whether the validator fired.
+	keyTriggered = "triggered"
+)
 
 // Type returns the eval type identifier.
 func (h *GuardrailTriggeredHandler) Type() string { return "guardrail_triggered" }
@@ -41,33 +61,36 @@ func (h *GuardrailTriggeredHandler) Eval(
 	if v, ok := params["should_trigger"].(bool); ok {
 		shouldTrigger = v
 	}
+	direction := directionFilter(params)
 
 	// Check PriorResults — includes both earlier evals in this batch and
 	// pipeline-level guardrail results seeded by BuildEvalContext.
-	if prior := findPriorResult(evalCtx.PriorResults, validatorType); prior != nil {
+	if prior := findPriorResult(evalCtx.PriorResults, validatorType, direction); prior != nil {
 		triggered := prior.Score != nil && *prior.Score < 1.0
-		return h.buildResult(validatorType, triggered, shouldTrigger), nil
+		return h.buildResult(validatorType, direction, triggered, shouldTrigger), nil
 	}
 
 	// Not found.
 	passed := !shouldTrigger
-	msg := fmt.Sprintf("expected validator %q to run but it did not", validatorType)
+	subject := describeValidator(validatorType, direction)
+	msg := fmt.Sprintf("expected validator %s to run but it did not", subject)
 	if passed {
-		msg = fmt.Sprintf("validator %q did not run (as expected)", validatorType)
+		msg = fmt.Sprintf("validator %s did not run (as expected)", subject)
 	}
 	return &evals.EvalResult{
 		Type:        h.Type(),
 		Score:       boolScore(passed),
 		Explanation: msg,
-		Value:       map[string]any{"triggered": false, "validator_type": validatorType},
+		Value:       triggeredValue(validatorType, direction, false),
 	}, nil
 }
 
 // buildResult constructs the eval result from triggered/shouldTrigger.
 func (h *GuardrailTriggeredHandler) buildResult(
-	validatorType string, triggered, shouldTrigger bool,
+	validatorType, direction string, triggered, shouldTrigger bool,
 ) *evals.EvalResult {
 	passed := shouldTrigger == triggered
+	subject := describeValidator(validatorType, direction)
 	if !passed {
 		action := "fail"
 		if !shouldTrigger {
@@ -76,28 +99,86 @@ func (h *GuardrailTriggeredHandler) buildResult(
 		return &evals.EvalResult{
 			Type:        h.Type(),
 			Score:       boolScore(false),
-			Explanation: fmt.Sprintf("expected validator %q to %s but it did not", validatorType, action),
-			Value:       map[string]any{"triggered": triggered, "validator_type": validatorType},
+			Explanation: fmt.Sprintf("expected validator %s to %s but it did not", subject, action),
+			Value:       triggeredValue(validatorType, direction, triggered),
 		}
 	}
 
+	details := map[string]any{"validator": validatorType, keyTriggered: triggered}
+	if direction != "" {
+		details[keyDirection] = direction
+	}
 	return &evals.EvalResult{
 		Type:        h.Type(),
 		Score:       boolScore(true),
-		Explanation: fmt.Sprintf("validator %q behaved as expected", validatorType),
-		Value:       map[string]any{"triggered": triggered, "validator_type": validatorType},
-		Details:     map[string]any{"validator": validatorType, "triggered": triggered},
+		Explanation: fmt.Sprintf("validator %s behaved as expected", subject),
+		Value:       triggeredValue(validatorType, direction, triggered),
+		Details:     details,
 	}
 }
 
-// findPriorResult searches PriorResults for a matching eval by Type or EvalID.
-func findPriorResult(results []evals.EvalResult, validatorType string) *evals.EvalResult {
+// triggeredValue builds the reported value map, naming the direction only when
+// the assertion asked for one so an unqualified assertion reports exactly what
+// it always did.
+func triggeredValue(validatorType, direction string, triggered bool) map[string]any {
+	value := map[string]any{keyTriggered: triggered, "validator_type": validatorType}
+	if direction != "" {
+		value[keyDirection] = direction
+	}
+	return value
+}
+
+// describeValidator names the validator in an explanation, including the
+// direction when one was requested — a direction-qualified assertion that finds
+// nothing must say which side it looked at, otherwise the failure reads as "the
+// guardrail never ran" when in fact it ran on the other side.
+func describeValidator(validatorType, direction string) string {
+	if direction == "" {
+		return fmt.Sprintf("%q", validatorType)
+	}
+	return fmt.Sprintf("%q (direction %q)", validatorType, direction)
+}
+
+// findPriorResult searches PriorResults for a matching eval by Type or EvalID,
+// newest first.
+//
+// direction, when non-empty, additionally requires the result's
+// Details["direction"] to equal it. That key is stamped by the pipeline's
+// guardrail recorder and carried into PriorResults by validationsToPriorResults.
+// A result without the key — an ordinary eval, or any prior result from a
+// non-guardrail source — never satisfies a direction-qualified search: reporting
+// it would claim a side the recorder never asserted.
+func findPriorResult(results []evals.EvalResult, validatorType, direction string) *evals.EvalResult {
 	for i := len(results) - 1; i >= 0; i-- {
-		if results[i].Type == validatorType || results[i].EvalID == validatorType {
-			return &results[i]
+		if results[i].Type != validatorType && results[i].EvalID != validatorType {
+			continue
 		}
+		if direction != "" && !hasDirection(results[i].Details, direction) {
+			continue
+		}
+		return &results[i]
 	}
 	return nil
+}
+
+// hasDirection reports whether a prior result was recorded for the given side.
+func hasDirection(details map[string]any, direction string) bool {
+	d, _ := details[keyDirection].(string)
+	return d == direction
+}
+
+// directionFilter reads the optional 'direction' param.
+//
+// Returns "" — match any direction, the pre-#1718 behavior — when the param is
+// absent, empty, not a string, or "both". "both" is accepted because that is a
+// legal direction on the guardrail *declaration*, but a firing is always
+// recorded as one side or the other, so as a filter it can only mean "either".
+func directionFilter(params map[string]any) string {
+	d, _ := params[keyDirection].(string)
+	if d == hooks.DirectionBoth {
+		return ""
+	}
+	return d
 }
 
 func extractValidatorType(params map[string]any) string {
@@ -109,12 +190,34 @@ func extractValidatorType(params map[string]any) string {
 }
 
 // ValidateParams checks that the required 'validator_type' (or alias
-// 'validator') param is set to a non-empty string.
+// 'validator') param is set to a non-empty string, and that 'direction' — if
+// present — names a side the guardrail recorder can actually stamp.
+//
+// A bad direction is an error here rather than a warning-and-fallback (which is
+// what the guardrail factory does with the same param) because the failure modes
+// are opposite: dropping a guardrail leaves a conversation unprotected, whereas
+// an assertion with a misspelled direction silently matches nothing and reports
+// "the guardrail never fired" — a green test that checks nothing.
 func (h *GuardrailTriggeredHandler) ValidateParams(params map[string]any) error {
 	if extractValidatorType(params) == "" {
 		return fmt.Errorf(
 			"%s requires a non-empty 'validator_type' (or 'validator') string param",
 			h.Type())
 	}
-	return nil
+	raw, present := params[keyDirection]
+	if !present || raw == nil {
+		return nil
+	}
+	d, ok := raw.(string)
+	if !ok {
+		return fmt.Errorf("%s: 'direction' must be a string, got %T", h.Type(), raw)
+	}
+	switch d {
+	case "", hooks.DirectionInput, hooks.DirectionOutput, hooks.DirectionBoth:
+		return nil
+	default:
+		return fmt.Errorf(
+			"%s: unknown 'direction' %q (want %q, %q or %q)",
+			h.Type(), d, hooks.DirectionInput, hooks.DirectionOutput, hooks.DirectionBoth)
+	}
 }

--- a/runtime/evals/handlers/guardrail_triggered_test.go
+++ b/runtime/evals/handlers/guardrail_triggered_test.go
@@ -2,9 +2,11 @@ package handlers
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
 func TestGuardrailTriggeredHandler_Type(t *testing.T) {
@@ -154,6 +156,282 @@ func TestGuardrailTriggered_DefaultShouldTriggerTrue(t *testing.T) {
 	}
 	if result.Score == nil || *result.Score != 1.0 {
 		t.Fatalf("expected pass with default should_trigger=true: %s", result.Explanation)
+	}
+}
+
+// bothDirectionsFired is the situation the direction param exists for: one eval
+// type declared as an input guardrail AND as an output guardrail, so the
+// transcript carries two firings that differ only in the side they judged. The
+// input one fired (score 0); the output one did not (score 1).
+func bothDirectionsFired() []evals.EvalResult {
+	return []evals.EvalResult{
+		{Type: "pii_leakage", Score: boolScore(false), Details: map[string]any{"direction": "input"}},
+		{Type: "pii_leakage", Score: boolScore(true), Details: map[string]any{"direction": "output"}},
+	}
+}
+
+// TestGuardrailTriggered_DirectionSelectsInputAmongBothDirections pins that
+// direction picks a specific firing rather than the most recent one.
+//
+// The no-direction case is asserted alongside deliberately: it reaches the
+// output entry (the last match) and therefore fails, so the direction filter is
+// demonstrably what changes the outcome. Delete the filter and the first
+// assertion fails.
+func TestGuardrailTriggered_DirectionSelectsInputAmongBothDirections(t *testing.T) {
+	h := &GuardrailTriggeredHandler{}
+	evalCtx := &evals.EvalContext{PriorResults: bothDirectionsFired()}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"validator_type": "pii_leakage",
+		"should_trigger": true,
+		"direction":      "input",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Score == nil || *result.Score != 1.0 {
+		t.Fatalf("direction=input must select the input firing: %s", result.Explanation)
+	}
+
+	unfiltered, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"validator_type": "pii_leakage",
+		"should_trigger": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unfiltered.Score == nil || *unfiltered.Score != 0.0 {
+		t.Fatal("without direction the last match (the output entry, which did not fire) must still win")
+	}
+}
+
+// TestGuardrailTriggered_DirectionSelectsOutputAmongBothDirections is the mirror:
+// a filter hardwired to "the input one" would pass the test above and fail here.
+func TestGuardrailTriggered_DirectionSelectsOutputAmongBothDirections(t *testing.T) {
+	h := &GuardrailTriggeredHandler{}
+	evalCtx := &evals.EvalContext{PriorResults: bothDirectionsFired()}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"validator_type": "pii_leakage",
+		"should_trigger": false,
+		"direction":      "output",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Score == nil || *result.Score != 1.0 {
+		t.Fatalf("direction=output must select the output entry, which did not fire: %s", result.Explanation)
+	}
+
+	// And it must report that entry's outcome, not the input entry's.
+	triggered, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"validator_type": "pii_leakage",
+		"should_trigger": true,
+		"direction":      "output",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if triggered.Score == nil || *triggered.Score != 0.0 {
+		t.Fatal("the output entry did not fire, so should_trigger=true must fail")
+	}
+}
+
+// TestGuardrailTriggered_DirectionSkipsResultsWithoutDirection pins that a prior
+// result carrying no direction never satisfies a direction-qualified assertion.
+// Treating a missing key as a match would report an ordinary eval result — or an
+// output firing recorded before the key existed — as an input firing.
+func TestGuardrailTriggered_DirectionSkipsResultsWithoutDirection(t *testing.T) {
+	h := &GuardrailTriggeredHandler{}
+	evalCtx := &evals.EvalContext{
+		PriorResults: []evals.EvalResult{
+			{Type: "banned_words", Score: boolScore(false)},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"validator_type": "banned_words",
+		"should_trigger": true,
+		"direction":      "input",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Score == nil || *result.Score != 0.0 {
+		t.Fatal("a result without a recorded direction must not match a direction-qualified search")
+	}
+	if !strings.Contains(result.Explanation, `direction "input"`) {
+		t.Fatalf("the failure must name the side it looked at, got: %s", result.Explanation)
+	}
+}
+
+// TestGuardrailTriggered_DirectionBothMatchesEitherSide pins that "both" — legal
+// on the guardrail declaration — means "either side" here, since a firing is
+// only ever recorded as input or output and would otherwise match nothing.
+func TestGuardrailTriggered_DirectionBothMatchesEitherSide(t *testing.T) {
+	h := &GuardrailTriggeredHandler{}
+	evalCtx := &evals.EvalContext{
+		PriorResults: []evals.EvalResult{
+			{Type: "pii_leakage", Score: boolScore(false), Details: map[string]any{"direction": "output"}},
+		},
+	}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"validator_type": "pii_leakage",
+		"should_trigger": true,
+		"direction":      "both",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Score == nil || *result.Score != 1.0 {
+		t.Fatalf("direction=both must match an output firing: %s", result.Explanation)
+	}
+}
+
+// TestGuardrailTriggered_ReportsDirectionOnlyWhenRequested pins that the
+// reported value gains a direction key exactly when the assertion asked for one.
+// guardrail_triggered is widely declared without direction; stamping one
+// unconditionally would change what every existing scenario reports.
+func TestGuardrailTriggered_ReportsDirectionOnlyWhenRequested(t *testing.T) {
+	h := &GuardrailTriggeredHandler{}
+	evalCtx := &evals.EvalContext{PriorResults: bothDirectionsFired()}
+
+	qualified, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"validator_type": "pii_leakage",
+		"should_trigger": true,
+		"direction":      "input",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, _ := qualified.Value.(map[string]any)
+	if value["direction"] != "input" {
+		t.Fatalf("a direction-qualified result must report the side, got %v", qualified.Value)
+	}
+	if qualified.Details["direction"] != "input" {
+		t.Fatalf("details must name the side too, got %v", qualified.Details)
+	}
+
+	plain, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"validator_type": "pii_leakage",
+		"should_trigger": false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plainValue, _ := plain.Value.(map[string]any)
+	if _, present := plainValue["direction"]; present {
+		t.Fatalf("an unqualified assertion must not invent a direction, got %v", plain.Value)
+	}
+	if _, present := plain.Details["direction"]; present {
+		t.Fatalf("an unqualified assertion must not invent a direction in details, got %v", plain.Details)
+	}
+}
+
+// TestGuardrailTriggered_ObservesFiringThroughBuildEvalContext drives the join
+// the design flagged as unpinned: message.Validations → BuildEvalContext →
+// PriorResults → this handler. Both halves have their own tests; before #1718
+// nothing exercised the bridge, and it dropped Details on the way across.
+func TestGuardrailTriggered_ObservesFiringThroughBuildEvalContext(t *testing.T) {
+	messages := []types.Message{
+		types.NewUserMessage("please arrange a wire transfer"),
+		{
+			Role:    "assistant",
+			Content: "I can't help with that.",
+			Validations: []types.ValidationResult{{
+				ValidatorType: "banned_words",
+				Passed:        false,
+				Details:       map[string]any{"direction": "input", "reason": "matched \"wire transfer\""},
+			}},
+		},
+	}
+
+	evalCtx := evals.BuildEvalContext(messages, 0, "s1", "chat", nil)
+	h := &GuardrailTriggeredHandler{}
+
+	result, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"validator_type": "banned_words",
+		"should_trigger": true,
+		"direction":      "input",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Score == nil || *result.Score != 1.0 {
+		t.Fatalf("an input firing must be observable through PriorResults: %s", result.Explanation)
+	}
+
+	// Discriminating: the same firing must not answer for the output side.
+	wrongSide, err := h.Eval(context.Background(), evalCtx, map[string]any{
+		"validator_type": "banned_words",
+		"should_trigger": true,
+		"direction":      "output",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wrongSide.Score == nil || *wrongSide.Score != 0.0 {
+		t.Fatal("an input firing must not satisfy a direction=output assertion")
+	}
+}
+
+// TestGuardrailTriggered_DirectionDisambiguatesThroughBuildEvalContext is the
+// case the change exists for, driven through the real bridge: one eval type
+// recorded on both sides. Without the direction filter only the last entry is
+// reachable, so the input assertion below cannot pass.
+//
+// The two validations are stamped on one message rather than produced by a live
+// pipeline because an input firing blocks the provider call, so the output
+// guardrail never runs in the same turn — the transcript, not the stage, is what
+// this contract is about.
+func TestGuardrailTriggered_DirectionDisambiguatesThroughBuildEvalContext(t *testing.T) {
+	messages := []types.Message{
+		types.NewUserMessage("my SSN is 123-45-6789"),
+		{
+			Role:    "assistant",
+			Content: "I can't help with that.",
+			Validations: []types.ValidationResult{
+				{
+					ValidatorType: "pii_leakage",
+					Passed:        false,
+					Details:       map[string]any{"direction": "input"},
+				},
+				{
+					ValidatorType: "pii_leakage",
+					Passed:        true,
+					Details:       map[string]any{"direction": "output"},
+				},
+			},
+		},
+	}
+
+	evalCtx := evals.BuildEvalContext(messages, 0, "s1", "chat", nil)
+	h := &GuardrailTriggeredHandler{}
+
+	cases := []struct {
+		name      string
+		direction string
+		want      float64
+	}{
+		{"input side fired", "input", 1.0},
+		{"output side did not fire", "output", 0.0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params := map[string]any{
+				"validator_type": "pii_leakage",
+				"should_trigger": true,
+				"direction":      tc.direction,
+			}
+			result, err := h.Eval(context.Background(), evalCtx, params)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Score == nil || *result.Score != tc.want {
+				t.Fatalf("want score %v, got %v (%s)", tc.want, result.Score, result.Explanation)
+			}
+		})
 	}
 }
 

--- a/runtime/evals/handlers/param_validator_test.go
+++ b/runtime/evals/handlers/param_validator_test.go
@@ -79,4 +79,23 @@ func TestGuardrailTriggeredValidateParams(t *testing.T) {
 	err := h.ValidateParams(map[string]any{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "validator_type")
+
+	// direction is optional, and accepts exactly the sides the guardrail
+	// factory accepts.
+	for _, d := range []string{"input", "output", "both"} {
+		require.NoErrorf(t, h.ValidateParams(map[string]any{
+			"validator_type": "pii_leakage", "direction": d,
+		}), "direction %q must be accepted", d)
+	}
+
+	// A typo must not be accepted: an unfiltered fallback would silently
+	// assert on the wrong side, and a filter that matches nothing reports
+	// "the guardrail never fired" — a test that checks nothing either way.
+	err = h.ValidateParams(map[string]any{"validator_type": "pii_leakage", "direction": "inpt"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inpt")
+
+	err = h.ValidateParams(map[string]any{"validator_type": "pii_leakage", "direction": 1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "direction")
 }

--- a/runtime/hooks/guardrails/adapter.go
+++ b/runtime/hooks/guardrails/adapter.go
@@ -166,18 +166,40 @@ func (a *GuardrailHookAdapter) AfterCall(
 // evalParams returns the params the inner handler should see, plus the
 // thresholds this adapter applies itself.
 //
-// Two things are load-bearing. Defaults and legacy-name normalization run
-// first, so a threshold declared under an aliased name is still found. And the
+// Three things are load-bearing. Defaults and legacy-name normalization run
+// first, so a threshold declared under an aliased name is still found. The
 // threshold keys are stripped before the handler sees them: they are wrapper
 // params by design, and several handler families call rejectThresholdParams,
 // which returns an error result scoring 0 — read by the guardrail as "block".
 // Forwarding a threshold therefore turned the guardrail into an always-block
 // instead of merely ignoring the param (#1707).
+//
+// "direction" is stripped for the same reason. It selects which phase this
+// adapter evaluates in, and it is already consumed — a.direction. Once
+// guardrail_triggered gained a direction param of its own, meaning "match a
+// firing recorded on that side", forwarding the wrapper's copy silently
+// re-purposed it and made the guardrail conclude nothing had fired (#1718).
 func (a *GuardrailHookAdapter) evalParams() (map[string]any, evals.ScoreThresholds) {
 	params := evals.ApplyDefaults(a.evalType, a.params)
 	params = evals.NormalizeParams(a.evalType, params)
 	thresholds := evals.ExtractScoreThresholds(params)
-	return evals.StripScoreThresholds(params), thresholds
+	return stripDirection(evals.StripScoreThresholds(params)), thresholds
+}
+
+// stripDirection returns params without the wrapper's "direction" key. The
+// input map is never mutated: adapters share their params across turns.
+func stripDirection(params map[string]any) map[string]any {
+	if _, present := params["direction"]; !present {
+		return params
+	}
+	stripped := make(map[string]any, len(params))
+	for k, v := range params {
+		if k == "direction" {
+			continue
+		}
+		stripped[k] = v
+	}
+	return stripped
 }
 
 // evaluate runs the handler and converts the EvalResult to a Decision.

--- a/runtime/hooks/guardrails/adapter_test.go
+++ b/runtime/hooks/guardrails/adapter_test.go
@@ -322,6 +322,48 @@ func TestGuardrailHookAdapter_ParamsPassedToHandler(t *testing.T) {
 	}
 }
 
+// TestGuardrailHookAdapter_DirectionNotForwardedToHandler pins that the
+// wrapper's own "direction" does not reach the inner handler.
+//
+// It selects the phase this adapter evaluates in and is consumed here. It is
+// also a param guardrail_triggered now reads, meaning "match a firing recorded
+// on that side" — forwarding the wrapper's copy silently re-purposes it, and
+// that guardrail then finds no firing at all (#1718).
+func TestGuardrailHookAdapter_DirectionNotForwardedToHandler(t *testing.T) {
+	var capturedParams map[string]any
+	handler := &capturingHandler{
+		typeName: "test_direction",
+		result:   &evals.EvalResult{Score: floatPtr(1.0)},
+		capture:  &capturedParams,
+	}
+	params := map[string]any{
+		"validator_type": "banned_words",
+		"direction":      "output",
+	}
+	adapter := &GuardrailHookAdapter{
+		handler:   handler,
+		evalType:  "test_direction",
+		params:    params,
+		direction: "output",
+	}
+
+	resp := &hooks.ProviderResponse{Message: types.Message{Content: "test"}}
+	adapter.AfterCall(context.Background(), nil, resp)
+
+	if capturedParams == nil {
+		t.Fatal("params were not passed to handler")
+	}
+	if _, present := capturedParams["direction"]; present {
+		t.Errorf("the wrapper's direction must not reach the handler, got %v", capturedParams)
+	}
+	if capturedParams["validator_type"] != "banned_words" {
+		t.Errorf("stripping direction must leave every other param, got %v", capturedParams)
+	}
+	if _, present := params["direction"]; !present {
+		t.Error("the adapter's own params map must not be mutated — it is reused every turn")
+	}
+}
+
 // capturingHandler records the params passed to Eval.
 type capturingHandler struct {
 	typeName string

--- a/sdk/guardrail_assertion_bridge_test.go
+++ b/sdk/guardrail_assertion_bridge_test.go
@@ -1,0 +1,140 @@
+package sdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/guardrails"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+)
+
+// The guardrail → assertion bridge, driven end to end.
+//
+// Each end of this bridge had its own test — the stage stamps
+// msg.Validations["direction"], and validationsToPriorResults has unit tests —
+// but nothing drove the join, and the join dropped Details, so an assertion
+// could never see which side a guardrail judged (#1718).
+
+// guardrailTriggeredDefs builds the eval definition an Arena scenario would
+// declare for this assertion.
+func guardrailTriggeredDefs(params map[string]any) []evals.EvalDef {
+	return []evals.EvalDef{{
+		ID:      "guardrail-fired",
+		Type:    "guardrail_triggered",
+		Trigger: evals.TriggerEveryTurn,
+		Params:  params,
+	}}
+}
+
+// TestGuardrail_InputFiringIsObservableByAssertion fires a real input guardrail
+// through Open + Send, then asserts on it the way a test suite would: by running
+// guardrail_triggered over the resulting transcript. Nothing here reaches into
+// msg.Validations — the whole point is that the assertion path works.
+func TestGuardrail_InputFiringIsObservableByAssertion(t *testing.T) {
+	conv, err := Open(guardrailTestPack, "chat",
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithSkipSchemaValidation(),
+		WithGuardrail(
+			guardrails.Input("banned_words", map[string]any{
+				"words": []any{"wire transfer"},
+			}),
+		),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	ctx := context.Background()
+	_, err = conv.Send(ctx, "please arrange a wire transfer")
+	require.NoError(t, err)
+
+	messages := conv.Messages(ctx)
+	require.NotEmpty(t, messages)
+
+	results, err := Evaluate(ctx, EvaluateOpts{
+		EvalDefs: guardrailTriggeredDefs(map[string]any{
+			"validator_type": "banned_words",
+			"should_trigger": true,
+			"direction":      "input",
+		}),
+		Messages: messages,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NotNil(t, results[0].Score)
+	assert.Equal(t, 1.0, *results[0].Score,
+		"an input firing must be observable through PriorResults: %s", results[0].Explanation)
+}
+
+// TestGuardrail_InputFiringDoesNotAnswerForTheOutputSide is the discriminating
+// half. The same transcript, asserted against the other side, must fail — a
+// bridge that carried the firing but not its direction would pass both.
+func TestGuardrail_InputFiringDoesNotAnswerForTheOutputSide(t *testing.T) {
+	conv, err := Open(guardrailTestPack, "chat",
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithSkipSchemaValidation(),
+		WithGuardrail(
+			guardrails.Input("banned_words", map[string]any{
+				"words": []any{"wire transfer"},
+			}),
+		),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	ctx := context.Background()
+	_, err = conv.Send(ctx, "please arrange a wire transfer")
+	require.NoError(t, err)
+
+	results, err := Evaluate(ctx, EvaluateOpts{
+		EvalDefs: guardrailTriggeredDefs(map[string]any{
+			"validator_type": "banned_words",
+			"should_trigger": true,
+			"direction":      "output",
+		}),
+		Messages: conv.Messages(ctx),
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NotNil(t, results[0].Score)
+	assert.Equal(t, 0.0, *results[0].Score,
+		"the guardrail judged the input, so an output-qualified assertion must not pass")
+}
+
+// TestGuardrail_UnqualifiedAssertionStillSeesTheFiring pins the compatibility
+// half: the overwhelmingly common declaration omits direction, and must keep
+// matching a firing from either side exactly as before.
+func TestGuardrail_UnqualifiedAssertionStillSeesTheFiring(t *testing.T) {
+	conv, err := Open(guardrailTestPack, "chat",
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithSkipSchemaValidation(),
+		WithGuardrail(
+			guardrails.Input("banned_words", map[string]any{
+				"words": []any{"wire transfer"},
+			}),
+		),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	ctx := context.Background()
+	_, err = conv.Send(ctx, "please arrange a wire transfer")
+	require.NoError(t, err)
+
+	results, err := Evaluate(ctx, EvaluateOpts{
+		EvalDefs: guardrailTriggeredDefs(map[string]any{
+			"validator_type": "banned_words",
+			"should_trigger": true,
+		}),
+		Messages: conv.Messages(ctx),
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NotNil(t, results[0].Score)
+	assert.Equal(t, 1.0, *results[0].Score,
+		"an assertion without direction must behave as it always did: %s", results[0].Explanation)
+}


### PR DESCRIPTION
Closes #1718

## What was broken

`recordGuardrailFiring` stamps `details["direction"]` onto the `ValidationResult` it records, but `validationsToPriorResults` built `EvalResult{Type, Score}` and dropped `Details` entirely. `guardrail_triggered` therefore could see *that* a guardrail fired and never *which side* it judged — the distinction `PRE_LLM_GUARDRAILS_DESIGN.md` §4.5 exists to serve. §6 also flagged that nothing drives the bridge end to end: both ends had unit tests, the join had none.

## What changed

**1. `runtime/evals/context.go` — carry `Details` across.** `validationsToPriorResults` now copies each `ValidationResult.Details` into `EvalResult.Details`. Shallow-copied, not aliased: `PriorResults` is handed to arbitrary (including third-party) eval handlers, and an aliased map would let any of them rewrite the recorded message's validations. An empty/absent map stays nil.

**2. `runtime/evals/handlers/guardrail_triggered.go` — optional `direction` param.** Matching semantics, exactly:

| `direction` | Match rule |
|---|---|
| omitted, empty, non-string, or `both` | unchanged — newest prior result whose `Type` **or** `EvalID` equals `validator_type` |
| `input` / `output` | as above, **and** the result's `Details["direction"]` must equal it (string compare, exact) |

- A prior result carrying no `Details["direction"]` never satisfies a direction-qualified search — reporting it would claim a side the recorder never asserted.
- `both` means "either side" because a firing is only ever recorded as `input` or `output`; it is accepted so the value is legal in the same places it is legal on the guardrail declaration.
- When a direction is requested it is named in the explanation and added to `Value`/`Details`; when it is not, the reported shape is byte-identical to before.
- `ValidateParams` rejects a non-string or unrecognized `direction`. The guardrail *factory* deliberately warns-and-falls-back on the same param (erroring would drop a guardrail and fail open); an assertion has the opposite failure mode — a typo would silently match nothing and report "the guardrail never fired", a green test that checks nothing.

**3. `runtime/hooks/guardrails/adapter.go` — strip the wrapper's `direction`.** `evalParams` already strips the score thresholds it owns; `direction` is the same kind of param (it names the phase the adapter evaluates in, and is already consumed as `a.direction`). Forwarding it meant `guardrail_triggered` *used as a guardrail* re-read it as a filter and concluded nothing had fired — caught by the existing `TestGuardrailEnrichment_GuardrailTriggeredSeesPriorResults`.

**4. Docs.** `docs/src/content/docs/reference/checks.md` documents `direction` under Meta Checks, cross-linked to the guardrail-side `direction` section. No schema change: assertion `params` is a free-form object (`schemas/v1alpha1/common/assertions.json`) and `make schemas-check` passes unchanged.

## What the tests pin

End-to-end (`sdk/guardrail_assertion_bridge_test.go`) — a real input guardrail fires through `Open` + `Send`, then the transcript is asserted with `sdk.Evaluate` running `guardrail_triggered`; nothing reaches into `msg.Validations`:
- `direction: input` passes — fails if `Details` is dropped on the bridge.
- `direction: output` on the same transcript fails — a bridge that carried the firing but not its side would pass both.
- no `direction` still passes — the compatibility half.

Discrimination (`runtime/evals/handlers`) — one eval type recorded on both sides, driven through `BuildEvalContext`:
- `direction: input` selects the input firing; the same context with no `direction` reaches the output entry and fails, so the filter is demonstrably what changes the outcome (catches deleting the filter).
- `direction: output` selects the output entry (catches a filter hardwired to "input").
- a prior result with no direction does not match, and the failure explanation names the side it looked at.
- `both` matches an output firing; `direction` appears in `Value`/`Details` only when requested.

Bridge (`runtime/evals`) — `Details` carried across, the map is copied not aliased, and a validation without details still yields a nil `Details`.

Adapter (`runtime/hooks/guardrails`) — the wrapper's `direction` does not reach the inner handler, every other param survives, and the adapter's own params map is not mutated.

Each was mutation-checked: dropping `Details`, disabling the filter, and hardwiring the filter to `input` each fail the tests named above.

The producing side (`stages_provider.go`) is untouched.
