### PR TITLE
fix(runtime): keep the tool-aware provider path when tool history exists

### DIFF
--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -1065,10 +1065,10 @@ func (s *ProviderStage) executeRound(
 	var toolCalls []types.MessageToolCall
 	var err error
 
-	if providerTools != nil {
+	toolProvider, supportsTools := s.provider.(providers.ToolSupport)
+	if s.useToolPath(providerTools, req.Messages, supportsTools) {
 		// Use tool-aware provider interface
-		toolProvider, ok := s.provider.(providers.ToolSupport)
-		if !ok {
+		if !supportsTools {
 			return types.Message{}, false, errors.New("provider does not support tools")
 		}
 		resp, toolCalls, err = toolProvider.PredictWithTools(ctx, req, providerTools, toolChoice)
@@ -1343,6 +1343,39 @@ func (s *ProviderStage) executeStreamingRound(
 	return responseMsg, len(toolCalls) > 0, nil
 }
 
+// messagesHaveToolLinkage reports whether the history contains assistant tool
+// calls or tool results. Providers keep two message serializers — a tool-aware
+// one and a plain one — and only the tool-aware one can represent that linkage
+// (OpenAI's plain path builds []openAIMessage, which has no tool_calls or
+// tool_call_id field at all; Claude's splits []claudeMessage vs
+// []claudeToolMessage the same way). Sending such a history down the plain path
+// silently strips the linkage and the provider rejects the array (issue #1735).
+func messagesHaveToolLinkage(messages []types.Message) bool {
+	for i := range messages {
+		if len(messages[i].ToolCalls) > 0 || messages[i].ToolResult != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// useToolPath decides whether a round goes to the provider's tool-aware entry
+// point. Having tools to declare is the obvious reason, but it is not the only
+// one: buildProviderTools returns nil both when the pack never had tools and
+// when the round's tools were filtered away (every tool excluded after repeated
+// rejection, or tool_choice "none"). In the second case the history already
+// carries tool linkage, so the tool-aware serializer is still required even
+// though there is nothing left to declare. Providers accept tool history with
+// no tools declared — verified against OpenAI, Anthropic and Gemini.
+func (s *ProviderStage) useToolPath(
+	providerTools interface{}, messages []types.Message, supportsTools bool,
+) bool {
+	if providerTools != nil {
+		return true
+	}
+	return supportsTools && messagesHaveToolLinkage(messages)
+}
+
 // startStreamingRequest initiates a streaming request with or without tools.
 func (s *ProviderStage) startStreamingRequest(
 	ctx context.Context,
@@ -1350,9 +1383,9 @@ func (s *ProviderStage) startStreamingRequest(
 	providerTools interface{},
 	toolChoice string,
 ) (<-chan providers.StreamChunk, error) {
-	if providerTools != nil {
-		toolProvider, ok := s.provider.(providers.ToolSupport)
-		if !ok {
+	toolProvider, supportsTools := s.provider.(providers.ToolSupport)
+	if s.useToolPath(providerTools, req.Messages, supportsTools) {
+		if !supportsTools {
 			return nil, errors.New("provider does not support tools")
 		}
 		streamChan, err := toolProvider.PredictStreamWithTools(ctx, req, providerTools, toolChoice)

--- a/runtime/pipeline/stage/stages_provider_toolroute_integration_test.go
+++ b/runtime/pipeline/stage/stages_provider_toolroute_integration_test.go
@@ -1,0 +1,74 @@
+package stage
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/openai"
+)
+
+// TestProviderStage_ToolHistorySurvivesEmptyToolSet_Live pins issue #1735 at the
+// wire level. The unit tests assert which provider entry point the stage picks;
+// this asserts what that choice actually does to the request, because the damage
+// happens inside the provider's serializer rather than in the stage.
+//
+// It exercises both routes against the live API:
+//   - provider.PredictStream — the pre-fix route. Its serializer builds
+//     []openAIMessage, which has no tool_calls / tool_call_id field, so the
+//     linkage is stripped and OpenAI rejects the array with a 400.
+//   - stage.startStreamingRequest with a nil tool set — the fixed route, which
+//     keeps the tool-aware serializer and is accepted.
+//
+// Skips without OPENAI_API_KEY; hits the paid API when it runs.
+func TestProviderStage_ToolHistorySurvivesEmptyToolSet_Live(t *testing.T) {
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		t.Skip("no OPENAI_API_KEY, skipping live tool-routing integration test")
+	}
+
+	provider := openai.NewToolProvider(
+		"openai", "gpt-4o-mini", "https://api.openai.com/v1",
+		providers.ProviderDefaults{MaxTokens: 64}, false, nil, nil,
+	)
+	stage := NewProviderStage(provider, nil, nil, &ProviderConfig{MaxTokens: 64})
+	req := providers.PredictionRequest{Messages: historyWithToolLinkage(), MaxTokens: 64}
+
+	drain := func(ch <-chan providers.StreamChunk) error {
+		for c := range ch {
+			if c.Error != nil {
+				return c.Error
+			}
+		}
+		return nil
+	}
+
+	// The plain path must still be demonstrably lossy. If OpenAI ever starts
+	// accepting this array the fix stops being load-bearing, and that should
+	// surface here rather than let the test silently keep passing.
+	err := func() error {
+		ch, streamErr := provider.PredictStream(context.Background(), req)
+		if streamErr != nil {
+			return streamErr
+		}
+		return drain(ch)
+	}()
+	if err == nil {
+		t.Error("plain path unexpectedly accepted tool history; #1735 premise no longer holds")
+	} else if !strings.Contains(err.Error(), "tool_calls") {
+		t.Errorf("expected a tool-linkage rejection, got: %v", err)
+	}
+
+	// Same nil tool set, routed through the stage: must be accepted.
+	err = func() error {
+		ch, streamErr := stage.startStreamingRequest(context.Background(), req, nil, "")
+		if streamErr != nil {
+			return streamErr
+		}
+		return drain(ch)
+	}()
+	if err != nil {
+		t.Fatalf("tool-aware path rejected tool history with an empty tool set: %v", err)
+	}
+}

--- a/runtime/pipeline/stage/stages_provider_toolroute_test.go
+++ b/runtime/pipeline/stage/stages_provider_toolroute_test.go
@@ -1,0 +1,161 @@
+package stage
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// toolRouteProvider wraps a tool-capable mock provider and records which
+// provider entry point the stage routed to. Only the tool-aware entry points
+// serialize tool_calls / tool_call_id, so "which method was called" is the
+// observable that decides whether history survives the round trip (#1735).
+type toolRouteProvider struct {
+	*mock.ToolProvider
+	toolPath    bool
+	nonToolPath bool
+}
+
+func newToolRouteProvider() *toolRouteProvider {
+	return &toolRouteProvider{ToolProvider: mock.NewToolProvider("test", "model", false, nil)}
+}
+
+func (p *toolRouteProvider) Predict(
+	ctx context.Context, req providers.PredictionRequest,
+) (providers.PredictionResponse, error) {
+	p.nonToolPath = true
+	return p.ToolProvider.Predict(ctx, req)
+}
+
+func (p *toolRouteProvider) PredictStream(
+	ctx context.Context, req providers.PredictionRequest,
+) (<-chan providers.StreamChunk, error) {
+	p.nonToolPath = true
+	return p.ToolProvider.PredictStream(ctx, req)
+}
+
+func (p *toolRouteProvider) PredictWithTools(
+	ctx context.Context, req providers.PredictionRequest,
+	tools providers.ProviderTools, toolChoice string,
+) (providers.PredictionResponse, []types.MessageToolCall, error) {
+	p.toolPath = true
+	return p.ToolProvider.PredictWithTools(ctx, req, tools, toolChoice)
+}
+
+func (p *toolRouteProvider) PredictStreamWithTools(
+	ctx context.Context, req providers.PredictionRequest,
+	tools providers.ProviderTools, toolChoice string,
+) (<-chan providers.StreamChunk, error) {
+	p.toolPath = true
+	return p.ToolProvider.PredictStreamWithTools(ctx, req, tools, toolChoice)
+}
+
+// historyWithToolLinkage returns a turn whose assistant message carries tool
+// calls and whose follow-up carries the matching tool result — the shape that
+// only the tool-aware serializers can represent.
+func historyWithToolLinkage() []types.Message {
+	denial := types.NewTextToolResult("call_A", "approve", "denied by policy")
+	denial.Error = "denied by policy"
+	return []types.Message{
+		{Role: "user", Content: "approve the refund"},
+		{Role: roleAssistant, ToolCalls: []types.MessageToolCall{
+			{ID: "call_A", Name: "approve", Args: json.RawMessage(`{}`)},
+		}},
+		types.NewToolResultMessage(denial),
+	}
+}
+
+func plainHistory() []types.Message {
+	return []types.Message{{Role: "user", Content: "hello"}}
+}
+
+// Once every tool is excluded, buildProviderTools yields nil. Routing on that
+// nil sent the turn to the tool-blind serializer, which drops tool_calls and
+// tool_call_id and produces the array OpenAI rejects with
+// "messages with role 'tool' must be a response to a preceding message with 'tool_calls'".
+func TestStartStreamingRequest_ToolHistoryKeepsToolPathWhenToolsEmpty(t *testing.T) {
+	provider := newToolRouteProvider()
+	stage := NewProviderStage(provider, nil, nil, &ProviderConfig{})
+
+	_, err := stage.startStreamingRequest(
+		context.Background(),
+		providers.PredictionRequest{Messages: historyWithToolLinkage()},
+		nil, // every tool excluded this round
+		"",
+	)
+	require.NoError(t, err)
+
+	assert.True(t, provider.toolPath,
+		"history carries tool_calls, so the turn must stay on PredictStreamWithTools")
+	assert.False(t, provider.nonToolPath,
+		"PredictStream drops tool_calls/tool_call_id and produces a 400")
+}
+
+func TestExecuteRound_ToolHistoryKeepsToolPathWhenToolsEmpty(t *testing.T) {
+	provider := newToolRouteProvider()
+	stage := NewProviderStage(provider, nil, nil, &ProviderConfig{})
+
+	_, _, err := stage.executeRound(
+		context.Background(), historyWithToolLinkage(), "", nil, "", 1, nil,
+	)
+	require.NoError(t, err)
+
+	assert.True(t, provider.toolPath,
+		"the non-streaming path has the same defect and needs the same fix")
+	assert.False(t, provider.nonToolPath)
+}
+
+// Guards the fix against being too broad: a turn with no tool linkage has
+// nothing for the tool-aware serializer to preserve, so it must keep using the
+// plain path exactly as before.
+func TestStartStreamingRequest_PlainHistoryStillUsesNonToolPath(t *testing.T) {
+	provider := newToolRouteProvider()
+	stage := NewProviderStage(provider, nil, nil, &ProviderConfig{})
+
+	_, err := stage.startStreamingRequest(
+		context.Background(),
+		providers.PredictionRequest{Messages: plainHistory()},
+		nil,
+		"",
+	)
+	require.NoError(t, err)
+
+	assert.True(t, provider.nonToolPath,
+		"no tool linkage in history — behavior must be unchanged")
+	assert.False(t, provider.toolPath)
+}
+
+// A provider that cannot do tools must fall back rather than newly erroring.
+func TestStartStreamingRequest_ToolHistoryOnNonToolProviderFallsBack(t *testing.T) {
+	stage := NewProviderStage(mock.NewProvider("test", "model", false), nil, nil, &ProviderConfig{})
+
+	_, err := stage.startStreamingRequest(
+		context.Background(),
+		providers.PredictionRequest{Messages: historyWithToolLinkage()},
+		nil,
+		"",
+	)
+	require.NoError(t, err,
+		"a provider without ToolSupport must degrade to PredictStream, not error")
+}
+
+// Preserved behavior: real tools plus a provider that cannot serve them is
+// still an error, not a silent downgrade.
+func TestStartStreamingRequest_ToolsOnNonToolProviderStillErrors(t *testing.T) {
+	stage := NewProviderStage(mock.NewProvider("test", "model", false), nil, nil, &ProviderConfig{})
+
+	_, err := stage.startStreamingRequest(
+		context.Background(),
+		providers.PredictionRequest{Messages: plainHistory()},
+		[]*providers.ToolDescriptor{{Name: "approve"}},
+		toolChoiceAuto,
+	)
+	require.Error(t, err)
+}

--- a/runtime/pipeline/stage/stages_provider_toolroute_test.go
+++ b/runtime/pipeline/stage/stages_provider_toolroute_test.go
@@ -132,11 +132,30 @@ func TestStartStreamingRequest_PlainHistoryStillUsesNonToolPath(t *testing.T) {
 	assert.False(t, provider.toolPath)
 }
 
-// A provider that cannot do tools must fall back rather than newly erroring.
-func TestStartStreamingRequest_ToolHistoryOnNonToolProviderFallsBack(t *testing.T) {
-	stage := NewProviderStage(mock.NewProvider("test", "model", false), nil, nil, &ProviderConfig{})
+// nonToolRouteProvider records the plain entry point on a provider that does
+// NOT implement providers.ToolSupport.
+type nonToolRouteProvider struct {
+	*mock.Provider
+	nonToolPath bool
+}
 
-	_, err := stage.startStreamingRequest(
+func (p *nonToolRouteProvider) PredictStream(
+	ctx context.Context, req providers.PredictionRequest,
+) (<-chan providers.StreamChunk, error) {
+	p.nonToolPath = true
+	return p.Provider.PredictStream(ctx, req)
+}
+
+// A provider that cannot do tools must actually fall back to the plain path.
+// Asserting only "no error" would pass even if the stage returned a nil stream
+// without calling the provider at all, so assert the call itself happened.
+func TestStartStreamingRequest_ToolHistoryOnNonToolProviderFallsBack(t *testing.T) {
+	provider := &nonToolRouteProvider{Provider: mock.NewProvider("test", "model", false)}
+	require.NotImplements(t, (*providers.ToolSupport)(nil), provider,
+		"premise of this test: the provider must not support tools")
+	stage := NewProviderStage(provider, nil, nil, &ProviderConfig{})
+
+	ch, err := stage.startStreamingRequest(
 		context.Background(),
 		providers.PredictionRequest{Messages: historyWithToolLinkage()},
 		nil,
@@ -144,6 +163,10 @@ func TestStartStreamingRequest_ToolHistoryOnNonToolProviderFallsBack(t *testing.
 	)
 	require.NoError(t, err,
 		"a provider without ToolSupport must degrade to PredictStream, not error")
+	require.NotNil(t, ch, "must return a usable stream, not a nil channel")
+	assert.True(t, provider.nonToolPath,
+		"the plain path must actually be invoked — catches useToolPath returning "+
+			"true for a provider that cannot serve tools")
 }
 
 // Preserved behavior: real tools plus a provider that cannot serve them is


### PR DESCRIPTION
## Summary

A denied tool call could crash the whole turn instead of degrading to "the model sees the denial and replies in text". Fixes #1735.

The reported 400 is real, but the root cause is not where the issue suspected — `updateExcludedTools` and the message reconstruction are innocent. Exclusion never touches `tl.messages`; the array stays well-formed the whole way.

## Root cause

`ProviderStage` routed each round on `providerTools != nil`. That `nil` is **overloaded** — it means both:

1. "this pack never had tools" (the plain path is correct), and
2. "this round's tools were filtered away" (the plain path corrupts the request).

Case 2 is reachable mid-conversation two ways: every tool excluded after repeated rejection (`stages_provider.go:2294`), or `ToolPolicy.ToolChoice: "none"` (`:2398`). By then the history already carries tool linkage.

Providers keep **two message serializers**, and only the tool-aware one can represent that linkage. OpenAI's plain path builds `[]openAIMessage` (`openai.go:508`), a struct with only `Role`, `Content`, `Audio` — no `tool_calls`, no `tool_call_id`. So the linkage is dropped **client-side, before the request is sent**. Claude splits `[]claudeMessage` vs `[]claudeToolMessage` the same way.

Serializing a denied-tool history through the plain path produces exactly the array the provider rejects:

```json
[ {"role":"user","content":"approve it"},
  {"role":"assistant","content":""},           ← tool_calls gone
  {"role":"tool","content":"denied by policy"} ]  ← tool_call_id gone
```

## Fix

Route on the history, not on whether there are tools to declare:

```go
func (s *ProviderStage) useToolPath(
	providerTools interface{}, messages []types.Message, supportsTools bool,
) bool {
	if providerTools != nil {
		return true
	}
	return supportsTools && messagesHaveToolLinkage(messages)
}
```

Applied at both defective seams — `startStreamingRequest` and `executeRound`. Fixing only one would leave the non-streaming path broken.

This also fixes the `tool_choice: "none"` trigger, which has nothing to do with exclusion, and covers Claude/Gemini/Ollama because it sits at the runtime seam rather than in a provider.

## Verification

Live against the real OpenAI API, both routes, same denied-tool history and empty tool set:

```
BEFORE (provider.PredictStream):      400 "messages with role 'tool' must be a
                                      response to a preceeding message with 'tool_calls'"
AFTER  (stage.startStreamingRequest): OK
```

Also probed the load-bearing assumption directly — **OpenAI, Anthropic and Gemini 2.5 all accept tool-call history with no `tools` declared** (HTTP 200). An earlier concern that Anthropic rejects this turned out to be wrong.

## Tests

Six tests, all written before the implementation. The two target tests were
watched fail for the right reason; the three guard tests assert *preserved*
behavior and passed pre-fix by design:

- tool history + empty tool set → tool path, on **both** seams (the two that failed)
- **no** tool history + nil tools → still the plain path — guards against the fix being too broad
- non-tool-capable provider + tool history → falls back, no new error
- real tools + non-tool-capable provider → still errors (preserved behavior)
- live integration test asserting both directions; skips without `OPENAI_API_KEY`

The fallback test initially asserted only "did not error" — the Weak Assertion
Guard flagged it as unfalsifiable, correctly. It now records and asserts that
the plain path was actually invoked, and is mutation-checked: dropping the
`supportsTools &&` guard in `useToolPath` makes it fail.

Full runtime suite passes; `golangci-lint --new-from-rev` clean; changed-file coverage 90.3%; `sdk` and `pkg` compile.

## Out of scope

- **vLLM is still broken.** Its *tool* path also uses the tool-blind `prepareMessages` (`vllm.go:172`), so it drops linkage on both paths — a separate pre-existing bug this PR neither fixes nor worsens. Worth its own issue.
- Incidental find: `gemini-flash-latest` (Gemini 3) rejects replayed `functionCall` parts without a `thought_signature`. Unrelated, but it will affect Gemini multi-turn tool use.
- #1736 (`parallel_tool_calls`) untouched. Its claims check out — there is no `parallel_tool_calls` anywhere and `buildToolRequest` has no generic `additionalConfig` merge — but it needs a field on `ParametersPack`/`PredictionRequest` and likely a `make schemas` cycle.

Closes #1735
