### PR TITLE
fix(seamscan): make lossy-rebuild assignment-aware and stop discarding partial results

### DIFF
--- a/tools/seamscan/lossy.go
+++ b/tools/seamscan/lossy.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"go/ast"
+	"go/token"
 	"go/types"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -67,16 +71,40 @@ import (
 // for the same reason (no data-flow tracing here): a value already copied out
 // of a field by an earlier statement (x := src.A; T{F: x}), and a parameter
 // or local forwarded opaquely.
+//
+// # Assignment awareness
+//
+// A field is not "dropped" merely because the literal omits it: a field
+// assigned to the literal's own target afterwards, on every path out of the
+// literal, is set. Without this the signature reads identically before and
+// after a fix — #1715 added resp.message.FinishReason = ... immediately below
+// the literal at sdk/streaming.go:435, and the pre-fix and post-fix trees
+// produced the same finding, which is why the true positive went unnoticed
+// among 31 findings for sdk alone. See lateAssignedFields for the exact
+// suppression rule and why conditional assignments are deliberately not
+// suppressed.
+//
+// # Partial results
+//
+// A pattern that fails to load does not discard the patterns that succeeded:
+// every pattern is scanned, findings from the ones that worked are returned,
+// and the failures are joined into the returned error so the caller still
+// exits non-zero. Returning nothing on the first bad path is how
+// "seams ./sdk ./runtime" used to throw away all of sdk's findings.
 func LossyRebuilds(patterns []string, minFields, minDropped int) ([]Finding, error) {
-	var out []Finding
+	var (
+		out  []Finding
+		errs []error
+	)
 	for _, pattern := range patterns {
 		found, err := lossyRebuildsInPattern(pattern, minFields, minDropped)
 		if err != nil {
-			return nil, err
+			errs = append(errs, err)
+			continue
 		}
 		out = append(out, found...)
 	}
-	return out, nil
+	return out, errors.Join(errs...)
 }
 
 // lossyRebuildsInPattern loads the single pattern (a filesystem path, plain or
@@ -103,6 +131,9 @@ func LossyRebuilds(patterns []string, minFields, minDropped int) ([]Finding, err
 // how "seams" on the whole repo root used to exit 0 having scanned nothing.
 func lossyRebuildsInPattern(pattern string, minFields, minDropped int) ([]Finding, error) {
 	dir, listPattern := splitPatternDir(pattern)
+	if err := checkBareModuleRoot(pattern, dir, listPattern); err != nil {
+		return nil, err
+	}
 	cfg := &packages.Config{
 		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
 			packages.NeedTypes | packages.NeedTypesInfo,
@@ -125,12 +156,13 @@ func lossyRebuildsInPattern(pattern string, minFields, minDropped int) ([]Findin
 			return
 		}
 		for _, file := range p.Syntax {
+			late := lateAssignedFields(p, file)
 			ast.Inspect(file, func(n ast.Node) bool {
 				lit, ok := n.(*ast.CompositeLit)
 				if !ok {
 					return true
 				}
-				f, ok := checkLiteral(p, lit, minFields, minDropped)
+				f, ok := checkLiteral(p, lit, late[lit], minFields, minDropped)
 				if ok {
 					out = append(out, f)
 				}
@@ -139,6 +171,38 @@ func lossyRebuildsInPattern(pattern string, minFields, minDropped int) ([]Findin
 		}
 	})
 	return out, nil
+}
+
+// checkBareModuleRoot turns the single sharpest edge of the path syntax into
+// an actionable message. "seamscan seams ./runtime" loads the directory as one
+// package, and a module root that holds only subdirectories has no root-level
+// .go files, so go/packages reports "no Go files in ..." — true, but it never
+// says that "./runtime/..." is the form that works. Both spellings are
+// accepted by splitPatternDir; only one of them scans a module.
+//
+// It deliberately reports rather than silently rewriting the pattern to
+// "<dir>/...": a bare directory means "this one package, non-recursively"
+// everywhere else in the tool, and quietly recursing only when the directory
+// happens to hold no .go files would make the pattern's meaning depend on the
+// contents of the directory it names.
+func checkBareModuleRoot(pattern, dir, listPattern string) error {
+	if listPattern == recursivePattern {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// Unreadable or nonexistent: let packages.Load produce the error.
+		return nil
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".go") {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"no Go files directly in %q, so there is no package to scan; "+
+			"to scan the whole tree below it use %q",
+		pattern, filepath.Clean(pattern)+"/...")
 }
 
 // recursivePattern is the go/packages pattern for "this directory and
@@ -162,9 +226,11 @@ func splitPatternDir(pattern string) (dir, listPattern string) {
 	return pattern, "."
 }
 
-// checkLiteral decides whether one composite literal is a lossy rebuild.
+// checkLiteral decides whether one composite literal is a lossy rebuild. late
+// is the set of field names assigned to the literal's target after it (see
+// lateAssignedFields); those fields are set, so they are not dropped.
 func checkLiteral(
-	p *packages.Package, lit *ast.CompositeLit, minFields, minDropped int,
+	p *packages.Package, lit *ast.CompositeLit, late map[string]bool, minFields, minDropped int,
 ) (Finding, bool) {
 	st, name := structType(p.TypesInfo.TypeOf(lit))
 	if st == nil {
@@ -190,7 +256,7 @@ func checkLiteral(
 		return Finding{}, false
 	}
 
-	dropped := droppedFieldNames(exported, set)
+	dropped := droppedFieldNames(exported, set, late)
 	if len(dropped) < minDropped {
 		return Finding{}, false
 	}
@@ -200,9 +266,209 @@ func checkLiteral(
 		Kind:    "lossy-rebuild",
 		File:    pos.Filename,
 		Line:    pos.Line,
-		Subject: fmt.Sprintf("%s (%d/%d exported fields set)", name, len(set), len(exported)),
-		Detail:  "not set in literal: " + strings.Join(dropped, ", "),
+		Subject: fmt.Sprintf("%s (%d/%d exported fields set)", name, len(exported)-len(dropped), len(exported)),
+		Detail:  "never set: " + strings.Join(dropped, ", "),
 	}, true
+}
+
+// litSite is a composite literal together with the lvalue it was assigned to
+// and the conditional constructs enclosing it.
+type litSite struct {
+	lit    *ast.CompositeLit
+	target string
+	conds  []ast.Node
+}
+
+// assignSite is a `target.Field = ...` statement: which target, which field,
+// where, and the conditional constructs enclosing it.
+type assignSite struct {
+	target string
+	field  string
+	pos    token.Pos
+	conds  []ast.Node
+}
+
+// lateAssignedFields maps each composite literal in file to the field names
+// assigned to that literal's own target afterwards, on every path out of the
+// literal. Those fields are set, so they are not dropped.
+//
+// "On every path" is what makes this correct rather than merely convenient.
+// The motivating shape (sdk/streaming.go, #1715) assigns the literal inside a
+// conditional and repairs the field after it:
+//
+//	if result != nil && result.Response != nil {
+//	    resp.message = &types.Message{Role: ..., Content: ...}   // literal
+//	}
+//	resp.message.FinishReason = state.finishReason()             // repair
+//
+// so a "same statement list" rule would miss it. Instead an assignment counts
+// only when it sits after the literal and inside no conditional that does not
+// already enclose the literal — its conditional ancestors must be a subset of
+// the literal's. A field assigned only on some branch therefore stays reported,
+// which is the deliberate trade in #1729: a partial rebuild is a real finding,
+// and a false positive there is cheaper than a missed dropped field.
+//
+// Targets are compared by declared object identity, not by name, so assigning
+// to a different variable that happens to share a name or type suppresses
+// nothing. Only `x = T{...}` / `x := &T{...}` forms are tracked; a literal
+// bound by `var x = T{...}` is not, and simply keeps its pre-existing behavior.
+func lateAssignedFields(p *packages.Package, file *ast.File) map[*ast.CompositeLit]map[string]bool {
+	lits, assigns := collectSites(p, file)
+	return matchLateAssignments(lits, assigns)
+}
+
+// collectSites walks file once, recording every composite literal bound to an
+// lvalue and every `target.Field = ...` assignment, each tagged with the
+// conditional constructs enclosing it.
+func collectSites(p *packages.Package, file *ast.File) ([]litSite, []assignSite) {
+	var (
+		lits    []litSite
+		assigns []assignSite
+		stack   []ast.Node
+	)
+	ast.Inspect(file, func(n ast.Node) bool {
+		if n == nil {
+			stack = stack[:len(stack)-1]
+			return true
+		}
+		stack = append(stack, n)
+		if as, ok := n.(*ast.AssignStmt); ok {
+			conds := conditionalAncestors(stack)
+			lits = append(lits, litSitesIn(p, as, conds)...)
+			assigns = append(assigns, assignSitesIn(p, as, conds)...)
+		}
+		return true
+	})
+	return lits, assigns
+}
+
+// litSitesIn returns the composite literals this statement binds to an lvalue.
+func litSitesIn(p *packages.Package, as *ast.AssignStmt, conds []ast.Node) []litSite {
+	var out []litSite
+	for i, rhs := range as.Rhs {
+		if i >= len(as.Lhs) {
+			break
+		}
+		lit := literalOf(rhs)
+		if lit == nil {
+			continue
+		}
+		if key, ok := targetKey(p, as.Lhs[i]); ok {
+			out = append(out, litSite{lit: lit, target: key, conds: conds})
+		}
+	}
+	return out
+}
+
+// assignSitesIn returns the field assignments this statement performs.
+func assignSitesIn(p *packages.Package, as *ast.AssignStmt, conds []ast.Node) []assignSite {
+	var out []assignSite
+	for _, lhs := range as.Lhs {
+		sel, ok := lhs.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+		if key, ok := targetKey(p, sel.X); ok {
+			out = append(out, assignSite{
+				target: key, field: sel.Sel.Name, pos: as.Pos(), conds: conds,
+			})
+		}
+	}
+	return out
+}
+
+// matchLateAssignments pairs each literal with the field assignments that run
+// on every path out of it: same target, later in the file, and inside no
+// conditional that does not already enclose the literal.
+func matchLateAssignments(lits []litSite, assigns []assignSite) map[*ast.CompositeLit]map[string]bool {
+	out := map[*ast.CompositeLit]map[string]bool{}
+	for _, ls := range lits {
+		for _, as := range assigns {
+			if as.target != ls.target || as.pos <= ls.lit.Pos() {
+				continue
+			}
+			if !condsSubset(as.conds, ls.conds) {
+				continue
+			}
+			if out[ls.lit] == nil {
+				out[ls.lit] = map[string]bool{}
+			}
+			out[ls.lit][as.field] = true
+		}
+	}
+	return out
+}
+
+// literalOf unwraps `T{...}` and `&T{...}`, returning nil for anything else.
+func literalOf(e ast.Expr) *ast.CompositeLit {
+	if u, ok := e.(*ast.UnaryExpr); ok && u.Op == token.AND {
+		e = u.X
+	}
+	lit, _ := e.(*ast.CompositeLit)
+	return lit
+}
+
+// targetKey renders an lvalue as a key that distinguishes variables by their
+// declared object, so two different variables never compare equal even when
+// they share a name. Reports false for anything that is not a chain of
+// identifiers and field selections.
+func targetKey(p *packages.Package, e ast.Expr) (string, bool) {
+	switch v := e.(type) {
+	case *ast.Ident:
+		obj := p.TypesInfo.ObjectOf(v)
+		if obj == nil {
+			return "", false
+		}
+		// Declaration position is unique per declared object and stable.
+		return fmt.Sprintf("obj@%d", obj.Pos()), true
+	case *ast.SelectorExpr:
+		base, ok := targetKey(p, v.X)
+		if !ok {
+			return "", false
+		}
+		return base + "." + v.Sel.Name, true
+	case *ast.StarExpr:
+		return targetKey(p, v.X)
+	case *ast.ParenExpr:
+		return targetKey(p, v.X)
+	}
+	return "", false
+}
+
+// conditionalAncestors returns the nodes on stack that make their body run
+// conditionally. A function literal counts: its body may run never, later, or
+// many times, so an assignment inside one is not on the path out of a literal
+// outside it.
+func conditionalAncestors(stack []ast.Node) []ast.Node {
+	var conds []ast.Node
+	for _, n := range stack {
+		switch n.(type) {
+		case *ast.IfStmt, *ast.ForStmt, *ast.RangeStmt, *ast.SwitchStmt,
+			*ast.TypeSwitchStmt, *ast.SelectStmt, *ast.CaseClause,
+			*ast.CommClause, *ast.FuncLit:
+			conds = append(conds, n)
+		}
+	}
+	return conds
+}
+
+// condsSubset reports whether every conditional enclosing the assignment also
+// encloses the literal — i.e. the assignment introduces no branch of its own
+// and therefore runs whenever the literal did.
+func condsSubset(assign, lit []ast.Node) bool {
+	for _, a := range assign {
+		found := false
+		for _, l := range lit {
+			if a == l {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 // exportedFieldNames returns the set of exported field names on st.
@@ -282,14 +548,16 @@ func readsExistingData(p *packages.Package, e ast.Expr) bool {
 	return found
 }
 
-// droppedFieldNames returns the sorted names present in exported but absent
-// from set.
-func droppedFieldNames(exported, set map[string]bool) []string {
+// droppedFieldNames returns the sorted names present in exported but set
+// neither by the literal (set) nor by a later unconditional assignment to the
+// literal's target (late).
+func droppedFieldNames(exported, set, late map[string]bool) []string {
 	var dropped []string
 	for f := range exported {
-		if !set[f] {
-			dropped = append(dropped, f)
+		if set[f] || late[f] {
+			continue
 		}
+		dropped = append(dropped, f)
 	}
 	sort.Strings(dropped)
 	return dropped

--- a/tools/seamscan/lossy_test.go
+++ b/tools/seamscan/lossy_test.go
@@ -458,3 +458,171 @@ type Wide struct{ A, B string }
 	assert.Error(t, err,
 		"scanning the workspace root itself (not a module member) must not silently report zero findings")
 }
+
+// --- assignment awareness (#1729) ---
+//
+// The four tests below define the suppression rule between them. Case 1 is
+// already covered by TestLossyRebuilds_ReportsDroppedFields: a literal whose
+// dropped fields are never assigned is reported.
+
+// A field assigned unconditionally after the literal is set, not dropped.
+//
+// Mutation caught: deleting the late-assignment lookup in droppedFieldNames
+// puts C back in Detail. Before this rule the detector reported C identically
+// whether or not the next line assigned it, which is why the finding read the
+// same before and after the #1715 fix.
+func TestLossyRebuilds_SuppressesFieldAssignedAfterLiteral(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Wide struct {
+	A, B, C, D, E, F string
+}
+
+func Rebuild(src Wide) Wide {
+	out := Wide{A: src.A, B: src.B}
+	out.C = "assigned right after the literal"
+	return out
+}
+`)
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	require.NoError(t, err)
+
+	require.Len(t, got, 1, "the literal still drops D, E and F, so the finding stands")
+	assert.NotContains(t, got[0].Detail, "C",
+		"C is assigned on the next line, so it is set — reporting it is the false signal #1729 is about")
+	for _, f := range []string{"D", "E", "F"} {
+		assert.Contains(t, got[0].Detail, f,
+			"suppressing C must not suppress fields that really are never set")
+	}
+}
+
+// The motivating shape: the literal is assigned inside a conditional and the
+// field is repaired after that conditional closes. This is sdk/streaming.go's
+// buildStreamingResponse (#1715) reduced to its essentials, and it is why the
+// rule compares conditional ancestors rather than requiring the same block —
+// a same-statement-list rule would fail to suppress here.
+func TestLossyRebuilds_SuppressesRepairAfterConditionalLiteral(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Wide struct {
+	A, B, C, D, E, F string
+}
+
+type Box struct {
+	msg *Wide
+}
+
+func Rebuild(src Wide, ok bool) *Box {
+	box := &Box{}
+	if ok {
+		box.msg = &Wide{A: src.A, B: src.B}
+	}
+	box.msg.C = "repaired after the branch, on every path out of the literal"
+	return box
+}
+`)
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.NotContains(t, got[0].Detail, "C",
+		"the repair runs on every path out of the literal, so C is set")
+}
+
+// A field assigned only on one branch is genuinely unset on the others, so it
+// stays reported. This is the deliberate false-positive-over-false-negative
+// trade recorded in #1729.
+//
+// Mutation caught: dropping the condsSubset check (suppressing on position
+// alone) removes C from Detail and this fails.
+func TestLossyRebuilds_ReportsFieldAssignedOnlyInBranch(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Wide struct {
+	A, B, C, D, E, F string
+}
+
+func Rebuild(src Wide, cond bool) Wide {
+	out := Wide{A: src.A, B: src.B}
+	if cond {
+		out.C = "only on this path"
+	}
+	return out
+}
+`)
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Contains(t, got[0].Detail, "C",
+		"a field set on only one branch is still unset on the others")
+}
+
+// Suppression is keyed on the declared object, not on the identifier's
+// spelling, so a same-named variable elsewhere suppresses nothing.
+//
+// The two variables are deliberately both named "out" and live in different
+// functions. lateAssignedFields collects literals and assignments per file
+// rather than per function, so object identity is the only thing scoping one
+// function's writes away from another's — a name-keyed implementation would
+// let Other's out.C suppress Rebuild's, across the function boundary.
+//
+// Mutation caught: keying targetKey on v.Name instead of the declared object's
+// position drops C from Detail and this fails. An earlier version of this test
+// used two *differently named* variables in one function; name-keying
+// distinguishes those perfectly well, so it passed under the mutation and was
+// a test that could not fail.
+func TestLossyRebuilds_SuppressionIsPerVariable(t *testing.T) {
+	dir := writeModule(t, `package m
+
+type Wide struct {
+	A, B, C, D, E, F string
+}
+
+func Rebuild(src Wide) Wide {
+	out := Wide{A: src.A, B: src.B}
+	return out
+}
+
+func Other() Wide {
+	out := Wide{}
+	out.C = "same name, different function, different object"
+	return out
+}
+`)
+
+	got, err := LossyRebuilds([]string{dir + "/..."}, 4, 2)
+	require.NoError(t, err)
+
+	require.Len(t, got, 1, "only the field-sourced literal is a rebuild candidate")
+	assert.Contains(t, got[0].Detail, "C",
+		"Rebuild's out.C is never assigned; Other's write to its own out.C must not suppress it")
+}
+
+// One unloadable pattern must not discard the findings from patterns that
+// loaded. "seams ./sdk ./runtime" used to return nothing at all, throwing away
+// every finding from sdk because runtime's bare root holds no .go files.
+//
+// Mutation caught: restoring the early `return nil, err` empties got while
+// leaving err non-nil, so the findings assertion fails.
+func TestLossyRebuilds_ContinuesAfterUnloadablePattern(t *testing.T) {
+	good := writeModule(t, `package m
+
+type Wide struct {
+	A, B, C, D, E, F string
+}
+
+func Rebuild(src Wide) Wide {
+	return Wide{A: src.A, B: src.B}
+}
+`)
+	bad := t.TempDir() // no go.mod, cannot load
+
+	got, err := LossyRebuilds([]string{bad + "/...", good + "/..."}, 4, 2)
+
+	assert.Error(t, err, "the failed pattern must still be reported so the caller exits non-zero")
+	assert.NotEmpty(t, got, "findings from the pattern that loaded must survive the one that did not")
+}

--- a/tools/seamscan/main.go
+++ b/tools/seamscan/main.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -58,13 +59,18 @@ func run(args []string, stdout io.Writer) error {
 	default:
 		return fmt.Errorf("unknown subcommand %q", cmd)
 	}
-	if err != nil {
-		return err
-	}
-
+	// Emit before reporting the scan error. A scan over several paths returns
+	// the findings from the paths that loaded alongside an error describing
+	// the ones that did not, so returning early here would throw away exactly
+	// the partial results LossyRebuilds and WeakAssertions go to the trouble
+	// of preserving (#1729). The error still propagates, so the exit status
+	// stays non-zero and a CI caller cannot mistake a partial scan for a
+	// clean one.
+	var emitErr error
 	if *text {
 		EmitText(stdout, found)
-		return nil
+	} else {
+		emitErr = EmitJSON(stdout, found)
 	}
-	return EmitJSON(stdout, found)
+	return errors.Join(err, emitErr)
 }

--- a/tools/seamscan/main_test.go
+++ b/tools/seamscan/main_test.go
@@ -93,6 +93,45 @@ func TestDoesNothing(t *testing.T) {
 	assert.Equal(t, "TestDoesNothing", got[0].Subject)
 }
 
+// TestRun_EmitsPartialFindingsWhenAPathFails pins the CLI half of #1729's
+// partial-results guarantee, which is a separate seam from the analyzer's.
+// LossyRebuilds returns the findings from the paths that loaded alongside an
+// error for the ones that did not; run must emit those findings before
+// propagating the error, or the guarantee stops at the function boundary and
+// never reaches the only interface anyone actually uses.
+//
+// Mutation caught: restoring `if err != nil { return err }` ahead of the emit
+// leaves TestLossyRebuilds_ContinuesAfterUnloadablePattern green — the
+// analyzer still returns its partial results — while the command prints
+// nothing at all. That is exactly the unit-passes/integration-fails split this
+// tool exists to find.
+func TestRun_EmitsPartialFindingsWhenAPathFails(t *testing.T) {
+	good := writeModule(t, `package m
+
+type Wide struct {
+	A, B, C, D, E, F string
+}
+
+func Rebuild(src Wide) Wide {
+	return Wide{A: src.A, B: src.B}
+}
+`)
+	bad := t.TempDir() // no go.mod: unloadable
+
+	var buf bytes.Buffer
+	err := run([]string{
+		"seams", "--min-fields", "4", "--min-dropped", "2",
+		bad + "/...", good + "/...",
+	}, &buf)
+
+	require.Error(t, err, "the unloadable path must still fail the run")
+
+	var got []Finding
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got),
+		"the command must still emit the findings it did collect")
+	assert.NotEmpty(t, got, "findings from the path that loaded must survive the one that did not")
+}
+
 // TestRun_PropagatesSeamsAnalyzerError pins run()'s error propagation for the
 // "seams" subcommand: a path with no reachable go.mod makes LossyRebuilds
 // return an error (see TestLossyRebuilds_ErrorsOnUnloadablePattern), and run

--- a/tools/seamscan/weakassert.go
+++ b/tools/seamscan/weakassert.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -35,11 +36,20 @@ var assertionsProvingNothing = map[string]bool{
 // WeakAssertions reports test functions and subtests whose assertions cannot
 // distinguish correct behavior from broken behavior.
 func WeakAssertions(paths []string) ([]Finding, error) {
-	var out []Finding
+	var (
+		out  []Finding
+		errs []error
+	)
 	for _, root := range paths {
 		files, err := goTestFiles(root)
 		if err != nil {
-			return nil, err
+			// Keep scanning the remaining roots. Returning here would discard
+			// every finding already collected because one path was bad — the
+			// same all-or-nothing shape fixed in LossyRebuilds for #1729, and
+			// fixing only one of the two would be precisely the sibling
+			// divergence that motivated that issue.
+			errs = append(errs, err)
+			continue
 		}
 		for _, path := range files {
 			found, err := scanTestFile(path)
@@ -50,7 +60,7 @@ func WeakAssertions(paths []string) ([]Finding, error) {
 			out = append(out, found...)
 		}
 	}
-	return out, nil
+	return out, errors.Join(errs...)
 }
 
 // scanTestFile parses a single test file and classifies each of its Test*


### PR DESCRIPTION
Closes #1729

Parts (2) and (3) of the issue. Part (1) — wiring `seams` into CI — is deliberately left out; it belongs in its own PR once this makes the output worth reading.

## Assignment awareness

The detector inspected only the composite literal, so a field assigned on the next line still counted as dropped. It emitted an **identical finding before and after a fix**: `sdk/streaming.go:435` reported `FinishReason` as dropped both before #1715 and after it. That is why the true positive sat unnoticed among 31 findings for `sdk` alone — a signal that reads the same whether the bug is present or absent cannot direct attention.

A field is now suppressed when it is assigned to the literal's own target afterwards, **on every path out of the literal**. "Every path" is what makes this correct rather than merely convenient — the motivating shape assigns the literal inside a conditional and repairs the field after that conditional closes:

```go
if result != nil && result.Response != nil {
    resp.message = &types.Message{Role: ..., Content: ...}   // literal
}
resp.message.FinishReason = state.finishReason()             // repair
```

so a "same statement list" rule would miss it. An assignment counts only when its conditional ancestors are a subset of the literal's. A field assigned on only one branch **stays reported** — a partial rebuild is a real finding, and a false positive there is cheaper than a missed dropped field. Targets compare by declared object, not by name.

### Measured on `sdk`

| | before | after |
|---|---|---|
| `streaming.go:435` | `4/13 set` — **FinishReason**, LatencyMs, Meta, … | `5/13 set` — LatencyMs, Meta, … |
| `conversation.go:742` | `4/13 set` — **FinishReason**, … | `5/13 set` — … |
| total findings | 31 | 31 |

`FinishReason` correctly drops out of both. **The count does not fall**, and that is the honest result: both literals genuinely never set eight other fields, which is over the `min-dropped` threshold on its own. The change makes each finding *accurate per field*; it does not make these two lines stop being flagged.

## Partial results — two seams, not one

`seamscan seams ./sdk ./runtime` returned nothing at all, discarding sdk's 31 findings because `runtime/`'s bare root holds no `.go` files. That turned out to be **two** independent early returns:

- `LossyRebuilds` returned on the first bad pattern, and
- `run()` discarded the findings even once the analyzer preserved them.

Fixing only the analyzer would have left the command emitting nothing while the analyzer's own test passed — the unit-passes/integration-fails split this tool exists to find. Both are fixed, with a test at each level. `WeakAssertions` had the same early-return shape and is fixed alongside rather than left as the odd sibling out.

A bare module root now reports how to scan it (`<path>/...`) instead of a bare go/packages error. Findings are emitted and the exit status stays non-zero, so a CI caller cannot mistake a partial scan for a clean one.

Verified end to end: `seams --text ./sdk ./runtime` now emits 31 findings and exits 1.

## Tests

Four cases define the suppression rule, each mutation-verified by breaking the implementation and confirming the expected test fails: unconditional assignment suppresses; repair-after-conditional suppresses (the `streaming.go` shape); branch-only assignment does **not**; a same-named variable in another function does **not**. Plus partial-results tests at both the analyzer and CLI level.

One of these started out unable to fail: the per-variable test first used two *differently named* variables, which name-keying distinguishes perfectly well, so it passed under the mutation it was meant to catch. It now uses two variables both named `out` in different functions. Noted in the test comment, since the tool's whole purpose is finding tests that cannot fail.
