### PR TITLE
fix(sdk): let ValidatePack preflight see a custom eval registry

### DIFF
--- a/docs/src/content/docs/reference/checks.md
+++ b/docs/src/content/docs/reference/checks.md
@@ -808,7 +808,10 @@ control. Unusable *params* keep the warn-and-skip behavior so that one bad entry
 break the others, and so a pack authored against a newer runtime stays loadable.
 
 To surface every problem at once without opening a conversation, use `sdk.ValidatePack`,
-which dry-run constructs each validator and reports all issues together.
+which dry-run constructs each validator and reports all issues together. If your handlers
+come from a custom registry (`sdk.WithEvalRegistry`), use `sdk.ValidatePackWithRegistry`
+and pass the same registry — otherwise preflight resolves types against the built-in set
+only and reports your custom types as unknown even though `Open()` accepts them.
 
 For direct scenario invocation as a pass/fail assertion, wrap the safety primitive with `type: assertion` and set `min_score` on the wrapper. Putting `min_score` / `max_score` directly on a safety handler is rejected — see the [eval/assertion wrapper](#assertion-wrapper) for the canonical shape.
 

--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -365,6 +365,7 @@ All pack examples conform to the PromptPack Specification v1.1.0: https://github
   - [func \(e \*PackError\) Unwrap\(\) error](<#PackError.Unwrap>)
 - [type PackIssue](<#PackIssue>)
   - [func ValidatePack\(path string, skipSchemaValidation bool\) \(\[\]PackIssue, error\)](<#ValidatePack>)
+  - [func ValidatePackWithRegistry\(path string, skipSchemaValidation bool, registry \*evals.EvalTypeRegistry\) \(\[\]PackIssue, error\)](<#ValidatePackWithRegistry>)
   - [func \(p PackIssue\) String\(\) string](<#PackIssue.String>)
 - [type PackTemplate](<#PackTemplate>)
   - [func LoadTemplate\(packPath string, opts ...Option\) \(\*PackTemplate, error\)](<#LoadTemplate>)
@@ -4517,6 +4518,21 @@ When skipSchemaValidation is false \(the default for callers who pass the zero v
 Returns \(nil, nil\) if the pack is fully valid. Returns \(nil, err\) if the pack file is missing, unreadable, fails JSON parse, or fails schema validation \(when strict\). These are considered fatal and distinct from semantic issues. Returns \(issues, nil\) if the pack loads cleanly but has semantic problems \(unknown validator/eval types, missing required params\) the caller should address.
 
 This is a pre\-flight check for CI gates and operator tools. It runs the same handler\-level validation the SDK runs internally during Open\(\), exposed as a standalone function.
+
+Validator and eval types are resolved against the built\-in eval registry. Callers who supply their own handlers to Open\(\) via WithEvalRegistry must use ValidatePackWithRegistry instead, or preflight will report those types as unknown.
+
+<a name="ValidatePackWithRegistry"></a>
+### func ValidatePackWithRegistry
+
+```go
+func ValidatePackWithRegistry(path string, skipSchemaValidation bool, registry *evals.EvalTypeRegistry) ([]PackIssue, error)
+```
+
+ValidatePackWithRegistry is ValidatePack resolving every validator and eval type against the supplied registry instead of the built\-in default. Pass the registry the caller configured \(sdk.WithEvalRegistry\) so preflight knows the same custom handlers Open\(\) does; a nil registry means the default one, so ValidatePackWithRegistry\(path, skip, nil\) and ValidatePack\(path, skip\) are equivalent.
+
+Without this a pack validator or eval naming a custom eval type is reported as an unknown\-type issue even though Open\(\) with the matching WithEvalRegistry builds and enforces it — preflight and runtime disagreeing about the same pack, in the direction that cries wolf \(\#1725\).
+
+Everything else — the error/issue split, strict schema validation, the \(nil, nil\) fully\-valid result — is exactly as documented on ValidatePack.
 
 <a name="PackIssue.String"></a>
 ### func \(PackIssue\) String

--- a/sdk/validate_pack.go
+++ b/sdk/validate_pack.go
@@ -75,7 +75,33 @@ func (p PackIssue) String() string {
 // This is a pre-flight check for CI gates and operator tools. It runs
 // the same handler-level validation the SDK runs internally during
 // Open(), exposed as a standalone function.
+//
+// Validator and eval types are resolved against the built-in eval
+// registry. Callers who supply their own handlers to Open() via
+// WithEvalRegistry must use ValidatePackWithRegistry instead, or
+// preflight will report those types as unknown.
 func ValidatePack(path string, skipSchemaValidation bool) ([]PackIssue, error) {
+	return ValidatePackWithRegistry(path, skipSchemaValidation, nil)
+}
+
+// ValidatePackWithRegistry is ValidatePack resolving every validator and
+// eval type against the supplied registry instead of the built-in
+// default. Pass the registry the caller configured (sdk.WithEvalRegistry)
+// so preflight knows the same custom handlers Open() does; a nil registry
+// means the default one, so ValidatePackWithRegistry(path, skip, nil) and
+// ValidatePack(path, skip) are equivalent.
+//
+// Without this a pack validator or eval naming a custom eval type is
+// reported as an unknown-type issue even though Open() with the matching
+// WithEvalRegistry builds and enforces it — preflight and runtime
+// disagreeing about the same pack, in the direction that cries wolf
+// (#1725).
+//
+// Everything else — the error/issue split, strict schema validation, the
+// (nil, nil) fully-valid result — is exactly as documented on ValidatePack.
+func ValidatePackWithRegistry(
+	path string, skipSchemaValidation bool, registry *evals.EvalTypeRegistry,
+) ([]PackIssue, error) {
 	loaded, err := pack.Load(path, pack.LoadOptions{
 		SkipSchemaValidation: skipSchemaValidation,
 	})
@@ -83,7 +109,9 @@ func ValidatePack(path string, skipSchemaValidation bool) ([]PackIssue, error) {
 		return nil, err
 	}
 
-	registry := evals.NewEvalTypeRegistry()
+	// Resolved once: every validator and eval in a pack must be checked
+	// against the same handlers, and the default constructor is not free.
+	reg := evalRegistryOrDefault(registry)
 	var issues []PackIssue
 
 	// Per-prompt validators.
@@ -91,21 +119,33 @@ func ValidatePack(path string, skipSchemaValidation bool) ([]PackIssue, error) {
 		if promptDef == nil {
 			continue
 		}
-		issues = append(issues, validatePromptValidators(promptID, promptDef.Validators, registry)...)
+		issues = append(issues, validatePromptValidators(promptID, promptDef.Validators, reg)...)
 	}
 
 	// Pack-level evals (apply to all prompts, PromptID="").
-	issues = append(issues, validateEvalDefs("", loaded.Evals, registry)...)
+	issues = append(issues, validateEvalDefs("", loaded.Evals, reg)...)
 
 	// Per-prompt evals.
 	for promptID, promptDef := range loaded.Prompts {
 		if promptDef == nil {
 			continue
 		}
-		issues = append(issues, validateEvalDefs(promptID, promptDef.Evals, registry)...)
+		issues = append(issues, validateEvalDefs(promptID, promptDef.Evals, reg)...)
 	}
 
 	return issues, nil
+}
+
+// evalRegistryOrDefault resolves an optional caller-supplied registry. nil
+// means "the caller expressed no preference", which is the default registry
+// of built-in handlers — the behavior every ValidatePack caller had before a
+// registry could be threaded through. This mirrors the runtime's
+// guardrails.registryOrDefault, which is unexported.
+func evalRegistryOrDefault(registry *evals.EvalTypeRegistry) *evals.EvalTypeRegistry {
+	if registry != nil {
+		return registry
+	}
+	return evals.NewEvalTypeRegistry()
 }
 
 // validatePromptValidators dry-run constructs each enabled validator

--- a/sdk/validate_pack_registry_test.go
+++ b/sdk/validate_pack_registry_test.go
@@ -1,0 +1,195 @@
+package sdk_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/sdk"
+)
+
+// Regression coverage for https://github.com/AltairaLabs/PromptKit/issues/1725.
+//
+// After #1724, Open() resolves an eval-backed guardrail against the registry
+// supplied by sdk.WithEvalRegistry, so a pack validator naming a custom eval
+// type builds and enforces. ValidatePack could not do the same — it always
+// resolved against a freshly built default registry — so preflight reported a
+// pack the runtime happily accepts. The failure mode is a FALSE POSITIVE, so
+// these tests assert the issue is ABSENT, each paired with a control that keeps
+// "report nothing at all" from passing.
+//
+// The custom type (customGuardrailType) and the registry carrying its handler
+// (customEvalRegistry) are shared with guardrail_custom_registry_test.go.
+
+// absentEvalType names a handler no registry in this package registers — not
+// the built-in default set, and not customEvalRegistry either.
+const absentEvalType = "test_absent_from_every_registry_1725"
+
+// customTypePack returns a schema-valid pack whose default prompt declares
+// BOTH a validator and an eval def naming typeName.
+//
+// Both halves matter: ValidatePack routes validators through
+// validatePromptValidators and eval defs through validateEvalDefs, two
+// separate helpers each taking their own registry argument. Threading the
+// caller's registry into one and leaving the other on the default is the
+// "fixed one sibling, left the other" shape this bug belongs to, so every
+// assertion below counts issues across both.
+func customTypePack(typeName, blockedMessage string) map[string]any {
+	p := baseValidPack()
+	prompts := p["prompts"].(map[string]any)
+	def := prompts["default"].(map[string]any)
+	def["validators"] = []any{
+		map[string]any{
+			"type":    typeName,
+			"enabled": true,
+			"params":  map[string]any{"message": blockedMessage},
+		},
+	}
+	def["evals"] = []any{
+		map[string]any{
+			"id":      "custom-eval",
+			"type":    typeName,
+			"trigger": "every_turn",
+			"params":  map[string]any{},
+		},
+	}
+	return p
+}
+
+// unknownTypeIssueKinds returns the Kind of every issue whose Reason names an
+// unknown type, so a test can assert which of the two preflight paths reported.
+// Both producers — guardrails.ErrUnknownGuardrailType and
+// evals.ValidateEvalTypes — spell it "unknown".
+func unknownTypeIssueKinds(issues []sdk.PackIssue) []string {
+	kinds := make([]string, 0, len(issues))
+	for _, iss := range issues {
+		if strings.Contains(iss.Reason, "unknown") {
+			kinds = append(kinds, iss.Kind)
+		}
+	}
+	return kinds
+}
+
+// TestValidatePackWithRegistry_CustomTypeAcceptedButDefaultStillReports is the
+// core pair. The same pack file is checked twice, and the two halves have to
+// disagree:
+//
+//   - with the caller's registry, the custom type is known and NOTHING is
+//     reported. Mutation caught: ValidatePackWithRegistry ignoring its registry
+//     argument for either the validator path or the eval path (an issue comes
+//     back), and a nil-vs-supplied mix-up in evalRegistryOrDefault.
+//   - with plain ValidatePack (default registry) the SAME pack still reports
+//     both. Mutation caught: a "fix" that simply stopped reporting unknown
+//     types, or dropped the dry-run construction entirely — that would make the
+//     first half pass while quietly disabling preflight.
+func TestValidatePackWithRegistry_CustomTypeAcceptedButDefaultStillReports(t *testing.T) {
+	path := writeValidatePackFixture(t, customTypePack(customGuardrailType, "blocked"))
+
+	t.Run("supplied registry knows the type", func(t *testing.T) {
+		issues, err := sdk.ValidatePackWithRegistry(path, false, customEvalRegistry())
+		require.NoError(t, err)
+		assert.Empty(t, issues,
+			"a validator and an eval naming a handler in the supplied registry must not be reported")
+	})
+
+	t.Run("default registry does not", func(t *testing.T) {
+		issues, err := sdk.ValidatePack(path, false)
+		require.NoError(t, err)
+		require.Len(t, issues, 2,
+			"the default registry does not know the custom type, so both the validator and the eval must be reported")
+		assert.ElementsMatch(t, []string{"validator", "eval"}, unknownTypeIssueKinds(issues),
+			"both preflight paths must be reporting — otherwise the pair above proves only one of them")
+	})
+}
+
+// TestValidatePackWithRegistry_StillReportsTypeAbsentFromSuppliedRegistry pins
+// that threading a registry narrows WHICH types are known — it does not switch
+// the check off. A type absent from the supplied registry is still reported on
+// both paths.
+//
+// Mutation caught: making ValidatePackWithRegistry skip validation whenever a
+// registry is supplied, or evalRegistryOrDefault handing back something
+// permissive. Either would pass the "custom type accepted" half above while
+// blinding preflight to real typos.
+func TestValidatePackWithRegistry_StillReportsTypeAbsentFromSuppliedRegistry(t *testing.T) {
+	path := writeValidatePackFixture(t, customTypePack(absentEvalType, "blocked"))
+
+	issues, err := sdk.ValidatePackWithRegistry(path, false, customEvalRegistry())
+	require.NoError(t, err)
+	require.Len(t, issues, 2,
+		"a type in neither the default nor the supplied registry must still be reported")
+	assert.ElementsMatch(t, []string{"validator", "eval"}, unknownTypeIssueKinds(issues))
+}
+
+// TestValidatePackWithRegistry_NilRegistryMeansDefault pins the nil contract
+// established by #1724's CompileValidatorsWithRegistry / HookWithRegistry: nil
+// is "no preference", i.e. the built-in default set — not "no registry, skip
+// the checks".
+//
+// Mutations caught: a nil registry silently disabling validation (the custom
+// pack would come back clean), and a missing nil guard (nil-deref panic inside
+// registry.Get). The built-in half additionally pins that the default path
+// still accepts a legitimate pack.
+func TestValidatePackWithRegistry_NilRegistryMeansDefault(t *testing.T) {
+	t.Run("custom type reported exactly as ValidatePack does", func(t *testing.T) {
+		path := writeValidatePackFixture(t, customTypePack(customGuardrailType, "blocked"))
+
+		withNil, err := sdk.ValidatePackWithRegistry(path, false, nil)
+		require.NoError(t, err)
+		viaValidatePack, err := sdk.ValidatePack(path, false)
+		require.NoError(t, err)
+
+		require.Len(t, withNil, 2, "nil must mean the default registry, not 'skip validation'")
+		assert.ElementsMatch(t, viaValidatePack, withNil,
+			"ValidatePackWithRegistry(path, skip, nil) must be equivalent to ValidatePack(path, skip)")
+	})
+
+	t.Run("built-in type still accepted", func(t *testing.T) {
+		p := baseValidPack()
+		prompts := p["prompts"].(map[string]any)
+		def := prompts["default"].(map[string]any)
+		def["validators"] = []any{
+			map[string]any{
+				"type":    "max_length",
+				"enabled": true,
+				"params":  map[string]any{"max_characters": 2000},
+			},
+		}
+		path := writeValidatePackFixture(t, p)
+
+		issues, err := sdk.ValidatePackWithRegistry(path, false, nil)
+		require.NoError(t, err)
+		assert.Empty(t, issues, "a built-in validator must remain valid under the nil-registry default")
+	})
+}
+
+// TestValidatePackWithRegistry_AgreesWithOpen is the consistency assertion that
+// gives the fix its point: what preflight accepts, the runtime must accept too.
+// The identical pack bytes are fed to ValidatePackWithRegistry and to
+// sdk.Open + Send with the SAME registry, and the guardrail is observed
+// actually enforcing on the turn.
+//
+// Mutation caught: preflight and runtime drifting apart again — e.g. preflight
+// resolving against the default registry (issues reported for a pack Open runs
+// fine), or the guardrail being built but not enforcing (the raw response with
+// the forbidden token comes back).
+func TestValidatePackWithRegistry_AgreesWithOpen(t *testing.T) {
+	const blocked = "blocked by the custom pack validator"
+	const dirty = "Have a kumquat, on the house."
+
+	packJSON, err := json.MarshalIndent(customTypePack(customGuardrailType, blocked), "", "  ")
+	require.NoError(t, err)
+
+	path := writeTestPack(t, packJSON)
+	issues, err := sdk.ValidatePackWithRegistry(path, false, customEvalRegistry())
+	require.NoError(t, err)
+	require.Empty(t, issues, "preflight must accept the pack the runtime is about to enforce")
+
+	got := sendOnce(t, packJSON, dirty, sdk.WithEvalRegistry(customEvalRegistry()))
+	assert.Equal(t, blocked, got,
+		"the validator preflight accepted must enforce at runtime under the same registry")
+	assert.NotContains(t, got, forbiddenToken)
+}


### PR DESCRIPTION
Closes #1725

## Problem

PR #1724 made `Open()` resolve eval-backed guardrails against a caller-supplied registry (`sdk.WithEvalRegistry`), so a pack `validators:` entry naming a custom eval type builds and enforces.

`ValidatePack` could not do the same. `validatePromptValidators` and `validateEvalDefs` both already take a `*evals.EvalTypeRegistry`, but the only registry `ValidatePack` could hand them was a freshly built default one:

```go
registry := evals.NewEvalTypeRegistry()
```

So preflight reported a custom-typed validator (or eval def) as an unknown-type issue while `Open()` with the matching registry accepted and enforced it — preflight and runtime disagreeing about the same pack, in the cry-wolf direction. Not a fail-open; the false report is the problem.

## API

```go
func ValidatePackWithRegistry(
    path string, skipSchemaValidation bool, registry *evals.EvalTypeRegistry,
) ([]PackIssue, error)
```

A sibling, not a signature change. `ValidatePack` keeps working and delegates with a nil registry.

**`nil` means "the built-in default set"** — the same contract `CompileValidatorsWithRegistry`, `ValidatorsToHooksWithRegistry` and `Spec.HookWithRegistry` established in #1724, resolved by a local `evalRegistryOrDefault` mirroring the runtime's unexported `registryOrDefault`. The sibling-with-`WithRegistry` shape was chosen over variadic options or an options struct purely for consistency with that just-established convention.

The registry is resolved once per pack rather than per entry, matching `compileValidators`.

## Both siblings, not just the one the issue names

`ValidatePack` routes validators through `validatePromptValidators` and eval defs (pack-level and per-prompt) through `validateEvalDefs`. Fixing only the validator path is the "fixed one sibling, left the other" shape that produced #1715 / #1719 / #1721, so **every fixture in the new tests declares both a validator and an eval def naming the same type**, and every assertion counts issues across both paths.

## What the tests pin

The failure mode is a **false positive**, so the primary assertions say the issue is **absent** — each paired with a control that stops "report nothing at all" from passing. New `sdk/validate_pack_registry_test.go` reuses the custom handler and registry from `sdk/guardrail_custom_registry_test.go` (#1724).

`TestValidatePackWithRegistry_CustomTypeAcceptedButDefaultStillReports` — the core pair, same pack file checked twice, the halves must disagree:
- with the caller's registry → **no issues**. Catches: ignoring the registry argument on either path.
- via plain `ValidatePack` → **still both issues** (`ElementsMatch` on `{validator, eval}`). Catches: a "fix" that simply stopped reporting unknown types, which would pass the first half while quietly disabling preflight.

`TestValidatePackWithRegistry_StillReportsTypeAbsentFromSuppliedRegistry` — a type in *neither* registry is still reported on both paths. Catches: skipping validation whenever a registry is supplied, or `evalRegistryOrDefault` returning something permissive.

`TestValidatePackWithRegistry_NilRegistryMeansDefault` — `ValidatePackWithRegistry(path, skip, nil)` returns exactly what `ValidatePack(path, skip)` returns, and a built-in validator stays clean under nil. Catches: nil read as "no registry, skip the checks", and a missing nil guard (nil-deref in `registry.Get`).

`TestValidatePackWithRegistry_AgreesWithOpen` — the consistency assertion that gives the fix its point. The **identical pack bytes** go to `ValidatePackWithRegistry` (must be clean) and to `sdk.Open` + `Send` with the **same registry**, asserting the guardrail actually rewrites the offending turn. Catches: preflight and runtime drifting apart again.

### Mutation verification

Each was applied and reverted:

| mutation | caught by |
|---|---|
| `evalRegistryOrDefault(nil)` — ignore the argument | core pair (supplied-registry half) + `AgreesWithOpen` |
| registry threaded to validators only, `validateEvalDefs` left on the default | core pair (supplied-registry half) + `AgreesWithOpen` |
| return no issues at all | core pair (default-registry half), `StillReportsTypeAbsent...`, `NilRegistryMeansDefault` |

## Verification

- `go -C sdk test ./... -count=1` — pass
- `golangci-lint run ./sdk/...` — no new findings on the changed lines
- `make docs-sdk-reference` regenerated and committed (Reference Drift gate)
- `docs/src/content/docs/reference/checks.md` prose updated to point custom-registry users at the new function
