### PR TITLE
ci(release): verify the previous release's go.mod at the start of each run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ on:
         required: false
         type: boolean
         default: false
+      ignore_previous_release_check:
+        description: "Release even if the PREVIOUS release's published go.mod is bad (use when this release is the roll-forward fix)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -120,6 +125,66 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "✓ Version $VERSION is valid and available"
     
+    # The post-tag check at the end of each release can only see modules the Go
+    # proxy has already picked up. Measured on v1.5.8: runtime and pkg were
+    # served ~3s after tagging, sdk and server/a2a were still 404 half an hour
+    # later — so that check reliably verifies half the modules and skips the
+    # other half. Checking the PREVIOUS release here closes the gap: by now the
+    # proxy has had days, so all four are actually verified. A bad release is
+    # caught one release late rather than never.
+    #
+    # Blocking by default, because the usual cause of a bad published go.mod is
+    # a broken release script — and running it again would just publish a second
+    # bad release. When THIS release is the roll-forward fix, re-run with
+    # ignore_previous_release_check=true. (The old tag can never be repaired;
+    # rolling forward is the only remedy.)
+    - name: Verify the previous release's published go.mod
+      env:
+        VERSION: ${{ steps.validate.outputs.version }}
+        IGNORE: ${{ inputs.ignore_previous_release_check }}
+      run: |
+        # Highest runtime/vX.Y.Z tag strictly BELOW the version being released.
+        # Splice VERSION into the sorted list and take the line before it —
+        # simply excluding VERSION and taking the max is wrong for a tools-only
+        # re-run of an older version, which would then select a LATER release as
+        # its "previous".
+        PREV=$( { git tag -l 'runtime/v*' | sed 's|^runtime/||'; echo "$VERSION"; } \
+          | sort -V -u \
+          | grep -B1 -Fx "$VERSION" \
+          | head -n1)
+
+        # VERSION sorted first, so there is nothing below it.
+        if [ -z "$PREV" ] || [ "$PREV" = "$VERSION" ]; then
+          echo "No previous release below $VERSION — nothing to verify."
+          exit 0
+        fi
+
+        echo "Verifying the previously published release $PREV..."
+        if ./scripts/verify-published-gomod.sh "$PREV" runtime pkg sdk server/a2a; then
+          echo "✓ $PREV is release-clean" >> $GITHUB_STEP_SUMMARY
+          exit 0
+        fi
+
+        {
+          echo "## ⚠ The previous release ($PREV) has a bad go.mod"
+          echo ""
+          echo "One or more published modules at \`$PREV\` carry an internal"
+          echo "\`replace\`, or an internal \`require\` pointing at the wrong version."
+          echo "See the job log for the offending lines."
+          echo ""
+          echo "\`$PREV\` cannot be repaired — published tags are immutable."
+          echo "If **this** release is the roll-forward fix, re-run it with"
+          echo "\`ignore_previous_release_check=true\`."
+        } >> $GITHUB_STEP_SUMMARY
+
+        if [ "$IGNORE" = "true" ]; then
+          echo "::warning::Previous release $PREV has a bad go.mod; continuing because ignore_previous_release_check=true"
+          exit 0
+        fi
+
+        echo "::error::Previous release $PREV published a bad go.mod — releasing again may repeat it. Re-run with ignore_previous_release_check=true if this release is the fix."
+        exit 1
+
     - name: Setup Go
       if: ${{ !inputs.skip_tests }}
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ PromptKit ships Go library modules only — the PromptArena/PackC CLIs (and thei
 binaries, npm packages and Homebrew casks) release from the separate
 `github.com/AltairaLabs/promptarena` repo. The release workflow
 (`.github/workflows/release.yml`) handles:
-1. **Validate** — semver format, version ordering, optional test suite
+1. **Validate** — semver format, version ordering, optional test suite, and a check that the **previous** release's published `go.mod` files are clean (the post-tag check can only see modules the Go proxy has picked up, and `sdk`/`server/a2a` routinely take longer than the retry budget). If it fails, the old tag cannot be repaired — re-run with `-f ignore_previous_release_check=true` when this release is the roll-forward fix.
 2. **Tag libraries** — tags root `vX.Y.Z` and `runtime/` from main (runtime is a leaf — it must not depend on a sibling module, enforced by `scripts/check-runtime-is-leaf.sh`), then bumps `pkg`'s `require` on runtime to `vX.Y.Z` and drops its local `replace` on a `release/libs/` branch before tagging `pkg/` from it
 3. **Update & tag SDK modules** — removes `replace` directives, tags `sdk/`, `server/a2a/`
 4. **Create GitHub release** — `gh release create` (no binaries); publishing it triggers the docs/schema deployment


### PR DESCRIPTION
Follow-up to #1731. Refs #1713.

## The gap

The post-tag guard from #1731 can only inspect modules the Go proxy has already fetched. Propagation turned out to be wildly uneven — measured on the v1.5.8 release:

| module | served by proxy.golang.org |
|---|---|
| `runtime` | ~3 seconds after tagging |
| `pkg` | ~3 seconds after tagging |
| `sdk` | still 404 after 30+ minutes |
| `server/a2a` | still 404 after 40+ minutes |

`GOPROXY=direct` resolved both immediately, so the tags were fine — it is proxy lag, not a release defect. But it means the guard verified `runtime`/`pkg` and **skipped `sdk`/`server/a2a` on its first real run**, reporting success. A guard that routinely doesn't check half its targets isn't a guard.

The concrete risk: someone adds a new internal dependency to `sdk` and forgets the matching line in `release.yml`. `runtime`/`pkg` pass, `sdk` is skipped, the release goes out green, and `sdk` consumers get a stale module — #1713 again, in the package most people actually import.

## The fix

Check the **previous** release in the `validate` job, where the proxy has had days rather than three minutes. All four modules then actually get verified.

Catching a bad release one release late costs nothing: a published tag is immutable, so there was never any way to act on the failure sooner than the next release anyway.

**Blocking by default**, because the usual cause of a bad published `go.mod` is a broken release script — and running it again would just publish a second bad release. New input `ignore_previous_release_check` covers the case where *this* release is the roll-forward fix. The post-tag check from #1731 stays as-is; it still catches `runtime`/`pkg` immediately.

## One subtlety

Picking the previous version splices `VERSION` into the version-sorted tag list and takes the line before it. My first attempt excluded `VERSION` and took the maximum — the obvious approach — and my own test caught it selecting a **later** release as "previous" on a `tools-only` re-run of an older version.

## Verification

Against the real 69-tag list, 9 cases, all passing:

```
new release v1.5.9                 -> v1.5.8     ok
tools-only v1.5.8                  -> v1.5.7     ok
tools-only v1.5.7 (was broken)     -> v1.5.6     ok
v1.0.0 (v0.0.1 exists below)       -> v0.0.1     ok
oldest tag — nothing below         -> (none)     ok
below every tag                    -> (none)     ok
no tags at all                     -> (none)     ok
v-sort not lexical (v1.5.10>v1.5.9)-> v1.5.10    ok
major bump v2.0.0                  -> v1.5.8     ok
```

End-to-end behaviour against the live proxy:

- **Releasing v1.5.8 would have checked v1.5.7** → flags all three known-bad modules, exit 1. The check would have caught #1713 a release earlier.
- **Releasing v1.5.9 checks v1.5.8** → exit 0. `sdk@v1.5.8`, which was unverifiable during its own release, now verifies clean. `server/a2a@v1.5.8` is still propagating and warns — by the next release it will be there, which is the whole point of the delay.

So the next release will not be blocked by this.

## Not covered

The step itself has not executed in a real workflow run — same limitation as #1731, since release runs push immutable tags. The version-selection logic and the underlying script are both exercised above against real data; what is untested is the YAML wiring and the `ignore_previous_release_check` branch.
