### PR TITLE
fix(release): bump internal module requires before tagging runtime and pkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,12 @@ jobs:
     - name: Test the published-go.mod release guard (issue #1713)
       run: ./scripts/test-verify-published-gomod.sh
 
+    # Catches the runtime <-> pkg module cycle at PR time. The release workflow
+    # re-checks before tagging, but by then a bad go.mod is one push away from
+    # being immutable.
+    - name: Check runtime is a leaf module (issue #1713)
+      run: ./scripts/check-runtime-is-leaf.sh
+
   weak-assertions:
     name: Weak Assertion Guard
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,12 @@ jobs:
     - name: Check foundational packages are purego-free (issue #1536)
       run: ./scripts/check-no-audio-device-leak.sh
 
+    # Fixture tests only — no network. The release workflow runs the guard
+    # itself against the Go proxy after tagging; this keeps the guard honest, so
+    # it cannot rot into something that passes everything.
+    - name: Test the published-go.mod release guard (issue #1713)
+      run: ./scripts/test-verify-published-gomod.sh
+
   weak-assertions:
     name: Weak Assertion Guard
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,11 +170,17 @@ jobs:
       # See update-tools/Fetch remote tags for rationale.
       run: git fetch --tags --force origin
 
-    # Tagged from the default branch, before the release branch is created:
-    # this is the tag the GitHub release (and therefore the docs/schema
-    # deployment) hangs off, so it must point at a commit on main. runtime and
-    # pkg are tagged further down, from the release branch, exactly as sdk and
-    # server/a2a already are.
+    # Fail before anything is pushed if runtime has grown a dependency on a
+    # sibling module: the tag below is cut straight from this tree, so a stale
+    # internal require would ship immutably (issue #1713).
+    - name: Check runtime is still a leaf module
+      run: ./scripts/check-runtime-is-leaf.sh
+
+    # Root and runtime are tagged from the default branch, before the release
+    # branch exists. The root tag is what the GitHub release — and therefore
+    # the docs/schema deployment — hangs off, so it must point at a commit on
+    # main; runtime has no internal requires to rewrite. Only pkg needs the
+    # release-branch treatment sdk and server/a2a get.
     - name: Tag root version (for GoReleaser)
       env:
         VERSION: ${{ needs.validate.outputs.version }}
@@ -186,6 +192,19 @@ jobs:
           git tag -a "$VERSION" -m "Release $VERSION"
           git push origin "$VERSION"
           echo "✓ Tagged $VERSION"
+        fi
+
+    - name: Tag runtime
+      env:
+        VERSION: ${{ needs.validate.outputs.version }}
+      run: |
+        echo "Tagging runtime/$VERSION"
+        if git rev-parse "runtime/$VERSION" >/dev/null 2>&1; then
+          echo "⚠ Tag runtime/$VERSION already exists, skipping"
+        else
+          git tag -a "runtime/$VERSION" -m "Release runtime $VERSION"
+          git push origin "runtime/$VERSION"
+          echo "✓ Tagged runtime/$VERSION"
         fi
 
     - name: Create release branch
@@ -203,39 +222,10 @@ jobs:
           echo "✓ Created branch $BRANCH"
         fi
 
-    # runtime and pkg import each other (runtime/hooks/exec_build.go uses
-    # pkg/config; pkg/config uses runtime/{credentials,providers/base,tools,...}),
-    # so the two must require each other at $VERSION. That is legal — Go forbids
-    # package cycles, not module cycles — and MVS resolves it fine. `go mod edit`
-    # is pure text manipulation, so neither tag has to exist yet.
-    #
     # No `go mod tidy`: a dependency module's go.sum is never consulted, since
     # Go verifies downloads against the *main* module's go.sum. Tidying here
-    # would require both tags to be proxy-visible first, which is the ordering
-    # problem this layout exists to avoid.
-    - name: Update runtime dependencies
-      env:
-        VERSION: ${{ needs.validate.outputs.version }}
-      run: |
-        echo "Updating runtime to use $VERSION..."
-        cd runtime
-
-        go mod edit -require="github.com/AltairaLabs/PromptKit/pkg@$VERSION"
-
-        # No-op today (runtime has no replace directives), but keeps runtime
-        # correct if one is ever added locally.
-        go mod edit -dropreplace=github.com/AltairaLabs/PromptKit/pkg
-
-        # Same guard as the pkg and sdk steps.
-        if grep -q '^replace' go.mod; then
-          echo "::error::runtime/go.mod still has replace directives after cleanup:"
-          grep '^replace' go.mod
-          exit 1
-        fi
-
-        cd ..
-        echo "✓ Updated runtime go.mod to $VERSION"
-
+    # would need runtime/$VERSION to be proxy-visible first; `go mod edit` is
+    # pure text and does not, which is what keeps this a single step.
     - name: Update pkg dependencies
       env:
         VERSION: ${{ needs.validate.outputs.version }}
@@ -268,26 +258,13 @@ jobs:
         BRANCH="release/libs/$VERSION"
 
         # Check if there are changes to commit
-        if git diff --quiet runtime/go.mod pkg/go.mod; then
+        if git diff --quiet pkg/go.mod; then
           echo "⚠ No changes to commit (already up to date)"
         else
-          git add runtime/go.mod pkg/go.mod
-          git commit -m "release: update library modules to $VERSION"
+          git add pkg/go.mod
+          git commit -m "release: update pkg to $VERSION"
           git push origin "$BRANCH"
           echo "✓ Pushed $BRANCH"
-        fi
-
-    - name: Tag runtime
-      env:
-        VERSION: ${{ needs.validate.outputs.version }}
-      run: |
-        echo "Tagging runtime/$VERSION from release branch (internal requires bumped)"
-        if git rev-parse "runtime/$VERSION" >/dev/null 2>&1; then
-          echo "⚠ Tag runtime/$VERSION already exists, skipping"
-        else
-          git tag -a "runtime/$VERSION" -m "Release runtime $VERSION"
-          git push origin "runtime/$VERSION"
-          echo "✓ Tagged runtime/$VERSION"
         fi
 
     - name: Tag pkg
@@ -317,7 +294,16 @@ jobs:
     name: Update and Tag SDK Modules
     runs-on: ubuntu-latest
     needs: [validate, tag-dependencies]
-    if: ${{ always() && (inputs.phase == 'full' || inputs.phase == 'tools-only') && needs.validate.result == 'success' }}
+    # `always()` is needed because tag-dependencies is *skipped* on a tools-only
+    # re-run, and a skipped dependency would otherwise skip this job too. But it
+    # must not mean "run even when the libs phase failed": on a full release,
+    # tagging sdk on top of libraries that failed to tag or published a bad
+    # go.mod just adds more immutable tags to clean up.
+    if: >-
+      ${{ always() && needs.validate.result == 'success' && (
+        inputs.phase == 'tools-only' ||
+        (inputs.phase == 'full' && needs.tag-dependencies.result == 'success')
+      ) }}
     
     steps:
     - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,13 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
-    
+
+    - name: Setup Go
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        go-version: '1.26.0'
+        cache: false  # Disable cache since we use a workspace setup
+
     - name: Configure Git
       run: |
         git config user.name "github-actions[bot]"
@@ -164,32 +170,11 @@ jobs:
       # See update-tools/Fetch remote tags for rationale.
       run: git fetch --tags --force origin
 
-    - name: Tag runtime
-      env:
-        VERSION: ${{ needs.validate.outputs.version }}
-      run: |
-        echo "Tagging runtime/$VERSION"
-        if git rev-parse "runtime/$VERSION" >/dev/null 2>&1; then
-          echo "⚠ Tag runtime/$VERSION already exists, skipping"
-        else
-          git tag -a "runtime/$VERSION" -m "Release runtime $VERSION"
-          git push origin "runtime/$VERSION"
-          echo "✓ Tagged runtime/$VERSION"
-        fi
-    
-    - name: Tag pkg
-      env:
-        VERSION: ${{ needs.validate.outputs.version }}
-      run: |
-        echo "Tagging pkg/$VERSION"
-        if git rev-parse "pkg/$VERSION" >/dev/null 2>&1; then
-          echo "⚠ Tag pkg/$VERSION already exists, skipping"
-        else
-          git tag -a "pkg/$VERSION" -m "Release pkg $VERSION"
-          git push origin "pkg/$VERSION"
-          echo "✓ Tagged pkg/$VERSION"
-        fi
-    
+    # Tagged from the default branch, before the release branch is created:
+    # this is the tag the GitHub release (and therefore the docs/schema
+    # deployment) hangs off, so it must point at a commit on main. runtime and
+    # pkg are tagged further down, from the release branch, exactly as sdk and
+    # server/a2a already are.
     - name: Tag root version (for GoReleaser)
       env:
         VERSION: ${{ needs.validate.outputs.version }}
@@ -202,63 +187,131 @@ jobs:
           git push origin "$VERSION"
           echo "✓ Tagged $VERSION"
         fi
-    
-    - name: Verify on Go proxy
+
+    - name: Create release branch
       env:
         VERSION: ${{ needs.validate.outputs.version }}
       run: |
-        echo "Verifying tags are available on Go proxy..."
-        
-        # Function to check if a module version is available
-        check_module() {
-          local module=$1
-          local version=$2
-          echo "Checking $module..."
-          for i in {1..10}; do
-            if curl -f -s "https://proxy.golang.org/github.com/!altaira!labs/!prompt!kit/$module/@v/$version.info" >/dev/null 2>&1; then
-              echo "✓ $module@$version is available"
-              return 0
-            fi
-            echo "  Attempt $i/10: Not available yet, waiting 20s..."
-            sleep 20
-          done
-          echo "⚠ $module@$version still not available after 200s"
-          return 1
-        }
-        
-        # runtime is a true leaf. pkg is NOT — it replaces runtime locally and
-        # is tagged straight from this tree with no go.mod cleanup, so pkg tags
-        # ship both that replace and a stale `require runtime v1.3.5`. Consumers
-        # ignore the replace but honor the require, so a pkg-only dependant
-        # resolves an old runtime. Tracked separately; fixing it means giving pkg
-        # the same release-branch treatment sdk and server/a2a get, which
-        # reorders this phase and is not a drive-by change.
-        #
-        # server/a2a and sdk are tagged later in update-tools after go.mod cleanup.
-        check_module "runtime" "$VERSION" &
-        PID_RUNTIME=$!
-
-        check_module "pkg" "$VERSION" &
-        PID_PKG=$!
-
-        # Wait for all checks to complete
-        wait $PID_RUNTIME
-        RESULT_RUNTIME=$?
-
-        wait $PID_PKG
-        RESULT_PKG=$?
-
-        # Report overall status (non-blocking - Go proxy can take time to propagate)
-        if [ $RESULT_RUNTIME -eq 0 ] && [ $RESULT_PKG -eq 0 ]; then
-          echo "✓ Leaf modules are available on Go proxy"
+        BRANCH="release/libs/$VERSION"
+        # Check if branch already exists remotely
+        if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+          echo "⚠ Branch $BRANCH already exists, checking it out"
+          git fetch origin "$BRANCH"
+          git checkout "$BRANCH"
         else
-          echo "⚠ Some modules may need more time to propagate"
-          echo "  This is normal and they will be available shortly"
-          echo "  Continuing with release process..."
+          git checkout -b "$BRANCH"
+          echo "✓ Created branch $BRANCH"
         fi
-        
-        # Always succeed - Go proxy propagation shouldn't block the release
-        exit 0
+
+    # runtime and pkg import each other (runtime/hooks/exec_build.go uses
+    # pkg/config; pkg/config uses runtime/{credentials,providers/base,tools,...}),
+    # so the two must require each other at $VERSION. That is legal — Go forbids
+    # package cycles, not module cycles — and MVS resolves it fine. `go mod edit`
+    # is pure text manipulation, so neither tag has to exist yet.
+    #
+    # No `go mod tidy`: a dependency module's go.sum is never consulted, since
+    # Go verifies downloads against the *main* module's go.sum. Tidying here
+    # would require both tags to be proxy-visible first, which is the ordering
+    # problem this layout exists to avoid.
+    - name: Update runtime dependencies
+      env:
+        VERSION: ${{ needs.validate.outputs.version }}
+      run: |
+        echo "Updating runtime to use $VERSION..."
+        cd runtime
+
+        go mod edit -require="github.com/AltairaLabs/PromptKit/pkg@$VERSION"
+
+        # No-op today (runtime has no replace directives), but keeps runtime
+        # correct if one is ever added locally.
+        go mod edit -dropreplace=github.com/AltairaLabs/PromptKit/pkg
+
+        # Same guard as the pkg and sdk steps.
+        if grep -q '^replace' go.mod; then
+          echo "::error::runtime/go.mod still has replace directives after cleanup:"
+          grep '^replace' go.mod
+          exit 1
+        fi
+
+        cd ..
+        echo "✓ Updated runtime go.mod to $VERSION"
+
+    - name: Update pkg dependencies
+      env:
+        VERSION: ${{ needs.validate.outputs.version }}
+      run: |
+        echo "Updating pkg to use $VERSION..."
+        cd pkg
+
+        go mod edit -require="github.com/AltairaLabs/PromptKit/runtime@$VERSION"
+
+        # pkg keeps `replace .../runtime => ../runtime` on main so workspace and
+        # GOWORK=off builds resolve the local tree. It must not ship in the tag:
+        # Go ignores replace in a dependency module but honors require, so the
+        # replace masked a stale `require runtime v1.3.5` for five releases
+        # (issue #1713).
+        go mod edit -dropreplace=github.com/AltairaLabs/PromptKit/runtime
+
+        if grep -q '^replace' go.mod; then
+          echo "::error::pkg/go.mod still has replace directives after cleanup:"
+          grep '^replace' go.mod
+          exit 1
+        fi
+
+        cd ..
+        echo "✓ Updated pkg go.mod to $VERSION"
+
+    - name: Commit changes
+      env:
+        VERSION: ${{ needs.validate.outputs.version }}
+      run: |
+        BRANCH="release/libs/$VERSION"
+
+        # Check if there are changes to commit
+        if git diff --quiet runtime/go.mod pkg/go.mod; then
+          echo "⚠ No changes to commit (already up to date)"
+        else
+          git add runtime/go.mod pkg/go.mod
+          git commit -m "release: update library modules to $VERSION"
+          git push origin "$BRANCH"
+          echo "✓ Pushed $BRANCH"
+        fi
+
+    - name: Tag runtime
+      env:
+        VERSION: ${{ needs.validate.outputs.version }}
+      run: |
+        echo "Tagging runtime/$VERSION from release branch (internal requires bumped)"
+        if git rev-parse "runtime/$VERSION" >/dev/null 2>&1; then
+          echo "⚠ Tag runtime/$VERSION already exists, skipping"
+        else
+          git tag -a "runtime/$VERSION" -m "Release runtime $VERSION"
+          git push origin "runtime/$VERSION"
+          echo "✓ Tagged runtime/$VERSION"
+        fi
+
+    - name: Tag pkg
+      env:
+        VERSION: ${{ needs.validate.outputs.version }}
+      run: |
+        echo "Tagging pkg/$VERSION from release branch (replace dropped, require bumped)"
+        if git rev-parse "pkg/$VERSION" >/dev/null 2>&1; then
+          echo "⚠ Tag pkg/$VERSION already exists, skipping"
+        else
+          git tag -a "pkg/$VERSION" -m "Release pkg $VERSION"
+          git push origin "pkg/$VERSION"
+          echo "✓ Tagged pkg/$VERSION"
+        fi
+
+    # Correctness gate, not an availability gate: it fetches each published
+    # go.mod from the Go proxy and fails the release if a tag carries an
+    # internal replace or an internal require pointing anywhere but $VERSION.
+    # Propagation timeouts are reported as warnings and do not fail, which is
+    # what the availability check this replaces was really doing.
+    - name: Verify published go.mod on Go proxy
+      env:
+        VERSION: ${{ needs.validate.outputs.version }}
+      run: ./scripts/verify-published-gomod.sh "$VERSION" runtime pkg
 
   update-tools:
     name: Update and Tag SDK Modules
@@ -412,39 +465,15 @@ jobs:
           echo "✓ Tagged sdk/$VERSION"
         fi
 
-    - name: Verify library modules on Go proxy
+    # Deliberately NOT continue-on-error, unlike the availability check this
+    # replaces: a published tag with an internal replace or a stale internal
+    # require is a real defect that reaches consumers, and tags are immutable,
+    # so it must stop the release loudly rather than warn into a log nobody
+    # reads. Propagation timeouts still pass — see the script header.
+    - name: Verify published go.mod on Go proxy
       env:
         VERSION: ${{ needs.validate.outputs.version }}
-      continue-on-error: true
-      run: |
-        echo "Verifying library modules are available on Go proxy..."
-
-        check_module() {
-          local module=$1
-          local version=$2
-          echo "Checking $module..."
-          for i in {1..10}; do
-            if curl -f -s "https://proxy.golang.org/github.com/!altaira!labs/!prompt!kit/$module/@v/$version.info" >/dev/null 2>&1; then
-              echo "✓ $module@$version is available"
-              return 0
-            fi
-            echo "  Attempt $i/10: Not available yet, waiting 20s..."
-            sleep 20
-          done
-          echo "⚠ $module@$version still not available after 200s"
-          return 1
-        }
-
-        check_module "server/a2a" "$VERSION" &
-        PID_SERVER_A2A=$!
-
-        check_module "sdk" "$VERSION" &
-        PID_SDK=$!
-
-        wait $PID_SERVER_A2A
-        wait $PID_SDK
-
-        echo "Library module verification complete"
+      run: ./scripts/verify-published-gomod.sh "$VERSION" sdk server/a2a
 
   create-release:
     name: Create GitHub Release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ binaries, npm packages and Homebrew casks) release from the separate
 `github.com/AltairaLabs/promptarena` repo. The release workflow
 (`.github/workflows/release.yml`) handles:
 1. **Validate** — semver format, version ordering, optional test suite
-2. **Tag libraries** — tags root `vX.Y.Z` from main, then bumps `runtime`/`pkg` internal requires to `vX.Y.Z` and drops `pkg`'s local `replace` on a `release/libs/` branch before tagging `runtime/`, `pkg/` from it
+2. **Tag libraries** — tags root `vX.Y.Z` and `runtime/` from main (runtime is a leaf — it must not depend on a sibling module, enforced by `scripts/check-runtime-is-leaf.sh`), then bumps `pkg`'s `require` on runtime to `vX.Y.Z` and drops its local `replace` on a `release/libs/` branch before tagging `pkg/` from it
 3. **Update & tag SDK modules** — removes `replace` directives, tags `sdk/`, `server/a2a/`
 4. **Create GitHub release** — `gh release create` (no binaries); publishing it triggers the docs/schema deployment
 5. **Notify downstream** — dispatches `promptkit-release` to the deploy repos

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ binaries, npm packages and Homebrew casks) release from the separate
 `github.com/AltairaLabs/promptarena` repo. The release workflow
 (`.github/workflows/release.yml`) handles:
 1. **Validate** — semver format, version ordering, optional test suite
-2. **Tag libraries** — tags `runtime/`, `pkg/`, and root `vX.Y.Z`, verifies Go proxy propagation
+2. **Tag libraries** — tags root `vX.Y.Z` from main, then bumps `runtime`/`pkg` internal requires to `vX.Y.Z` and drops `pkg`'s local `replace` on a `release/libs/` branch before tagging `runtime/`, `pkg/` from it
 3. **Update & tag SDK modules** — removes `replace` directives, tags `sdk/`, `server/a2a/`
 4. **Create GitHub release** — `gh release create` (no binaries); publishing it triggers the docs/schema deployment
 5. **Notify downstream** — dispatches `promptkit-release` to the deploy repos

--- a/docs/src/content/docs/runtime/reference/hooks.md
+++ b/docs/src/content/docs/runtime/reference/hooks.md
@@ -17,8 +17,8 @@ Package hooks provides synchronous interception points for provider calls, tool 
 
 - [Constants](<#constants>)
 - [Variables](<#variables>)
-- [func BuildExecHooks\(bindings map\[string\]\*config.ExecHook, sandboxes map\[string\]sandbox.Sandbox\) \(provider \[\]ProviderHook, tool \[\]ToolHook, session \[\]SessionHook, err error\)](<#BuildExecHooks>)
-- [func ResolveSandboxes\(specs map\[string\]\*config.SandboxConfig\) \(map\[string\]sandbox.Sandbox, error\)](<#ResolveSandboxes>)
+- [func BuildExecHooks\(bindings map\[string\]\*execconfig.ExecHook, sandboxes map\[string\]sandbox.Sandbox\) \(provider \[\]ProviderHook, tool \[\]ToolHook, session \[\]SessionHook, err error\)](<#BuildExecHooks>)
+- [func ResolveSandboxes\(specs map\[string\]\*execconfig.SandboxConfig\) \(map\[string\]sandbox.Sandbox, error\)](<#ResolveSandboxes>)
 - [type ChunkInterceptor](<#ChunkInterceptor>)
 - [type Decision](<#Decision>)
   - [func Deny\(reason string\) Decision](<#Deny>)
@@ -73,7 +73,7 @@ Package hooks provides synchronous interception points for provider calls, tool 
 
 ## Constants
 
-<a name="HookTypeProvider"></a>Hook type names as used in config.ExecHook.Hook.
+<a name="HookTypeProvider"></a>Hook type names as used in execconfig.ExecHook.Hook.
 
 ```go
 const (
@@ -111,16 +111,16 @@ var Allow = Decision{Allow: true} //nolint:gochecknoglobals // convenience senti
 ## func BuildExecHooks
 
 ```go
-func BuildExecHooks(bindings map[string]*config.ExecHook, sandboxes map[string]sandbox.Sandbox) (provider []ProviderHook, tool []ToolHook, session []SessionHook, err error)
+func BuildExecHooks(bindings map[string]*execconfig.ExecHook, sandboxes map[string]sandbox.Sandbox) (provider []ProviderHook, tool []ToolHook, session []SessionHook, err error)
 ```
 
-BuildExecHooks converts runtime\-config exec\-hook bindings into provider, tool, and session hook instances, resolving each binding's named sandbox from the provided map. Bindings with Hook=="eval" are skipped — eval hooks live in the evals package and are wired by the caller. This is the single source of truth for turning config.ExecHook bindings into runtime hooks, used by both the SDK and Arena so the two never drift.
+BuildExecHooks converts runtime\-config exec\-hook bindings into provider, tool, and session hook instances, resolving each binding's named sandbox from the provided map. Bindings with Hook=="eval" are skipped — eval hooks live in the evals package and are wired by the caller. This is the single source of truth for turning execconfig.ExecHook bindings into runtime hooks, used by both the SDK and Arena so the two never drift.
 
 <a name="ResolveSandboxes"></a>
 ## func ResolveSandboxes
 
 ```go
-func ResolveSandboxes(specs map[string]*config.SandboxConfig) (map[string]sandbox.Sandbox, error)
+func ResolveSandboxes(specs map[string]*execconfig.SandboxConfig) (map[string]sandbox.Sandbox, error)
 ```
 
 ResolveSandboxes builds a map from declared sandbox names to ready Sandbox instances using the process\-wide factory registry. Factories must have been registered \(via sandbox.RegisterFactory or a backend's init\) beforehand. Shared by the SDK and Arena so both resolve sandboxes identically.

--- a/pkg/config/execconfig_alias_test.go
+++ b/pkg/config/execconfig_alias_test.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/execconfig"
+)
+
+// The exec/sandbox binding types moved to runtime/hooks/execconfig to break the
+// runtime <-> pkg module cycle (issue #1713). They must stay *aliases*, not
+// defined types: runtime/hooks takes execconfig.ExecHook while the SDK reads
+// config.ExecHook out of a parsed RuntimeConfig, so a defined type would make
+// `hooks.BuildExecHooks(spec.Hooks, ...)` stop compiling for every consumer.
+func TestExecTypesAreAliasesOfExecconfig(t *testing.T) {
+	// Direct assignment in both directions compiles only for an alias. A
+	// defined type (`type ExecHook execconfig.ExecHook`) fails to build here.
+	var hook execconfig.ExecHook = ExecHook{Hook: "provider"}
+	var binding ExecBinding = execconfig.ExecBinding{Command: "./x"}
+	var sandbox execconfig.SandboxConfig = SandboxConfig{Mode: "direct"}
+
+	assert.Equal(t, "provider", hook.Hook)
+	assert.Equal(t, "./x", binding.Command)
+	assert.Equal(t, "direct", sandbox.Mode)
+
+	// Reflect identity is what the schema generator sees: promptarena keys its
+	// $defs off the bare type name, and a split type graph would emit two
+	// definitions where there is meant to be one.
+	assert.Equal(t, reflect.TypeOf(execconfig.ExecHook{}), reflect.TypeOf(ExecHook{}))
+	assert.Equal(t, reflect.TypeOf(execconfig.ExecBinding{}), reflect.TypeOf(ExecBinding{}))
+	assert.Equal(t, reflect.TypeOf(execconfig.SandboxConfig{}), reflect.TypeOf(SandboxConfig{}))
+}
+
+// Both moved structs rely on `yaml:",inline"` — ExecHook embeds ExecBinding
+// inline, and SandboxConfig sweeps unknown keys into an inline map. Losing
+// either tag in the move would still compile and still generate the same
+// schema, but would silently parse real configs into empty fields.
+func TestMovedTypesKeepInlineYAMLShape(t *testing.T) {
+	const src = `
+sandboxes:
+  docker:
+    mode: docker_run
+    image: alpine:3.20
+    network: none
+hooks:
+  audit:
+    command: ./hooks/audit
+    hook: session
+    phases: [before_call]
+    sandbox: docker
+    timeout_ms: 500
+`
+
+	var spec RuntimeConfigSpec
+	require.NoError(t, yaml.Unmarshal([]byte(src), &spec))
+
+	sb := spec.Sandboxes["docker"]
+	require.NotNil(t, sb)
+	assert.Equal(t, "docker_run", sb.Mode)
+	// Proves SandboxConfig.Config kept `yaml:",inline"`: mode is a named field,
+	// image/network are not and must land in the catch-all map.
+	assert.Equal(t, "alpine:3.20", sb.Config["image"])
+	assert.Equal(t, "none", sb.Config["network"])
+	assert.NotContains(t, sb.Config, "mode")
+
+	h := spec.Hooks["audit"]
+	require.NotNil(t, h)
+	assert.Equal(t, "session", h.Hook)
+	assert.Equal(t, []string{"before_call"}, h.Phases)
+	// Promoted from the embedded ExecBinding — empty here if the embed lost
+	// its inline tag and started expecting a nested `execBinding:` key.
+	assert.Equal(t, "./hooks/audit", h.Command)
+	assert.Equal(t, "docker", h.Sandbox)
+	assert.Equal(t, 500, h.TimeoutMs)
+}

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/execconfig"
 )
 
 // RuntimeConfig represents a runtime environment configuration in K8s-style manifest format.
@@ -253,60 +255,23 @@ type InferenceProviderConfig struct {
 	AdditionalConfig map[string]any `yaml:"additional_config,omitempty" json:"additional_config,omitempty" jsonschema:"title=Additional Config,description=Provider-specific extras"`
 }
 
-// SandboxConfig declares a named sandbox backend. Mode selects a
-// factory registered via runtime/hooks/sandbox.RegisterFactory; every
-// other field is passed to the factory as its config map.
-type SandboxConfig struct {
-	// Mode names a registered sandbox factory. "direct" ships in-tree
-	// and needs no extra registration.
-	//nolint:lll // jsonschema tags require single line
-	Mode string `yaml:"mode" json:"mode" jsonschema:"title=Mode,description=Registered sandbox factory name (direct ships in-tree; docker_run/docker_exec/kubectl_exec are examples)"`
+// The exec-hook, exec-eval and sandbox binding types live in
+// runtime/hooks/execconfig, not here. runtime/hooks needs them to build hooks
+// and this package needs them to parse a RuntimeConfig, so declaring them in
+// either module makes runtime and pkg require each other — the module cycle
+// behind issue #1713. They are aliases, not wrappers: config.ExecHook and
+// execconfig.ExecHook are the same type, so call sites, YAML tags and the
+// generated JSON schema are all unchanged.
+type (
+	// SandboxConfig declares a named sandbox backend.
+	SandboxConfig = execconfig.SandboxConfig
 
-	// Config carries mode-specific configuration. Each factory
-	// documents its own keys. For example, the docker_run example
-	// expects "image", "network", and "mounts".
-	Config map[string]any `yaml:",inline" json:"-" jsonschema:"-"`
-}
+	// ExecBinding defines how to invoke an external process for tool or eval execution.
+	ExecBinding = execconfig.ExecBinding
 
-// ExecBinding defines how to invoke an external process for tool or eval execution.
-type ExecBinding struct {
-	// Command is the path to the executable, resolved relative to the config file.
-	Command string `yaml:"command" json:"command" jsonschema:"title=Command,description=Path to the executable"`
-	// Runtime selects the execution mode: "exec" (one-shot, default) or "server" (long-running JSON-RPC).
-	//nolint:lll // jsonschema tags require single line
-	Runtime string `yaml:"runtime,omitempty" json:"runtime,omitempty" jsonschema:"enum=exec,enum=server,default=exec,title=Runtime,description=Execution mode"`
-	// Env lists environment variable names required by the process. Values come from the host environment.
-	//nolint:lll // jsonschema tags require single line
-	Env []string `yaml:"env,omitempty" json:"env,omitempty" jsonschema:"title=Env,description=Required environment variable names"`
-	// Args are additional arguments passed to the command.
-	//nolint:lll // jsonschema tags require single line
-	Args []string `yaml:"args,omitempty" json:"args,omitempty" jsonschema:"title=Args,description=Additional command arguments"`
-	// TimeoutMs is the per-invocation timeout in milliseconds.
-	//nolint:lll // jsonschema tags require single line
-	TimeoutMs int `yaml:"timeout_ms,omitempty" json:"timeout_ms,omitempty" jsonschema:"title=Timeout,description=Per-invocation timeout in milliseconds"`
-	// Sandbox names a sandbox backend declared under spec.sandboxes.
-	// When empty the built-in "direct" backend is used. Only applies to
-	// exec hooks; ignored for exec tools and exec eval handlers (which
-	// reuse this struct via embedding but do not yet support sandboxing).
-	//nolint:lll // jsonschema tags require single line
-	Sandbox string `yaml:"sandbox,omitempty" json:"sandbox,omitempty" jsonschema:"title=Sandbox,description=Name of a sandbox declared under spec.sandboxes"`
-}
-
-// ExecHook defines an external process hook bound to a pipeline lifecycle event.
-type ExecHook struct {
-	ExecBinding `yaml:",inline"`
-	// Hook identifies the hook interface: "provider", "tool", "session", or "eval".
-	// "eval" hooks are observational and ignore Phases / Mode — they run
-	// once per eval result, fire-and-forget.
-	//nolint:lll // jsonschema tags require single line
-	Hook string `yaml:"hook" json:"hook" jsonschema:"enum=provider,enum=tool,enum=session,enum=eval,title=Hook,description=Hook interface type"`
-	// Phases lists the hook phases to intercept (e.g. before_call, after_call).
-	//nolint:lll // jsonschema tags require single line
-	Phases []string `yaml:"phases,omitempty" json:"phases,omitempty" jsonschema:"title=Phases,description=Hook phases to intercept"`
-	// Mode is the hook execution mode: "filter" (synchronous, can modify/deny) or "observe" (async, fire-and-forget).
-	//nolint:lll // jsonschema tags require single line
-	Mode string `yaml:"mode,omitempty" json:"mode,omitempty" jsonschema:"enum=filter,enum=observe,default=filter,title=Mode,description=Hook execution mode"`
-}
+	// ExecHook defines an external process hook bound to a pipeline lifecycle event.
+	ExecHook = execconfig.ExecHook
+)
 
 // State store type constants.
 const (

--- a/runtime/CLAUDE.md
+++ b/runtime/CLAUDE.md
@@ -8,6 +8,10 @@ The runtime is PromptKit's core library. It defines all interfaces, executes LLM
 
 **Runtime has zero dependencies on `sdk/` or downstream consumers (PromptArena)**. All extensibility is via interfaces that higher-level modules implement. If you need to add functionality that both SDK and Arena use, it belongs here.
 
+**Runtime is also a leaf module — it must not depend on `pkg/` either.** `runtime/go.mod` carries no `require` or `replace` on a sibling PromptKit module, and `scripts/check-runtime-is-leaf.sh` enforces it in CI and again before release tagging. Runtime used to import `pkg/config` from `hooks/exec_build.go`, which made the two modules require each other; that cycle is why every published library tag shipped a stale internal `require` for five releases (issue #1713).
+
+If runtime and `pkg/config` both need a declarative type, put it in `runtime/hooks/execconfig` (a stdlib-only leaf package) and re-export it from `pkg/config` as an **alias** — `type ExecHook = execconfig.ExecHook`. An alias keeps call sites, YAML tags and the generated JSON schema identical; a defined type does not.
+
 ## Architecture Overview
 
 ```

--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -5,7 +5,6 @@ go 1.26.0
 retract v1.4.0 // Published prematurely; missing StreamMediaData changes and breaking MediaDelta removal
 
 require (
-	github.com/AltairaLabs/PromptKit/pkg v1.5.3
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/runtime/go.sum
+++ b/runtime/go.sum
@@ -1,7 +1,5 @@
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
-github.com/AltairaLabs/PromptKit/pkg v1.5.3 h1:1ZBdhCE+gAX2JP1u8//Ma2kYu3iO79p1GV4lKXtfmig=
-github.com/AltairaLabs/PromptKit/pkg v1.5.3/go.mod h1:rptlFxs6zCsuFAwb7yPcRQD1OLqatbQV7fopq0eW1f4=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0 h1:aokoqcHvaGjiM3VpjKDfMMnF/8epJ+Q1HLJ7CudztqE=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0/go.mod h1:/WYEx9pcM9Y+Dd/APJaNlSvVSvzl54rrMdZT5+Oi2LM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0 h1:CU4+EJeJi3TKYWEcYuSdWsjzw0nVsK/H0MSQOiPcymU=

--- a/runtime/hooks/exec_build.go
+++ b/runtime/hooks/exec_build.go
@@ -3,11 +3,11 @@ package hooks
 import (
 	"fmt"
 
-	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/execconfig"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks/sandbox"
 )
 
-// Hook type names as used in config.ExecHook.Hook.
+// Hook type names as used in execconfig.ExecHook.Hook.
 const (
 	HookTypeProvider = "provider"
 	HookTypeTool     = "tool"
@@ -19,7 +19,7 @@ const (
 // instances using the process-wide factory registry. Factories must have been
 // registered (via sandbox.RegisterFactory or a backend's init) beforehand.
 // Shared by the SDK and Arena so both resolve sandboxes identically.
-func ResolveSandboxes(specs map[string]*config.SandboxConfig) (map[string]sandbox.Sandbox, error) {
+func ResolveSandboxes(specs map[string]*execconfig.SandboxConfig) (map[string]sandbox.Sandbox, error) {
 	if len(specs) == 0 {
 		return nil, nil
 	}
@@ -45,9 +45,9 @@ func ResolveSandboxes(specs map[string]*config.SandboxConfig) (map[string]sandbo
 // and session hook instances, resolving each binding's named sandbox from the
 // provided map. Bindings with Hook=="eval" are skipped — eval hooks live in the
 // evals package and are wired by the caller. This is the single source of truth
-// for turning config.ExecHook bindings into runtime hooks, used by both the SDK
+// for turning execconfig.ExecHook bindings into runtime hooks, used by both the SDK
 // and Arena so the two never drift.
-func BuildExecHooks(bindings map[string]*config.ExecHook, sandboxes map[string]sandbox.Sandbox) (
+func BuildExecHooks(bindings map[string]*execconfig.ExecHook, sandboxes map[string]sandbox.Sandbox) (
 	provider []ProviderHook, tool []ToolHook, session []SessionHook, err error) {
 	for name, b := range bindings {
 		if b == nil {

--- a/runtime/hooks/exec_build_test.go
+++ b/runtime/hooks/exec_build_test.go
@@ -3,7 +3,7 @@ package hooks
 import (
 	"testing"
 
-	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/execconfig"
 )
 
 func TestResolveSandboxes_NilAndEmpty(t *testing.T) {
@@ -11,7 +11,7 @@ func TestResolveSandboxes_NilAndEmpty(t *testing.T) {
 	if err != nil || out != nil {
 		t.Fatalf("nil specs: got out=%v err=%v", out, err)
 	}
-	out, err = ResolveSandboxes(map[string]*config.SandboxConfig{"skip": nil})
+	out, err = ResolveSandboxes(map[string]*execconfig.SandboxConfig{"skip": nil})
 	if err != nil {
 		t.Fatalf("nil entry: %v", err)
 	}
@@ -21,7 +21,7 @@ func TestResolveSandboxes_NilAndEmpty(t *testing.T) {
 }
 
 func TestResolveSandboxes_UnknownMode(t *testing.T) {
-	_, err := ResolveSandboxes(map[string]*config.SandboxConfig{
+	_, err := ResolveSandboxes(map[string]*execconfig.SandboxConfig{
 		"x": {Mode: "not_a_registered_mode"},
 	})
 	if err == nil {
@@ -30,11 +30,11 @@ func TestResolveSandboxes_UnknownMode(t *testing.T) {
 }
 
 func TestBuildExecHooks_ByType(t *testing.T) {
-	bindings := map[string]*config.ExecHook{
-		"p": {Hook: "provider", ExecBinding: config.ExecBinding{Command: "echo"}},
-		"t": {Hook: "tool", ExecBinding: config.ExecBinding{Command: "echo"}},
-		"s": {Hook: "session", ExecBinding: config.ExecBinding{Command: "echo"}},
-		"e": {Hook: "eval", ExecBinding: config.ExecBinding{Command: "echo"}}, // skipped
+	bindings := map[string]*execconfig.ExecHook{
+		"p": {Hook: "provider", ExecBinding: execconfig.ExecBinding{Command: "echo"}},
+		"t": {Hook: "tool", ExecBinding: execconfig.ExecBinding{Command: "echo"}},
+		"s": {Hook: "session", ExecBinding: execconfig.ExecBinding{Command: "echo"}},
+		"e": {Hook: "eval", ExecBinding: execconfig.ExecBinding{Command: "echo"}}, // skipped
 	}
 	provider, tool, session, err := BuildExecHooks(bindings, nil)
 	if err != nil {
@@ -47,15 +47,15 @@ func TestBuildExecHooks_ByType(t *testing.T) {
 }
 
 func TestBuildExecHooks_NilBindingSkipped(t *testing.T) {
-	p, to, s, err := BuildExecHooks(map[string]*config.ExecHook{"nil": nil}, nil)
+	p, to, s, err := BuildExecHooks(map[string]*execconfig.ExecHook{"nil": nil}, nil)
 	if err != nil || len(p)+len(to)+len(s) != 0 {
 		t.Fatalf("nil binding should be skipped: p=%d t=%d s=%d err=%v", len(p), len(to), len(s), err)
 	}
 }
 
 func TestBuildExecHooks_UnknownType(t *testing.T) {
-	_, _, _, err := BuildExecHooks(map[string]*config.ExecHook{
-		"x": {Hook: "bogus", ExecBinding: config.ExecBinding{Command: "echo"}},
+	_, _, _, err := BuildExecHooks(map[string]*execconfig.ExecHook{
+		"x": {Hook: "bogus", ExecBinding: execconfig.ExecBinding{Command: "echo"}},
 	}, nil)
 	if err == nil {
 		t.Fatal("expected error for unknown hook type")
@@ -63,8 +63,8 @@ func TestBuildExecHooks_UnknownType(t *testing.T) {
 }
 
 func TestBuildExecHooks_UndeclaredSandbox(t *testing.T) {
-	_, _, _, err := BuildExecHooks(map[string]*config.ExecHook{
-		"x": {Hook: "session", ExecBinding: config.ExecBinding{Command: "echo", Sandbox: "ghost"}},
+	_, _, _, err := BuildExecHooks(map[string]*execconfig.ExecHook{
+		"x": {Hook: "session", ExecBinding: execconfig.ExecBinding{Command: "echo", Sandbox: "ghost"}},
 	}, nil)
 	if err == nil {
 		t.Fatal("expected error for undeclared sandbox reference")

--- a/runtime/hooks/execconfig/execconfig.go
+++ b/runtime/hooks/execconfig/execconfig.go
@@ -1,0 +1,74 @@
+// Package execconfig holds the declarative shape of exec-hook, exec-eval and
+// sandbox bindings.
+//
+// It exists to keep runtime a leaf module. These types are consumed by
+// runtime/hooks (which builds hooks from them) and declared by pkg/config
+// (which parses them out of a RuntimeConfig), so putting them in either place
+// makes runtime and pkg require each other — a module cycle that let every
+// published tag ship a stale internal require for five releases (issue #1713).
+//
+// pkg/config re-exports every type here as an alias, so `config.ExecHook` and
+// `execconfig.ExecHook` are the same type and existing call sites are
+// unaffected. Keep the type names stable: promptarena's schema generator keys
+// its `$defs` off the bare Go type name, so renaming one silently rewrites the
+// published JSON schema.
+//
+// This package must import nothing but the standard library. Anything it pulls
+// in becomes a dependency of pkg/config, and a PromptKit import here would
+// re-create the cycle it exists to break.
+package execconfig
+
+// SandboxConfig declares a named sandbox backend. Mode selects a
+// factory registered via runtime/hooks/sandbox.RegisterFactory; every
+// other field is passed to the factory as its config map.
+type SandboxConfig struct {
+	// Mode names a registered sandbox factory. "direct" ships in-tree
+	// and needs no extra registration.
+	//nolint:lll // jsonschema tags require single line
+	Mode string `yaml:"mode" json:"mode" jsonschema:"title=Mode,description=Registered sandbox factory name (direct ships in-tree; docker_run/docker_exec/kubectl_exec are examples)"`
+
+	// Config carries mode-specific configuration. Each factory
+	// documents its own keys. For example, the docker_run example
+	// expects "image", "network", and "mounts".
+	Config map[string]any `yaml:",inline" json:"-" jsonschema:"-"`
+}
+
+// ExecBinding defines how to invoke an external process for tool or eval execution.
+type ExecBinding struct {
+	// Command is the path to the executable, resolved relative to the config file.
+	Command string `yaml:"command" json:"command" jsonschema:"title=Command,description=Path to the executable"`
+	// Runtime selects the execution mode: "exec" (one-shot, default) or "server" (long-running JSON-RPC).
+	//nolint:lll // jsonschema tags require single line
+	Runtime string `yaml:"runtime,omitempty" json:"runtime,omitempty" jsonschema:"enum=exec,enum=server,default=exec,title=Runtime,description=Execution mode"`
+	// Env lists environment variable names required by the process. Values come from the host environment.
+	//nolint:lll // jsonschema tags require single line
+	Env []string `yaml:"env,omitempty" json:"env,omitempty" jsonschema:"title=Env,description=Required environment variable names"`
+	// Args are additional arguments passed to the command.
+	//nolint:lll // jsonschema tags require single line
+	Args []string `yaml:"args,omitempty" json:"args,omitempty" jsonschema:"title=Args,description=Additional command arguments"`
+	// TimeoutMs is the per-invocation timeout in milliseconds.
+	//nolint:lll // jsonschema tags require single line
+	TimeoutMs int `yaml:"timeout_ms,omitempty" json:"timeout_ms,omitempty" jsonschema:"title=Timeout,description=Per-invocation timeout in milliseconds"`
+	// Sandbox names a sandbox backend declared under spec.sandboxes.
+	// When empty the built-in "direct" backend is used. Only applies to
+	// exec hooks; ignored for exec tools and exec eval handlers (which
+	// reuse this struct via embedding but do not yet support sandboxing).
+	//nolint:lll // jsonschema tags require single line
+	Sandbox string `yaml:"sandbox,omitempty" json:"sandbox,omitempty" jsonschema:"title=Sandbox,description=Name of a sandbox declared under spec.sandboxes"`
+}
+
+// ExecHook defines an external process hook bound to a pipeline lifecycle event.
+type ExecHook struct {
+	ExecBinding `yaml:",inline"`
+	// Hook identifies the hook interface: "provider", "tool", "session", or "eval".
+	// "eval" hooks are observational and ignore Phases / Mode — they run
+	// once per eval result, fire-and-forget.
+	//nolint:lll // jsonschema tags require single line
+	Hook string `yaml:"hook" json:"hook" jsonschema:"enum=provider,enum=tool,enum=session,enum=eval,title=Hook,description=Hook interface type"`
+	// Phases lists the hook phases to intercept (e.g. before_call, after_call).
+	//nolint:lll // jsonschema tags require single line
+	Phases []string `yaml:"phases,omitempty" json:"phases,omitempty" jsonschema:"title=Phases,description=Hook phases to intercept"`
+	// Mode is the hook execution mode: "filter" (synchronous, can modify/deny) or "observe" (async, fire-and-forget).
+	//nolint:lll // jsonschema tags require single line
+	Mode string `yaml:"mode,omitempty" json:"mode,omitempty" jsonschema:"enum=filter,enum=observe,default=filter,title=Mode,description=Hook execution mode"`
+}

--- a/scripts/check-runtime-is-leaf.sh
+++ b/scripts/check-runtime-is-leaf.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Guards issue #1713: runtime must not depend on any sibling PromptKit module.
+#
+# runtime/hooks used to import pkg/config while pkg/config imports
+# runtime/{credentials,providers/base,tools,...}, so the two modules required
+# each other. Module cycles are legal in Go, but they make the release
+# ordering circular: neither tag can be cut with a correct `require` on the
+# other without editing both go.mod files in the same commit. That is how
+# every published tag ended up with a stale internal require.
+#
+# The shared binding types now live in runtime/hooks/execconfig, a leaf package
+# pkg/config re-exports as aliases. Keep it that way: if runtime needs a type
+# that pkg/config also needs, put it in execconfig (or another runtime leaf
+# package) rather than importing pkg/config from runtime.
+#
+# Run from the repo root: scripts/check-runtime-is-leaf.sh
+set -euo pipefail
+
+GOMOD="${1:-runtime/go.mod}"
+
+if [ ! -f "$GOMOD" ]; then
+	echo "ERROR: no such file: $GOMOD (run from the repo root)"
+	exit 2
+fi
+
+# Matches a require/replace of another PromptKit module in either the
+# single-line or the parenthesised-block form. The `module github.com/...`
+# declaration starts with "module " and is deliberately not matched.
+PATTERN='^[[:space:]]*(require[[:space:]]+|replace[[:space:]]+)?github\.com/AltairaLabs/PromptKit/'
+
+if grep -nE "$PATTERN" "$GOMOD"; then
+	echo ""
+	echo "FAIL: $GOMOD depends on a sibling PromptKit module (issue #1713)."
+	echo ""
+	echo "runtime is the foundation — see runtime/CLAUDE.md. Depending on pkg,"
+	echo "sdk or server/a2a re-creates the module cycle that made every published"
+	echo "library tag ship a stale internal require."
+	echo ""
+	echo "If runtime and pkg/config both need a type, declare it in"
+	echo "runtime/hooks/execconfig (or another runtime leaf package) and re-export"
+	echo "it from pkg/config as an alias."
+	exit 1
+fi
+
+echo "OK: $GOMOD has no sibling PromptKit dependencies — runtime is a leaf."

--- a/scripts/test-verify-published-gomod.sh
+++ b/scripts/test-verify-published-gomod.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# Fixture tests for scripts/verify-published-gomod.sh.
+#
+# Each case names the mutation it catches, because a guard that cannot fail is
+# worse than no guard — that is exactly how issue #1713 survived five releases.
+#
+# Run from the repo root: scripts/test-verify-published-gomod.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERIFY="$SCRIPT_DIR/verify-published-gomod.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+indent() { awk '{ print "      " $0 }'; }
+
+# expect <name> <want-exit> <version> <gomod-content> [<substring the output must contain>]
+expect() {
+	local name="$1" want="$2" version="$3" content="$4" needle="${5:-}"
+	local file="$WORK/$name.mod"
+	local out got=0
+
+	printf '%s' "$content" >"$file"
+	out="$("$VERIFY" --file "$file" "$version" 2>&1)" || got=$?
+
+	if [ "$got" -ne "$want" ]; then
+		echo "FAIL: $name — exit $got, wanted $want"
+		echo "$out" | indent
+		fail=$((fail + 1))
+		return
+	fi
+	if [ -n "$needle" ] && ! printf '%s' "$out" | grep -qF "$needle"; then
+		echo "FAIL: $name — output missing '$needle'"
+		echo "$out" | indent
+		fail=$((fail + 1))
+		return
+	fi
+	echo "OK:   $name"
+	pass=$((pass + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Clean go.mod files must pass. Catches a guard that rejects everything, which
+# would be indistinguishable from a working guard on the bad fixtures below.
+# ---------------------------------------------------------------------------
+
+expect "clean-block-requires" 0 v1.5.8 'module github.com/AltairaLabs/PromptKit/sdk
+
+go 1.26.0
+
+require (
+	github.com/AltairaLabs/PromptKit/pkg v1.5.8
+	github.com/AltairaLabs/PromptKit/runtime v1.5.8
+	github.com/AltairaLabs/PromptKit/server/a2a v1.5.8
+	github.com/stretchr/testify v1.11.1
+)
+'
+
+expect "clean-single-line-require" 0 v1.5.8 'module github.com/AltairaLabs/PromptKit/pkg
+
+go 1.26.0
+
+require github.com/AltairaLabs/PromptKit/runtime v1.5.8
+'
+
+# A module with no internal dependencies at all is correct by construction.
+# Catches a guard that demands at least one internal require.
+expect "no-internal-deps" 0 v1.5.8 'module github.com/AltairaLabs/PromptKit/runtime
+
+go 1.26.0
+
+require (
+	github.com/google/uuid v1.6.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+'
+
+# Third-party replaces and requires at other versions are none of our business.
+# Catches a guard that matches any `replace`, or that version-checks every require.
+expect "external-replace-and-requires-ignored" 0 v1.5.8 'module github.com/AltairaLabs/PromptKit/pkg
+
+go 1.26.0
+
+replace github.com/xeipuuv/gojsonschema => github.com/AltairaLabsFork/gojsonschema v1.0.0
+
+require (
+	github.com/AltairaLabs/PromptKit/runtime v1.5.8
+	github.com/stretchr/testify v1.11.1
+	k8s.io/apimachinery v0.36.3
+)
+'
+
+# retract blocks contain bare versions that are not requires.
+# Catches a parser that treats every block line as a require.
+expect "retract-block-ignored" 0 v1.5.8 'module github.com/AltairaLabs/PromptKit/pkg
+
+go 1.26.0
+
+retract v1.4.0 // Published prematurely; use v1.4.1+
+
+retract (
+	v1.4.0
+	v1.2.3
+)
+
+require github.com/AltairaLabs/PromptKit/runtime v1.5.8
+'
+
+# ---------------------------------------------------------------------------
+# Bad go.mod files must fail, and must name the offender.
+# ---------------------------------------------------------------------------
+
+# The pkg/v1.5.7 defect exactly: a masked replace plus the stale require it hid.
+expect "issue-1713-shape" 1 v1.5.8 'module github.com/AltairaLabs/PromptKit/pkg
+
+go 1.26.0
+
+replace github.com/AltairaLabs/PromptKit/runtime => ../runtime
+
+require (
+	github.com/AltairaLabs/PromptKit/runtime v1.3.5
+	github.com/stretchr/testify v1.11.1
+)
+' "github.com/AltairaLabs/PromptKit/runtime"
+
+# Catches a guard that only inspects require lines.
+expect "single-line-internal-replace" 1 v1.5.8 'module github.com/AltairaLabs/PromptKit/pkg
+
+go 1.26.0
+
+replace github.com/AltairaLabs/PromptKit/runtime => ../runtime
+
+require github.com/AltairaLabs/PromptKit/runtime v1.5.8
+' "replace"
+
+# Catches a parser that only handles the single-line replace form.
+expect "block-internal-replace" 1 v1.5.8 'module github.com/AltairaLabs/PromptKit/sdk
+
+go 1.26.0
+
+replace (
+	github.com/AltairaLabs/PromptKit/pkg => ../pkg
+	github.com/AltairaLabs/PromptKit/runtime => ../runtime
+)
+
+require (
+	github.com/AltairaLabs/PromptKit/pkg v1.5.8
+	github.com/AltairaLabs/PromptKit/runtime v1.5.8
+)
+' "replace"
+
+# The runtime -> pkg half of #1713: a plain stale require, no replace masking it.
+# Catches a guard that only looks for replaces.
+expect "stale-internal-require" 1 v1.5.8 'module github.com/AltairaLabs/PromptKit/runtime
+
+go 1.26.0
+
+require (
+	github.com/AltairaLabs/PromptKit/pkg v1.5.3
+	github.com/google/uuid v1.6.0
+)
+' "v1.5.3"
+
+# Catches a guard that skips indirect requires — sdk carries pkg as indirect in
+# some example modules, and an indirect stale require is just as wrong.
+expect "stale-indirect-require" 1 v1.5.8 'module github.com/AltairaLabs/PromptKit/sdk
+
+go 1.26.0
+
+require (
+	github.com/AltairaLabs/PromptKit/runtime v1.5.8
+	github.com/AltairaLabs/PromptKit/pkg v1.5.3 // indirect
+)
+' "v1.5.3"
+
+# Catches a guard that uses substring/prefix matching on the version instead of
+# equality — v1.5.80 contains v1.5.8.
+expect "version-near-miss" 1 v1.5.8 'module github.com/AltairaLabs/PromptKit/pkg
+
+go 1.26.0
+
+require github.com/AltairaLabs/PromptKit/runtime v1.5.80
+' "v1.5.80"
+
+# A pseudo-version is never a release version.
+# Catches a guard that only rejects lower semver.
+expect "pseudo-version-require" 1 v1.5.8 'module github.com/AltairaLabs/PromptKit/pkg
+
+go 1.26.0
+
+require github.com/AltairaLabs/PromptKit/runtime v0.0.0-20260101000000-abcdef123456
+' "v0.0.0-"
+
+# ---------------------------------------------------------------------------
+# Argument handling.
+# ---------------------------------------------------------------------------
+
+got=0
+"$VERIFY" >/dev/null 2>&1 || got=$?
+if [ "$got" -eq 0 ]; then
+	echo "FAIL: no-arguments — expected non-zero exit"
+	fail=$((fail + 1))
+else
+	echo "OK:   no-arguments"
+	pass=$((pass + 1))
+fi
+
+got=0
+"$VERIFY" --file "$WORK/does-not-exist.mod" v1.5.8 >/dev/null 2>&1 || got=$?
+if [ "$got" -eq 0 ]; then
+	echo "FAIL: missing-file — expected non-zero exit"
+	fail=$((fail + 1))
+else
+	echo "OK:   missing-file"
+	pass=$((pass + 1))
+fi
+
+echo ""
+if [ "$fail" -ne 0 ]; then
+	echo "$fail failed, $pass passed"
+	exit 1
+fi
+echo "All $pass checks passed."

--- a/scripts/verify-published-gomod.sh
+++ b/scripts/verify-published-gomod.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# Guards issue #1713: a published module tag must not carry a local `replace`
+# on a sibling PromptKit module, and every internal `require` must name the
+# version being released.
+#
+# Go ignores `replace` directives in dependency modules but honors `require`, so
+# a stale internal require reaches consumers. It stayed invisible for five
+# releases because the local replace in pkg/go.mod meant no workspace or CI
+# build ever exercised the require line.
+#
+# Usage:
+#   verify-published-gomod.sh <version> <module>...   # fetch from the Go proxy
+#   verify-published-gomod.sh --file <path> <version> # check a local go.mod
+#
+# Modules are repo-relative module directories: runtime, pkg, sdk, server/a2a.
+#
+# Exit status:
+#   0  every go.mod checked is clean (or never propagated — see below)
+#   1  at least one published go.mod is wrong
+#   2  usage error
+#
+# A module that never appears on the proxy within the retry budget is reported
+# as a warning, not a failure: that is a propagation problem, not a correctness
+# one, and the existing release steps already treat propagation as advisory.
+set -euo pipefail
+
+PROXY_PREFIX="https://proxy.golang.org/github.com/!altaira!labs/!prompt!kit"
+RETRIES="${VERIFY_GOMOD_RETRIES:-10}"
+RETRY_SLEEP="${VERIFY_GOMOD_SLEEP:-20}"
+
+INTERNAL_PREFIX='github.com/AltairaLabs/PromptKit/'
+
+read -r -d '' AWK_PROG <<'AWK' || true
+BEGIN { block = ""; bad = 0 }
+
+function check_require(s,   n, a) {
+	n = split(s, a, /[ \t]+/)
+	if (n < 2) return
+	if (index(a[1], PREFIX) != 1) return
+	if (a[2] != VERSION) {
+		printf("  BAD  require %s %s (expected %s)\n", a[1], a[2], VERSION)
+		bad++
+	}
+}
+
+function check_replace(s,   n, a) {
+	n = split(s, a, /[ \t]+/)
+	if (n < 1 || a[1] == "") return
+	if (index(a[1], PREFIX) != 1) return
+	printf("  BAD  replace %s (internal replace must be dropped before tagging)\n", a[1])
+	bad++
+}
+
+{
+	line = $0
+	sub(/\/\/.*$/, "", line)
+	gsub(/^[ \t]+|[ \t]+$/, "", line)
+	if (line == "") next
+
+	if (block != "") {
+		if (line == ")") { block = "" }
+		else if (block == "require") { check_require(line) }
+		else if (block == "replace") { check_replace(line) }
+		next
+	}
+
+	if (line ~ /^require[ \t]*\($/)  { block = "require"; next }
+	if (line ~ /^replace[ \t]*\($/)  { block = "replace"; next }
+	if (line ~ /^[a-z]+[ \t]*\($/)   { block = "other";   next }
+	if (line ~ /^require[ \t]+/)     { sub(/^require[ \t]+/, "", line); check_require(line); next }
+	if (line ~ /^replace[ \t]+/)     { sub(/^replace[ \t]+/, "", line); check_replace(line); next }
+}
+
+END { exit (bad > 0 ? 1 : 0) }
+AWK
+
+usage() {
+	sed -n '3,25p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+annotate_error() {
+	if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+		echo "::error::$1"
+	else
+		echo "ERROR: $1"
+	fi
+}
+
+# check_gomod <file> <version> <label>
+check_gomod() {
+	local file="$1" version="$2" label="$3"
+	echo "Checking $label ..."
+	if awk -v VERSION="$version" -v PREFIX="$INTERNAL_PREFIX" "$AWK_PROG" "$file"; then
+		echo "  OK   no internal replace directives; internal requires all at $version"
+		return 0
+	fi
+	annotate_error "$label go.mod is not release-clean (see BAD lines above)"
+	return 1
+}
+
+if [ "$#" -lt 2 ]; then
+	usage
+	exit 2
+fi
+
+if [ "$1" = "--file" ]; then
+	FILE="$2"
+	VERSION="${3:-}"
+	if [ -z "$VERSION" ]; then
+		usage
+		exit 2
+	fi
+	if [ ! -f "$FILE" ]; then
+		annotate_error "no such file: $FILE"
+		exit 2
+	fi
+	check_gomod "$FILE" "$VERSION" "$FILE"
+	exit $?
+fi
+
+VERSION="$1"
+shift
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+failed=0
+skipped=0
+
+for module in "$@"; do
+	url="$PROXY_PREFIX/$module/@v/$VERSION.mod"
+	out="$WORK/$(echo "$module" | tr '/' '_').mod"
+	fetched=0
+
+	for attempt in $(seq 1 "$RETRIES"); do
+		if curl -f -s "$url" -o "$out"; then
+			fetched=1
+			break
+		fi
+		if [ "$attempt" -lt "$RETRIES" ]; then
+			echo "  attempt $attempt/$RETRIES: $module@$VERSION not on the Go proxy yet, waiting ${RETRY_SLEEP}s..."
+			sleep "$RETRY_SLEEP"
+		fi
+	done
+
+	if [ "$fetched" -ne 1 ]; then
+		echo "WARN: $module@$VERSION never appeared on the Go proxy — go.mod not verified"
+		skipped=$((skipped + 1))
+		continue
+	fi
+
+	if ! check_gomod "$out" "$VERSION" "$module@$VERSION"; then
+		failed=$((failed + 1))
+	fi
+done
+
+echo ""
+if [ "$failed" -ne 0 ]; then
+	annotate_error "$failed published module(s) at $VERSION have a bad go.mod"
+	echo "Tags are immutable — the bad tag cannot be fixed in place. Release a new"
+	echo "patch version once release.yml's go.mod cleanup is corrected."
+	exit 1
+fi
+
+if [ "$skipped" -ne 0 ]; then
+	echo "$skipped module(s) not verified (Go proxy propagation); the rest are clean."
+	exit 0
+fi
+
+echo "All published go.mod files at $VERSION are release-clean."


### PR DESCRIPTION
Closes #1713.

## What was wrong

`release.yml`'s `tag-dependencies` job tagged `runtime`, `pkg` and the root straight from the checked-out tree with **no `go mod edit`**. Go ignores `replace` in a dependency module but honors `require`, so the stale requires reach consumers — `go get pkg@v1.5.7` resolves `runtime v1.3.5`.

**Both directions of the cycle were wrong, not just the one the issue reported.** `runtime/hooks/exec_build.go` imports `pkg/config`, and `pkg/config` imports `runtime/{credentials,providers/base,prompt/schema,tools,httputil}` — so the `# runtime is a true leaf` comment at `release.yml:229` was wrong on both counts:

| Published tag | requires | why it was invisible |
|---|---|---|
| `pkg/v1.5.7` | `runtime v1.3.5` | masked by `replace .../runtime => ../runtime` in `pkg/go.mod` |
| `runtime/v1.5.7` | `pkg v1.5.3` | no replace at all — the require line was simply never bumped |

Blast radius today, verified against proxy.golang.org with scratch modules at `GOWORK=off`: both combinations still build. `pkg@v1.5.7` only survives because `go mod tidy` silently upgraded `runtime` to v1.5.7 — `runtime/httputil` does not exist in v1.3.5. That is luck, not design. PromptArena pins `pkg` **and** `runtime` at v1.5.7 explicitly, so it is unaffected.

## The fix

The libs phase gets the release-branch treatment `sdk`/`server/a2a` already have:

1. **Tag root `$VERSION` from main first** — the GitHub release, and therefore the docs/schema deploy, hangs off this tag, so it must stay on a main commit.
2. Create `release/libs/$VERSION`.
3. `go mod edit -require=.../pkg@$VERSION` in `runtime`; `-require=.../runtime@$VERSION` + `-dropreplace` in `pkg`. Both guarded by the same `^replace` assertion the sdk step uses.
4. Commit, push, tag `runtime/$VERSION` and `pkg/$VERSION` from the branch.

The two modules now require each other at `$VERSION`. That is legal — Go forbids package cycles, not module cycles — and MVS resolves it.

`pkg` keeps its local `replace` **on main**; only the tag drops it. Removing it from main would need `pkg/go.sum` populated and would pin `pkg` to the *previous* release's runtime, breaking local dev whenever `pkg` needs a new runtime API.

### Why this was simpler than the issue expected

The issue assumed `runtime/$VERSION` had to be proxy-visible before anything could require it. It does not. A dependency module's `go.sum` is never consulted — Go verifies downloads against the **main** module's `go.sum` (`pkg@v1.5.7` has zero `AltairaLabs` lines in its own `go.sum` and resolves fine). So no `go mod tidy` is needed, and `go mod edit` is pure text manipulation that does not require the target tag to exist. The ordering problem disappears.

## The guard

`scripts/verify-published-gomod.sh` fetches each published `go.mod` from the Go proxy and fails on an internal `replace` or an internal `require` at anything but `$VERSION`. It replaces the two old availability checks, which it subsumes, and drops `continue-on-error` on the `update-tools` one. A propagation timeout still passes — that is availability, not correctness — but a bad `go.mod` stops the release.

**Real-data proof**, run against the already-published v1.5.7 tags:

```
Checking runtime@v1.5.7 ...
  BAD  require github.com/AltairaLabs/PromptKit/pkg v1.5.3 (expected v1.5.7)
Checking pkg@v1.5.7 ...
  BAD  replace github.com/AltairaLabs/PromptKit/runtime (internal replace must be dropped before tagging)
  BAD  require github.com/AltairaLabs/PromptKit/runtime v1.3.5 (expected v1.5.7)
Checking sdk@v1.5.7 ...
  BAD  replace github.com/AltairaLabs/PromptKit/pkg (internal replace must be dropped before tagging)
Checking server/a2a@v1.5.7 ...
  OK   no internal replace directives; internal requires all at v1.5.7
```

It flags all three known-bad modules and passes `server/a2a`, the only one already handled correctly — so it discriminates rather than failing everything.

## Tests

`scripts/test-verify-published-gomod.sh`, 14 fixture cases, each named for the mutation it catches — clean/no-internal-deps/external-only/retract-block must pass; single-line replace, block replace, stale require, stale `// indirect` require, `v1.5.80`-vs-`v1.5.8` near miss and pseudo-version must fail. Wired into `ci.yml` next to `check-no-audio-device-leak.sh`. No network.

I also replayed the `go mod edit` sequence against a scratch copy of `runtime/` and `pkg/` and asserted the resulting `go.mod` files pass the guard at a simulated v1.5.8.

## Not done

- **No full release dry run.** Tagging is destructive and tags are immutable, hence the scratch-tree replay above instead.
- **Already-published tags stay wrong** — `pkg/v1.5.2`, `v1.5.5`, `v1.5.7`. This applies from the next release.
- **`update-tools` still runs when `tag-dependencies` fails**, because of its pre-existing `always()` guard for `tools-only` re-runs. So a failed libs verification will not stop sdk from being tagged — but it does stop `create-release` and `notify-downstream`, so a bad release is neither published nor announced. Left alone as out of scope.
- **The `runtime` -> `pkg` cycle itself is not broken.** Moving `config.ExecHook`/`config.SandboxConfig` into `runtime` and aliasing them from `pkg/config` would make `runtime` a true leaf and match `runtime/CLAUDE.md`'s "foundation" invariant, but it touches schema-generating types and risks a cross-repo schema regen in promptarena. Worth a separate issue.

---

## Follow-up pass (second commit)

Both actionable "Not done" items above are now addressed in this PR.

### 1. The `runtime` -> `pkg` cycle is broken — `runtime` is a real leaf

`ExecBinding`, `ExecHook` and `SandboxConfig` moved to `runtime/hooks/execconfig`, a stdlib-only leaf package, and `pkg/config` re-exports them as **aliases**. They must stay aliases: `runtime/hooks` takes `execconfig.ExecHook` while the SDK reads `config.ExecHook` out of a parsed `RuntimeConfig`, so a defined type would break every consumer's call sites. A test asserts both directions of assignment and reflect identity.

`runtime/go.mod` now has **zero** internal requires. That simplifies the release workflow rather than complicating it: `runtime` is tagged from main again, and only `pkg` needs the release branch. The `Update runtime dependencies` step is gone.

`scripts/check-runtime-is-leaf.sh` holds the invariant — in CI at PR time, and again in the release workflow before any tag is pushed.

### Schema neutrality: verified, not assumed

This was the stated risk, so I measured it rather than reasoning about it. promptarena's `tools/schema-gen` was run twice through a workspace `replace` — once against promptkit `main`, once against this branch — and the two generated schema trees are **byte-identical** (`diff -r`, 9 schemas + common). `ExecHook`, `ExecBinding` and `SandboxConfig` keep their `$defs` entries with identical field sets.

Why it holds: `invopop/jsonschema` derives definition names from `t.Name()` and never the package path (`reflect.go` `typeName()`), the generator sets no `Namer`/`BaseSchemaID`, and aliases are transparent to reflection. promptarena's working tree was left clean.

### 2. `update-tools` no longer runs after a failed libs phase

Its `always()` is still required so a `tools-only` re-run works while `tag-dependencies` is skipped, but on a `full` release it now also requires `tag-dependencies.result == 'success'`. Tagging sdk on top of libraries that failed to tag only adds more immutable tags to clean up.

### Tests

- `pkg/config/execconfig_alias_test.go` — alias identity (assignment both ways + `reflect.TypeOf`), and a YAML round-trip proving both `yaml:",inline"` tags survived the move: `SandboxConfig.Config`'s catch-all map and `ExecHook`'s embedded `ExecBinding`.
- Mutation-checked: removing either inline tag fails `TestMovedTypesKeepInlineYAMLShape`; both mutations were run and confirmed failing, then reverted.
- `scripts/check-runtime-is-leaf.sh` verified against a clean `runtime/go.mod` (passes) and two crafted bad ones — block-form `require` and single-line `replace` (both fail).
- Full suites green for `runtime`, `pkg`, `sdk`, `server/a2a`; purego guard still clean with the new package in `pkg/config`'s graph.
- `docs/src/content/docs/runtime/reference/hooks.md` regenerated for the changed signatures.

### Still not done

The remaining two items are unchanged and not actionable here: no full release dry run (tags are immutable), and the already-published `v1.5.2`/`v1.5.5`/`v1.5.7` tags stay wrong.
