### PR TITLE
fix(guardrails): stream a blocked turn's canned text instead of withholding it

### DIFF
--- a/runtime/pipeline/stage/guardrail_blocked_stream_test.go
+++ b/runtime/pipeline/stage/guardrail_blocked_stream_test.go
@@ -1,0 +1,183 @@
+package stage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// A guardrail-blocked turn must stream like every other turn (#1716).
+//
+// The fixtures these tests build on (runProviderStage, assistantMessages,
+// enforceBeforeCallHook, denyAllProviderHook, redactionRecordingProvider) live
+// in stages_provider_hooks_test.go, alongside the rest of the provider-hook
+// coverage.
+
+const blockedTurnText = "I can't help with transfers."
+
+// newBlockedTurnStage builds a streaming ProviderStage whose input guardrail
+// enforces on every call, substituting blockedTurnText.
+func newBlockedTurnStage(t *testing.T) (*ProviderStage, *redactionRecordingProvider) {
+	t.Helper()
+
+	provider := &redactionRecordingProvider{
+		Provider:  mock.NewProvider("p", "m", false),
+		streaming: true,
+	}
+	reg := hooks.NewRegistry(hooks.WithProviderHook(&enforceBeforeCallHook{
+		reason:      "input blocked",
+		replacement: blockedTurnText,
+	}))
+	stage := NewProviderStageWithHooks(provider, nil, nil, &ProviderConfig{
+		MaxTokens: 100,
+	}, nil, reg)
+	return stage, provider
+}
+
+// splitTurnStream separates a turn's elements into the text deltas (in emission
+// order), the index of the first text delta, and the index of the first
+// assistant Message element; the indices are -1 when absent.
+//
+// The indices let a test assert the delta reaches the caller *before* the
+// complete message — the ordering StreamPipeline.accumulateResult relies on. It
+// appends text arriving after an assistant response onto that response's
+// content, so a delta emitted after the message would duplicate the reply.
+func splitTurnStream(elems []StreamElement) (deltas []string, firstText, firstMsg int) {
+	firstText, firstMsg = -1, -1
+	for i := range elems {
+		if elems[i].Text != nil && *elems[i].Text != "" {
+			if firstText == -1 {
+				firstText = i
+			}
+			deltas = append(deltas, *elems[i].Text)
+		}
+		if firstMsg == -1 && elems[i].Message != nil && elems[i].Message.Role == roleAssistant {
+			firstMsg = i
+		}
+	}
+	return deltas, firstText, firstMsg
+}
+
+// TestProviderStage_EnforcedPreCall_StreamsCannedTextExactlyOnce is the
+// regression for #1716: enforcement returns before startStreamingRequest, so no
+// chunk ever reached emitChunkElement and a blocked turn produced zero text
+// deltas — the caller saw nothing until the whole message arrived at the end.
+//
+// The assertions cover the whole delivery, not merely that a delta exists:
+// joining the deltas pins that they concatenate to exactly the canned text (a
+// second emission would double it), and the assistant message carries it once
+// more only as the turn's complete message, exactly as on an unblocked turn.
+func TestProviderStage_EnforcedPreCall_StreamsCannedTextExactlyOnce(t *testing.T) {
+	stage, provider := newBlockedTurnStage(t)
+
+	elems, err := runProviderStage(t, stage, "please arrange a wire transfer")
+	require.NoError(t, err)
+	require.Equal(t, 0, provider.callCount(),
+		"the blocked turn must still cost zero tokens")
+
+	deltas, firstText, firstMsg := splitTurnStream(elems)
+
+	require.NotEmpty(t, deltas,
+		"a blocked turn must stream its reply, not deliver it only at the end")
+	assert.Equal(t, blockedTurnText, strings.Join(deltas, ""),
+		"the streamed deltas must concatenate to the canned text exactly once")
+
+	msgs := assistantMessages(elems)
+	require.Len(t, msgs, 1, "the canned reply must be emitted as exactly one assistant message")
+	assert.Equal(t, blockedTurnText, msgs[0].Content)
+
+	require.NotEqual(t, -1, firstMsg, "the turn must still emit its complete message")
+	assert.Less(t, firstText, firstMsg,
+		"the delta must precede the complete message, or accumulateResult appends it "+
+			"onto the response and the caller gets the reply twice")
+}
+
+// TestProviderStage_EnforcedPreCall_TextElementIsMarked pins the element-level
+// metadata of the blocked turn's delta (PRE_LLM_GUARDRAILS_DESIGN.md §4.1.2).
+//
+// StreamingDelta is load-bearing for delivering the reply once, not decoration:
+// a speech-out stage skips deltas and speaks the complete Message, so an
+// unmarked delta would be synthesized in addition to the message and the blocked
+// reply would be spoken twice. FinishReason is the marker a consumer reading
+// element metadata (rather than Message.FinishReason) needs to tell a policy
+// block from a model reply.
+func TestProviderStage_EnforcedPreCall_TextElementIsMarked(t *testing.T) {
+	stage, _ := newBlockedTurnStage(t)
+
+	elems, err := runProviderStage(t, stage, "please arrange a wire transfer")
+	require.NoError(t, err)
+
+	var textElem *StreamElement
+	for i := range elems {
+		if elems[i].Text != nil && *elems[i].Text != "" {
+			textElem = &elems[i]
+			break
+		}
+	}
+	require.NotNil(t, textElem, "the blocked turn must emit a text element")
+
+	assert.True(t, textElem.Meta.StreamingDelta,
+		"the canned text must be marked a streaming delta so a speech stage speaks "+
+			"the message once instead of the delta and the message")
+	require.NotNil(t, textElem.Meta.FinishReason,
+		"the blocked turn's element must carry the finish reason (§4.1.2)")
+	assert.Equal(t, types.FinishReasonSafety, *textElem.Meta.FinishReason)
+}
+
+// TestProviderStage_CleanStreamingTurn_DeltasAreNotMarkedSafety is the
+// discriminating half: a fix that stamped FinishReasonSafety on every streamed
+// element would satisfy the test above while making every normal turn look
+// policy-blocked.
+func TestProviderStage_CleanStreamingTurn_DeltasAreNotMarkedSafety(t *testing.T) {
+	provider := &redactionRecordingProvider{
+		Provider:  mock.NewProvider("p", "m", false),
+		streaming: true,
+	}
+	stage := NewProviderStageWithHooks(provider, nil, nil, &ProviderConfig{
+		MaxTokens: 100,
+	}, nil, hooks.NewRegistry())
+
+	elems, err := runProviderStage(t, stage, "hello")
+	require.NoError(t, err)
+	require.Positive(t, provider.callCount(), "a clean turn must reach the provider")
+
+	deltas, _, _ := splitTurnStream(elems)
+	require.NotEmpty(t, deltas, "a clean streaming turn must produce text deltas")
+
+	for i := range elems {
+		if elems[i].Text == nil || elems[i].Meta.FinishReason == nil {
+			continue
+		}
+		assert.NotEqual(t, types.FinishReasonSafety, *elems[i].Meta.FinishReason,
+			"an unblocked turn's elements must not be marked safety-blocked")
+	}
+}
+
+// TestProviderStage_DeniedPreCall_EmitsNoText pins that the deny path — which
+// aborts the pipeline with HookDeniedError instead of substituting a reply —
+// still streams nothing. Only an Enforced decision produces assistant text;
+// streaming text for a denial would hand the caller content from a failed turn.
+func TestProviderStage_DeniedPreCall_EmitsNoText(t *testing.T) {
+	provider := &redactionRecordingProvider{
+		Provider:  mock.NewProvider("p", "m", false),
+		streaming: true,
+	}
+	reg := hooks.NewRegistry(hooks.WithProviderHook(&denyAllProviderHook{
+		reason: "streaming blocked",
+	}))
+	stage := NewProviderStageWithHooks(provider, nil, nil, &ProviderConfig{
+		MaxTokens: 100,
+	}, nil, reg)
+
+	elems, err := runProviderStage(t, stage, "hello")
+	require.Error(t, err)
+
+	deltas, _, _ := splitTurnStream(elems)
+	assert.Empty(t, deltas, "a denied turn must not stream any assistant text")
+}

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -1182,6 +1182,11 @@ func (s *ProviderStage) executeStreamingRound(
 	if blocked, handled, err := s.runBeforeCallHooks(
 		ctx, params.messages, params.systemPrompt, params.round, params.metadata,
 	); handled {
+		if err == nil {
+			if emitErr := s.emitBlockedTurnText(ctx, &blocked, output); emitErr != nil {
+				return blocked, false, emitErr
+			}
+		}
 		return blocked, false, err
 	}
 
@@ -1872,6 +1877,44 @@ func (s *ProviderStage) runBeforeCallHooks(
 	blocked := s.blockedMessage(hookReq, d)
 	s.recordGuardrailFiring(&blocked, d, hooks.DirectionInput, time.Since(hookStart))
 	return blocked, true, nil
+}
+
+// emitBlockedTurnText streams the canned assistant text of a guardrail-blocked
+// turn as a text element, so a blocked turn reaches the caller the same way
+// every unblocked turn does. Enforcement returns before startStreamingRequest,
+// so no chunk ever passes through emitChunkElement: without this the caller
+// received nothing at all until the whole message landed at once at the end of
+// the turn, and a UI rendering text deltas showed an empty reply (#1716).
+//
+// The element is shaped exactly like the element a real final chunk produces
+// (emitChunkElement), which is what keeps the reply delivered exactly once:
+//
+//   - Meta.StreamingDelta marks it as the live-text feed. A speech-out stage
+//     skips deltas and speaks the complete Message (stages_speech.go,
+//     stages_tts.go), so the canned reply is synthesized once; and
+//     accumulateResult only folds text that arrives after the assistant message,
+//     which this element precedes. Consumers that render deltas concatenate them
+//     to exactly the Message content, as on any other turn.
+//   - Meta.FinishReason carries the message's finish reason
+//     (types.FinishReasonSafety), the element-level marker
+//     PRE_LLM_GUARDRAILS_DESIGN.md §4.1.2 calls for. It mirrors how the duplex
+//     stage marks an interrupted turn, and lets a consumer reading element
+//     metadata rather than the message tell a policy block from a model reply.
+func (s *ProviderStage) emitBlockedTurnText(
+	ctx context.Context, blocked *types.Message, output chan<- StreamElement,
+) error {
+	if blocked == nil || blocked.Content == "" {
+		return nil
+	}
+	elem := NewTextElement(blocked.Content)
+	elem.Timestamp = timeNow()
+	elem.Priority = PriorityNormal
+	elem.Meta.StreamingDelta = true
+	if blocked.FinishReason != "" {
+		fr := blocked.FinishReason
+		elem.Meta.FinishReason = &fr
+	}
+	return sendStreamElement(ctx, elem, output)
 }
 
 // applyEnforcedResponse folds an enforcing AfterCall decision into the round's

--- a/sdk/guardrail_e2e_test.go
+++ b/sdk/guardrail_e2e_test.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -212,6 +213,120 @@ func TestGuardrail_StreamingOutputBlockDoesNotLeakBannedContent(t *testing.T) {
 		"the banned pattern must not reach the caller")
 	assert.Equal(t, "I can't share that.", resp.Text(),
 		"the configured guardrail message must replace the model text")
+}
+
+// guardrailTurnDelivery is everything a caller of Stream() actually receives for
+// one turn: the ChunkText payloads in order, how many arrived, and the final
+// ChunkDone response. Named for this file to avoid colliding with the other
+// stream helpers in package sdk.
+type guardrailTurnDelivery struct {
+	deltas     []string
+	textChunks int
+	done       *Response
+}
+
+// joined is the text a UI rendering ChunkText would have displayed by the end of
+// the turn.
+func (d guardrailTurnDelivery) joined() string {
+	return strings.Join(d.deltas, "")
+}
+
+// drainGuardrailStream consumes a Stream() channel to completion. Draining fully
+// (rather than breaking at ChunkDone) is deliberate: a duplicate emission after
+// the terminal chunk would otherwise go unseen.
+func drainGuardrailStream(t *testing.T, ch <-chan StreamChunk) guardrailTurnDelivery {
+	t.Helper()
+
+	var got guardrailTurnDelivery
+	for chunk := range ch {
+		require.NoError(t, chunk.Error, "no chunk may carry an error")
+		switch chunk.Type {
+		case ChunkText:
+			got.textChunks++
+			got.deltas = append(got.deltas, chunk.Text)
+		case ChunkDone:
+			got.done = chunk.Message
+		case ChunkToolCall, ChunkMedia, ChunkClientTool:
+			// Not produced by these turns.
+		}
+	}
+	return got
+}
+
+// TestGuardrail_InputBlockStreamsCannedTextExactlyOnce is the user-visible
+// regression for #1716. An enforcing input guardrail skips the provider call
+// before startStreamingRequest, so the canned reply never passed through
+// emitChunkElement: a probe through this exact API saw `text chunk count = 0`
+// and then the whole message at once on ChunkDone. A UI rendering ChunkText
+// showed an empty reply for the entire turn.
+//
+// The pair of assertions is the point. Counting the chunks proves the text now
+// streams at all; comparing the *concatenation* of every delta against the
+// canned text proves the fix did not buy that by delivering the reply twice —
+// the specific hazard here, since the blocked turn's message element already
+// carries the same text.
+func TestGuardrail_InputBlockStreamsCannedTextExactlyOnce(t *testing.T) {
+	conv, err := Open(guardrailTestPack, "chat",
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithSkipSchemaValidation(),
+		WithGuardrail(
+			guardrails.Input("banned_words", map[string]any{
+				"words": []any{"wire transfer"},
+			}, guardrails.WithMessage("I can't help with transfers.")),
+		),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	got := drainGuardrailStream(t, conv.Stream(context.Background(), "please arrange a wire transfer"))
+
+	assert.Equal(t, 1, got.textChunks,
+		"a blocked turn must stream its reply — before the fix this was 0 and the "+
+			"caller saw nothing until ChunkDone")
+	assert.Equal(t, "I can't help with transfers.", got.joined(),
+		"every delta concatenated must equal the canned text exactly once, not twice")
+
+	require.NotNil(t, got.done, "the turn must still end with a ChunkDone")
+	assert.Equal(t, "I can't help with transfers.", got.done.Text(),
+		"the terminal response must carry the same reply, not the deltas appended to it")
+
+	// The streaming surface's own blocked-turn marker. Validations() is the
+	// signal that names WHICH guardrail fired, so it is worth pinning
+	// independently of Message().FinishReason — which answers only whether the
+	// turn was blocked, and is covered by
+	// TestGuardrail_InputBlockIsVisibleToStreamCaller above (#1715).
+	validations := got.done.Validations()
+	require.NotEmpty(t, validations,
+		"a Stream() caller must still be able to tell the turn was policy-blocked")
+	assert.Equal(t, "banned_words", validations[0].ValidatorType)
+	assert.Equal(t, "input", validations[0].Details["direction"])
+}
+
+// TestGuardrail_CleanTurnStreamsProviderTextOnce is the discriminating half: a
+// fix that emitted a synthetic delta on every turn — or that let the canned text
+// leak into unblocked turns — would pass the test above while doubling or
+// corrupting normal streaming.
+func TestGuardrail_CleanTurnStreamsProviderTextOnce(t *testing.T) {
+	conv, err := Open(guardrailTestPack, "chat",
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithSkipSchemaValidation(),
+		WithGuardrail(
+			guardrails.Input("banned_words", map[string]any{
+				"words": []any{"wire transfer"},
+			}, guardrails.WithMessage("I can't help with transfers.")),
+		),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	got := drainGuardrailStream(t, conv.Stream(context.Background(), "what is the capital of France?"))
+
+	require.Positive(t, got.textChunks, "a clean turn must stream the model's reply")
+	assert.NotContains(t, got.joined(), "I can't help with transfers.",
+		"the canned block message must never appear on an unblocked turn")
+	require.NotNil(t, got.done)
+	assert.Equal(t, got.done.Text(), got.joined(),
+		"the deltas of a clean turn must concatenate to exactly the final response")
 }
 
 // TestGuardrail_StreamingOutputAllowsCleanResponse is the discriminating half:


### PR DESCRIPTION
**Stacked on #1723** (`fix/1719-guardrail-validation-details-shape`). GitHub will retarget this to `main` when the parent merges — do not use `--delete-branch` on #1723 while this is open.

Closes #1716

## The bug

An enforcing `BeforeCall` guardrail returns before `startStreamingRequest`, so the canned assistant text never passes through `emitChunkElement`. A blocked turn produced **zero** text deltas. Probed through the public API before the fix:

```
text chunk count = 0
DONE text="I can't help with transfers."
```

The caller received nothing until the terminal `ChunkDone`, then the whole message at once. A UI rendering `ChunkText` showed an empty reply for the entire turn — unlike every unblocked turn.

## The fix

`emitBlockedTurnText` emits the canned text as an element shaped exactly like the one a real final chunk produces, and marks it:

- **`Meta.StreamingDelta`** — load-bearing, not decoration. A speech-out stage skips deltas and speaks the complete `Message`, so an unmarked delta would be synthesized *in addition to* the message and the blocked reply spoken twice.
- **`Meta.FinishReason`** — the element-level marker `PRE_LLM_GUARDRAILS_DESIGN.md` §4.1.2 calls for and which shipped unimplemented. A consumer reading element metadata rather than `Message.FinishReason` can now tell a policy block from a model reply.

## Avoiding double-delivery

This was the hazard to clear: the blocked turn's message element already carries the same text. The delta is emitted **before** the complete message, which is what `accumulateResult` relies on — it appends text arriving *after* an assistant response onto that response, so a delta emitted afterwards would duplicate the reply. `TestProviderStage_EnforcedPreCall_StreamsCannedTextExactlyOnce` asserts that ordering directly (`firstText < firstMsg`), not just that a delta exists.

## What the tests pin

- **SDK, user-visible** — `TestGuardrail_InputBlockStreamsCannedTextExactlyOnce` counts `ChunkText` chunks *and* asserts every delta concatenated equals the canned text exactly once. `TestGuardrail_CleanTurnStreamsProviderTextOnce` is the discriminating half.
- **Runtime** — delta/message ordering, element metadata, and `TestProviderStage_CleanStreamingTurn_DeltasAreNotMarkedSafety` (a fix stamping `FinishReasonSafety` on every element would otherwise pass).
- **Deny path** — `TestProviderStage_DeniedPreCall_EmitsNoText`: only `Enforced` streams text; a denial aborts the pipeline and must not hand the caller content from a failed turn.

Mutation-verified: neutering `emitBlockedTurnText` fails all three headline tests, the SDK one reporting `actual: 0` text chunks — reproducing the original probe exactly.

Note: `Message().FinishReason` on the streaming path is a separate defect fixed by #1721 (issue #1715); it is not addressed here, and the test comment says so.
