### PR TITLE
feat(deploy): optional Links field on deploy responses for operator-facing URLs

### DIFF
--- a/runtime/deploy/adaptersdk/helpers.go
+++ b/runtime/deploy/adaptersdk/helpers.go
@@ -69,3 +69,28 @@ func formatProgress(message string, pct float64) string {
 	}
 	return fmt.Sprintf("%s (%d%%)", message, pctInt)
 }
+
+// ConsoleLink builds the conventional "Console" link for a deployed resource.
+// It is a convenience over constructing deploy.ResourceLink directly, so the
+// common case reads the same across adapters.
+//
+// It returns nil when url is empty, which is the intended way to express "the
+// console URL is not known". Callers can append the result unconditionally:
+//
+//	result.Links = append(result.Links, adaptersdk.ConsoleLink(consoleURL)...)
+//
+// An adapter must never substitute a guessed URL for an unknown one — a link
+// that 404s or lands on the wrong workspace is worse than no link at all.
+func ConsoleLink(url string) []deploy.ResourceLink {
+	return Link("Console", url, "console")
+}
+
+// Link builds a single-element ResourceLink slice, or nil when url is empty.
+// The nil-on-empty behavior is what makes "no link" the safe default at every
+// call site rather than something each adapter has to remember to check.
+func Link(label, url, rel string) []deploy.ResourceLink {
+	if url == "" {
+		return nil
+	}
+	return []deploy.ResourceLink{{Label: label, URL: url, Rel: rel}}
+}

--- a/runtime/deploy/adaptersdk/helpers_test.go
+++ b/runtime/deploy/adaptersdk/helpers_test.go
@@ -170,3 +170,39 @@ func TestFormatProgress_Boundaries(t *testing.T) {
 		})
 	}
 }
+
+func TestConsoleLink(t *testing.T) {
+	got := ConsoleLink("https://omnia.example.com/agents/a?workspace=ws")
+	if len(got) != 1 {
+		t.Fatalf("ConsoleLink = %+v, want one link", got)
+	}
+	if got[0].Label != "Console" || got[0].Rel != "console" {
+		t.Errorf("ConsoleLink = %+v, want the conventional Console label and rel", got[0])
+	}
+	if got[0].URL != "https://omnia.example.com/agents/a?workspace=ws" {
+		t.Errorf("ConsoleLink URL = %q", got[0].URL)
+	}
+}
+
+func TestConsoleLink_EmptyURLYieldsNoLink(t *testing.T) {
+	// "No link" is the correct outcome for an unknown console URL, and it must
+	// be safe to append unconditionally.
+	if got := ConsoleLink(""); got != nil {
+		t.Errorf("ConsoleLink(\"\") = %+v, want nil so callers can append blindly", got)
+	}
+	var links []deploy.ResourceLink
+	links = append(links, ConsoleLink("")...)
+	if len(links) != 0 {
+		t.Errorf("appending an empty console link added %d entries", len(links))
+	}
+}
+
+func TestLink_EmptyURLYieldsNoLink(t *testing.T) {
+	if got := Link("Logs", "", "logs"); got != nil {
+		t.Errorf("Link with empty URL = %+v, want nil", got)
+	}
+	got := Link("Logs", "https://example.com/logs", "logs")
+	if len(got) != 1 || got[0].Label != "Logs" || got[0].Rel != "logs" {
+		t.Errorf("Link = %+v", got)
+	}
+}

--- a/runtime/deploy/links_test.go
+++ b/runtime/deploy/links_test.go
@@ -1,0 +1,180 @@
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The Links field is optional end to end. These tests pin the two properties
+// the protocol depends on: an adapter that sets no links produces JSON with no
+// `links` key at all (so old adapters and new clients interoperate), and links
+// that ARE set survive a marshal/unmarshal round trip intact.
+
+func TestResourceResult_LinksOmittedWhenAbsent(t *testing.T) {
+	b, err := json.Marshal(ResourceResult{
+		Type: "agent_runtime", Name: "a", Action: ActionCreate, Status: "created",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "links") {
+		t.Errorf("a result with no links must not emit the key at all, got %s", b)
+	}
+}
+
+func TestResourceStatus_LinksOmittedWhenAbsent(t *testing.T) {
+	b, err := json.Marshal(ResourceStatus{Type: "agent_runtime", Name: "a", Status: "healthy"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "links") {
+		t.Errorf("a status with no links must not emit the key at all, got %s", b)
+	}
+}
+
+func TestStatusResponse_LinksOmittedWhenAbsent(t *testing.T) {
+	b, err := json.Marshal(StatusResponse{Status: "deployed"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "links") {
+		t.Errorf("a response with no links must not emit the key at all, got %s", b)
+	}
+}
+
+func TestResourceResult_LinksRoundTrip(t *testing.T) {
+	in := ResourceResult{
+		Type: "agent_runtime", Name: "a", Action: ActionCreate, Status: "created",
+		Links: []ResourceLink{
+			{Label: "Console", URL: "https://omnia.example.com/agents/a?workspace=ws", Rel: "console"},
+			{Label: "Logs", URL: "https://omnia.example.com/agents/a/logs"},
+		},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var out ResourceResult
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Links) != 2 {
+		t.Fatalf("links = %+v, want 2", out.Links)
+	}
+	if out.Links[0] != in.Links[0] {
+		t.Errorf("links[0] = %+v, want %+v", out.Links[0], in.Links[0])
+	}
+	// Rel is optional and must not be invented on the way through.
+	if out.Links[1].Rel != "" {
+		t.Errorf("links[1].Rel = %q, want it left empty", out.Links[1].Rel)
+	}
+}
+
+// TestResourceLink_UnknownFieldIsIgnored covers the forward-compatible
+// direction: a NEWER adapter that adds a field to a link must not break an
+// older client decoding it.
+func TestResourceLink_UnknownFieldIsIgnored(t *testing.T) {
+	var out ResourceResult
+	if err := json.Unmarshal([]byte(`{
+		"type":"agent_runtime","name":"a","action":"CREATE","status":"created",
+		"links":[{"label":"Console","url":"https://example.com","rel":"console","icon":"rocket"}]
+	}`), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Links) != 1 || out.Links[0].Label != "Console" {
+		t.Fatalf("links = %+v, want the link decoded despite the unknown field", out.Links)
+	}
+}
+
+// TestLinksAbsentDecodesToNil pins the client-side half of "absent means no
+// links": a payload from an OLDER adapter, with no links key, decodes to nil
+// rather than an empty non-nil slice, so `len(...) == 0` and `== nil` agree.
+func TestLinksAbsentDecodesToNil(t *testing.T) {
+	var out ResourceResult
+	if err := json.Unmarshal(
+		[]byte(`{"type":"agent_runtime","name":"a","action":"CREATE","status":"created"}`), &out,
+	); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Links != nil {
+		t.Errorf("Links = %+v, want nil for a payload with no links key", out.Links)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC round trip
+// ---------------------------------------------------------------------------
+
+// linksHandler is a mock adapter that returns links on both an Apply resource
+// event and a Status resource, plus a deployment-wide link on the response.
+func linksHandler(method string, _ json.RawMessage) (any, *rpcError) {
+	switch method {
+	case "status":
+		return StatusResponse{
+			Status: "deployed",
+			Resources: []ResourceStatus{{
+				Type: "agent_runtime", Name: "a", Status: "healthy",
+				Links: []ResourceLink{{
+					Label: "Console", URL: "https://omnia.example.com/agents/a?workspace=ws",
+					Rel: "console",
+				}},
+			}},
+			Links: []ResourceLink{{Label: "Workspace", URL: "https://omnia.example.com/ws"}},
+		}, nil
+	default:
+		return nil, &rpcError{Code: -32601, Message: "method not found: " + method}
+	}
+}
+
+// TestClientStatus_LinksSurviveTheWire is the round trip the protocol actually
+// depends on: links set by an adapter must reach a client through the JSON-RPC
+// transport, not merely survive struct marshalling.
+func TestClientStatus_LinksSurviveTheWire(t *testing.T) {
+	client := startTestClient(t, linksHandler)
+
+	status, err := client.Status(context.Background(), &StatusRequest{DeployConfig: `{}`})
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+
+	if len(status.Resources) != 1 {
+		t.Fatalf("resources = %+v, want 1", status.Resources)
+	}
+	links := status.Resources[0].Links
+	if len(links) != 1 {
+		t.Fatalf("resource links = %+v, want 1", links)
+	}
+	if links[0].URL != "https://omnia.example.com/agents/a?workspace=ws" {
+		t.Errorf("resource link URL = %q", links[0].URL)
+	}
+	if links[0].Rel != "console" {
+		t.Errorf("resource link Rel = %q, want console", links[0].Rel)
+	}
+
+	if len(status.Links) != 1 || status.Links[0].Label != "Workspace" {
+		t.Errorf("deployment-wide links = %+v, want the Workspace link", status.Links)
+	}
+}
+
+// TestClientStatus_NoLinksFromOlderAdapter covers the compatibility direction
+// that matters most: an adapter that knows nothing about links (defaultHandler
+// predates the field) must decode cleanly with none, not error.
+func TestClientStatus_NoLinksFromOlderAdapter(t *testing.T) {
+	client := startTestClient(t, defaultHandler)
+
+	status, err := client.Status(context.Background(), &StatusRequest{DeployConfig: `{}`})
+	if err != nil {
+		t.Fatalf("Status against a links-unaware adapter: %v", err)
+	}
+	if status.Links != nil {
+		t.Errorf("deployment links = %+v, want nil", status.Links)
+	}
+	for i, r := range status.Resources {
+		if r.Links != nil {
+			t.Errorf("resources[%d].Links = %+v, want nil", i, r.Links)
+		}
+	}
+}

--- a/runtime/deploy/provider.go
+++ b/runtime/deploy/provider.go
@@ -69,6 +69,34 @@ type ApplyEvent struct {
 	Resource *ResourceResult `json:"resource,omitempty"`
 }
 
+// ResourceLink is an optional operator-facing URL an adapter associates with a
+// deployed resource — a web console, a logs view, a dashboard page.
+//
+// The protocol contract, which both sides depend on:
+//
+//   - Optional end to end. An adapter that returns no links is fully supported
+//     and must never be treated as degraded. An absent field simply means "no
+//     links", so old adapters and new clients interoperate in both directions
+//     with no capability negotiation.
+//   - Clients MUST NOT synthesize links. If the adapter returns none, the
+//     client shows nothing. Deriving a URL client-side bakes one provider's
+//     scheme into a provider-agnostic tool, and the control-plane host is not
+//     guaranteed to be the console host — so the guess is not even reliable for
+//     the provider it would be hardcoded for.
+//   - Rel is a hint, not an enum to switch on. Render Label, open URL.
+type ResourceLink struct {
+	// Label is the short human-facing text for the link, e.g. "Console".
+	Label string `json:"label"`
+	// URL is the absolute URL to open. Adapters should include whatever scoping
+	// (workspace, namespace, project) the target needs in order to resolve for
+	// an operator with access to more than one.
+	URL string `json:"url"`
+	// Rel is an optional machine hint about what the link is, e.g. "console" or
+	// "logs". Clients may use it for an icon or ordering, but must still render
+	// links whose Rel they do not recognize.
+	Rel string `json:"rel,omitempty"`
+}
+
 // ResourceResult describes the outcome of a resource operation.
 type ResourceResult struct {
 	Type   string `json:"type"`
@@ -76,6 +104,8 @@ type ResourceResult struct {
 	Action Action `json:"action"`
 	Status string `json:"status"` // "created", "updated", "deleted", "failed"
 	Detail string `json:"detail,omitempty"`
+	// Links are optional operator-facing URLs for this resource — see ResourceLink.
+	Links []ResourceLink `json:"links,omitempty"`
 }
 
 // DestroyEvent is a streaming event during Destroy.
@@ -90,6 +120,9 @@ type StatusResponse struct {
 	Status    string           `json:"status"` // "deployed", "not_deployed", "degraded", "unknown"
 	Resources []ResourceStatus `json:"resources,omitempty"`
 	State     string           `json:"state,omitempty"` // Opaque adapter state
+	// Links are optional deployment-wide operator-facing URLs that do not
+	// belong to any single resource — see ResourceLink.
+	Links []ResourceLink `json:"links,omitempty"`
 }
 
 // ResourceStatus describes the current state of a resource.
@@ -98,6 +131,8 @@ type ResourceStatus struct {
 	Name   string `json:"name"`
 	Status string `json:"status"` // "healthy", "unhealthy", "missing"
 	Detail string `json:"detail,omitempty"`
+	// Links are optional operator-facing URLs for this resource — see ResourceLink.
+	Links []ResourceLink `json:"links,omitempty"`
 }
 
 // DestroyRequest is the input to Destroy.


### PR DESCRIPTION
Closes #1733.

## Summary

Adds an optional `Links` field to the deploy response types so an adapter can hand the CLI provider-specific URLs — a web console for a deployed agent, a logs view, a dashboard page — for the operator to open after a deploy.

After `promptarena deploy` succeeds the operator's next question is "where do I go to talk to the thing I just deployed?", and the protocol had no slot for the answer.

## What's added

```go
type ResourceLink struct {
	Label string `json:"label"`
	URL   string `json:"url"`
	Rel   string `json:"rel,omitempty"`
}
```

`Links []ResourceLink` on:

- **`ResourceResult`** — links for a resource just created/updated by Apply
- **`ResourceStatus`** — links for a resource observed by Status
- **`StatusResponse`** — deployment-wide links belonging to no single resource

## Compatibility

Purely additive. An absent field simply means "no links", so old adapters and new clients interoperate in **both** directions with no capability negotiation — there is nothing to degrade and nothing to version.

The doc comment carries the two rules both sides depend on:

- **Clients must not synthesize links.** If the adapter returns none, the client shows nothing. Deriving a URL client-side bakes one provider's scheme into a provider-agnostic tool, and the control-plane host is not guaranteed to be the console host — so the guess is not reliable even for the provider it would be hardcoded for.
- **`Rel` is a hint, not an enum to switch on.** Render `Label`, open `URL`, and render links whose `Rel` you do not recognize.

## adaptersdk helpers

`ConsoleLink(url)` and `Link(label, url, rel)` return **nil for an empty URL**, so callers can append unconditionally:

```go
result.Links = append(result.Links, adaptersdk.ConsoleLink(consoleURL)...)
```

That makes "no link" the safe default at the call site rather than something every adapter has to remember to check. The failure mode being guarded against is an adapter emitting a guessed URL that 404s or lands on the wrong workspace — worse than no link at all.

## Tests

- Round trip **through the JSON-RPC transport** via the existing client↔mock-server harness, not merely struct marshalling — that's the path the protocol actually depends on.
- Absent-field case in both directions: a links-unaware adapter decodes cleanly with none, and a result with no links emits no `links` key at all.
- Absent decodes to `nil` rather than an empty non-nil slice, so `len(...) == 0` and `== nil` agree.
- Forward compatibility: an unknown field inside a link (a newer adapter) doesn't break an older client.
- Helper coverage including the empty-URL path.

## Consumers

- `AltairaLabs/promptarena#73` — TUI renders the link and opens it
- `AltairaLabs/promptarena-deploy-omnia#79` — the Omnia adapter populates a console link

Both degrade gracefully without this, and both are unblocked by it.
