### PR TITLE
feat(openai): honor additional_config.parallel_tool_calls

### DIFF
--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -108,6 +108,16 @@ type Provider struct {
 	// Opt-in: OpenAI requires a verified org to return summaries. Configured via
 	// additional_config.reasoning_summary.
 	reasoningSummary string
+	// parallelToolCalls, when non-nil, is sent as parallel_tool_calls on requests
+	// that declare tools. Setting it false makes the model emit at most one tool
+	// call per assistant turn instead of a parallel batch. nil means omit the
+	// field and take OpenAI's default (parallel calling enabled). Configured via
+	// additional_config.parallel_tool_calls.
+	//
+	// Only valid alongside a non-empty tools array — OpenAI rejects the pair with
+	// "'parallel_tool_calls' is only allowed when 'tools' are specified" — so
+	// every write of this field sits inside a tools guard.
+	parallelToolCalls *bool
 }
 
 // NewProvider creates a new OpenAI provider
@@ -225,6 +235,7 @@ func NewProviderFromConfig(cfg *ProviderConfig) *Provider {
 		capabilities:      providers.CapabilitySet(cfg.Capabilities),
 		reasoningEffort:   getReasoningEffort(cfg.AdditionalConfig),
 		reasoningSummary:  getReasoningSummary(cfg.AdditionalConfig),
+		parallelToolCalls: getParallelToolCalls(cfg.AdditionalConfig),
 	}
 	// Neither Azure OpenAI nor Bedrock OpenAI exposes the Responses API.
 	// Force the legacy Chat Completions path so the request shape matches
@@ -296,6 +307,27 @@ func getReasoningSummary(additionalConfig map[string]any) string {
 			"value", raw, "accepted", "auto|concise|detailed")
 		return ""
 	}
+}
+
+// getParallelToolCalls resolves parallel_tool_calls from additional_config.
+// Returns nil (omit the field, take OpenAI's default of parallel calling) when
+// unset or not a bool, so a malformed value degrades to current behavior rather
+// than silently disabling a capability. Issue #1736.
+func getParallelToolCalls(additionalConfig map[string]any) *bool {
+	if additionalConfig == nil {
+		return nil
+	}
+	raw, present := additionalConfig["parallel_tool_calls"]
+	if !present {
+		return nil
+	}
+	value, ok := raw.(bool)
+	if !ok {
+		logger.Warn("openai: ignoring non-boolean parallel_tool_calls",
+			"value", raw, "expected", "true|false")
+		return nil
+	}
+	return &value
 }
 
 // getAudioModalities returns the output modalities for audio models from

--- a/runtime/providers/openai/openai_parallel_tool_calls_integration_test.go
+++ b/runtime/providers/openai/openai_parallel_tool_calls_integration_test.go
@@ -1,0 +1,116 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// TestParallelToolCalls_Live proves the additional_config key actually changes
+// model behavior end-to-end through the provider, not just the request map.
+//
+// The prompt asks for two refunds, which gpt-4o-mini answers with two parallel
+// tool calls by default. With parallel_tool_calls:false it must answer with
+// exactly one.
+//
+// Skips without OPENAI_API_KEY; hits the paid API when it runs.
+func TestParallelToolCalls_Live(t *testing.T) {
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		t.Skip("no OPENAI_API_KEY, skipping live parallel_tool_calls test")
+	}
+
+	descriptors := []*providers.ToolDescriptor{{
+		Name:        "approve_refund",
+		Description: "Approve a customer refund request.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"order_id": {"type": "string"},
+				"amount": {"type": "number"}
+			},
+			"required": ["order_id", "amount"]
+		}`),
+	}}
+
+	req := providers.PredictionRequest{
+		Messages: []types.Message{{
+			Role: "user",
+			Content: "Refund both of my orders: order A-1 is $30 and order B-2 is $45. " +
+				"Approve each one.",
+		}},
+		MaxTokens: 200,
+	}
+
+	callsFor := func(t *testing.T, cfg map[string]any) int {
+		t.Helper()
+		p := NewToolProvider(
+			"openai", "gpt-4o-mini", "https://api.openai.com/v1",
+			providers.ProviderDefaults{MaxTokens: 200}, false, cfg, nil,
+		)
+		p.apiMode = APIModeCompletions
+		tooling, err := p.BuildTooling(descriptors)
+		require.NoError(t, err)
+		_, toolCalls, err := p.PredictWithTools(context.Background(), req, tooling, toolChoiceAuto)
+		require.NoError(t, err)
+		return len(toolCalls)
+	}
+
+	// Control: establish that this prompt really does provoke parallel calls.
+	// Without it the assertion below could pass vacuously on a model that only
+	// ever emits one call.
+	baseline := callsFor(t, nil)
+	t.Logf("default (parallel_tool_calls omitted): %d tool call(s)", baseline)
+	if baseline < 2 {
+		t.Skipf("control did not reproduce parallel calling (got %d call(s)); "+
+			"nothing to suppress, so the assertion would be vacuous", baseline)
+	}
+
+	suppressed := callsFor(t, map[string]any{"parallel_tool_calls": false})
+	t.Logf("parallel_tool_calls=false: %d tool call(s)", suppressed)
+	require.Equal(t, 1, suppressed,
+		"parallel_tool_calls=false must reduce the turn to a single tool call")
+}
+
+// TestParallelToolCalls_NoToolsLive guards the interaction with #1735. Since
+// that fix, a turn whose tool set was emptied still routes through the
+// tool-aware path, reaching buildToolRequest with tools == nil. Emitting
+// parallel_tool_calls there would 400 with "only allowed when 'tools' are
+// specified" — reintroducing a crash on exactly the path #1735 repaired.
+//
+// Skips without OPENAI_API_KEY; hits the paid API when it runs.
+func TestParallelToolCalls_NoToolsLive(t *testing.T) {
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		t.Skip("no OPENAI_API_KEY, skipping live no-tools guard test")
+	}
+
+	p := NewToolProvider(
+		"openai", "gpt-4o-mini", "https://api.openai.com/v1",
+		providers.ProviderDefaults{MaxTokens: 64}, false,
+		map[string]any{"parallel_tool_calls": false}, nil,
+	)
+	p.apiMode = APIModeCompletions
+
+	denial := types.NewTextToolResult("call_A", "approve_refund", "denied by policy")
+	denial.Error = "denied by policy"
+	req := providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "user", Content: "approve the refund"},
+			{Role: "assistant", ToolCalls: []types.MessageToolCall{
+				{ID: "call_A", Name: "approve_refund", Args: json.RawMessage(`{}`)},
+			}},
+			types.NewToolResultMessage(denial),
+		},
+		MaxTokens: 64,
+	}
+
+	// nil tooling: the emptied-tool-set case from #1735.
+	_, _, err := p.PredictWithTools(context.Background(), req, nil, "")
+	require.NoError(t, err,
+		"configured parallel_tool_calls must not leak into a request with no tools")
+}

--- a/runtime/providers/openai/openai_parallel_tool_calls_integration_test.go
+++ b/runtime/providers/openai/openai_parallel_tool_calls_integration_test.go
@@ -89,9 +89,11 @@ func TestParallelToolCalls_NoToolsLive(t *testing.T) {
 		t.Skip("no OPENAI_API_KEY, skipping live no-tools guard test")
 	}
 
+	// includeRawOutput exposes the built request on the response, so this can
+	// assert what actually went on the wire rather than only that nothing blew up.
 	p := NewToolProvider(
 		"openai", "gpt-4o-mini", "https://api.openai.com/v1",
-		providers.ProviderDefaults{MaxTokens: 64}, false,
+		providers.ProviderDefaults{MaxTokens: 64}, true,
 		map[string]any{"parallel_tool_calls": false}, nil,
 	)
 	p.apiMode = APIModeCompletions
@@ -110,7 +112,22 @@ func TestParallelToolCalls_NoToolsLive(t *testing.T) {
 	}
 
 	// nil tooling: the emptied-tool-set case from #1735.
-	_, _, err := p.PredictWithTools(context.Background(), req, nil, "")
+	resp, _, err := p.PredictWithTools(context.Background(), req, nil, "")
 	require.NoError(t, err,
 		"configured parallel_tool_calls must not leak into a request with no tools")
+
+	// Assert on the request we actually sent, not merely on the absence of an
+	// error: the key must be gone, and "tools" with it. Hoisting the assignment
+	// out of the tools guard fails this here and 400s at the API.
+	sent, ok := resp.RawRequest.(map[string]interface{})
+	require.True(t, ok, "raw request should be captured for inspection")
+	require.NotContains(t, sent, "parallel_tool_calls",
+		"must be omitted when no tools are declared — OpenAI rejects the pair")
+	require.NotContains(t, sent, "tools",
+		"sanity: this is genuinely the no-tools case the guard protects")
+
+	// And the round trip produced a real answer, so the request was well formed
+	// rather than merely accepted.
+	require.NotEmpty(t, resp.Content,
+		"model should have replied in text after seeing the denied tool result")
 }

--- a/runtime/providers/openai/openai_parallel_tool_calls_test.go
+++ b/runtime/providers/openai/openai_parallel_tool_calls_test.go
@@ -1,0 +1,105 @@
+package openai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+func sampleTools() []openAITool {
+	return []openAITool{{
+		Type:     "function",
+		Function: openAIToolFunction{Name: "approve_refund", Description: "approve"},
+	}}
+}
+
+func newParallelToolCallsProvider(cfg map[string]any) *ToolProvider {
+	return NewToolProvider(
+		"test", "gpt-4o-mini", "https://api.openai.com/v1",
+		providers.ProviderDefaults{MaxTokens: 64}, false, cfg, nil,
+	)
+}
+
+func TestGetParallelToolCalls(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  map[string]any
+		want *bool
+	}{
+		{"absent", map[string]any{}, nil},
+		{"nil config", nil, nil},
+		{"false", map[string]any{"parallel_tool_calls": false}, boolPtr(false)},
+		{"true", map[string]any{"parallel_tool_calls": true}, boolPtr(true)},
+		{"wrong type ignored", map[string]any{"parallel_tool_calls": "false"}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getParallelToolCalls(tt.cfg)
+			if tt.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, *tt.want, *got)
+		})
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// Configured plus tools declared: the parameter must reach the wire, otherwise
+// the whole feature is inert (the bug reported in #1736).
+func TestBuildToolRequest_ParallelToolCallsSentWithTools(t *testing.T) {
+	p := newParallelToolCallsProvider(map[string]any{"parallel_tool_calls": false})
+	p.apiMode = APIModeCompletions
+
+	got := p.buildToolRequest(context.Background(), providers.PredictionRequest{}, sampleTools(), "")
+
+	v, ok := got["parallel_tool_calls"]
+	require.True(t, ok, "parallel_tool_calls must be serialized when configured")
+	assert.Equal(t, false, v)
+}
+
+// Configured but no tools to declare: OpenAI rejects the pair with
+// "400 'parallel_tool_calls' is only allowed when 'tools' are specified".
+// That combination is reachable now that an emptied tool set still routes down
+// the tool-aware path (#1735), so this guard is load-bearing, not theoretical.
+func TestBuildToolRequest_ParallelToolCallsOmittedWithoutTools(t *testing.T) {
+	p := newParallelToolCallsProvider(map[string]any{"parallel_tool_calls": false})
+	p.apiMode = APIModeCompletions
+
+	got := p.buildToolRequest(context.Background(), providers.PredictionRequest{}, nil, "")
+
+	_, ok := got["parallel_tool_calls"]
+	assert.False(t, ok,
+		"must be omitted when no tools are declared, or OpenAI 400s the request")
+}
+
+func TestBuildToolRequest_ParallelToolCallsAbsentWhenUnconfigured(t *testing.T) {
+	p := newParallelToolCallsProvider(nil)
+	p.apiMode = APIModeCompletions
+
+	got := p.buildToolRequest(context.Background(), providers.PredictionRequest{}, sampleTools(), "")
+
+	_, ok := got["parallel_tool_calls"]
+	assert.False(t, ok, "unset config must not put the key on the wire at all")
+}
+
+// Responses mode shares the same additional_config but a separate builder.
+// Without this the same YAML silently does nothing depending on api_mode.
+func TestBuildResponsesRequest_ParallelToolCalls(t *testing.T) {
+	p := newParallelToolCallsProvider(map[string]any{"parallel_tool_calls": false})
+
+	withTools := p.buildResponsesRequest(providers.PredictionRequest{}, sampleTools(), "")
+	v, ok := withTools["parallel_tool_calls"]
+	require.True(t, ok, "Responses path must honor the same config key")
+	assert.Equal(t, false, v)
+
+	withoutTools := p.buildResponsesRequest(providers.PredictionRequest{}, nil, "")
+	_, ok = withoutTools["parallel_tool_calls"]
+	assert.False(t, ok, "same no-tools guard applies on the Responses path")
+}

--- a/runtime/providers/openai/openai_responses_integration.go
+++ b/runtime/providers/openai/openai_responses_integration.go
@@ -169,11 +169,16 @@ func (p *Provider) buildResponsesRequest(req providers.PredictionRequest, tools 
 		responsesReq["top_p"] = topP
 	}
 
-	// Add tools if provided
+	// Add tools if provided. parallel_tool_calls is scoped to this guard for the
+	// same reason as the completions builder — it is only valid alongside a
+	// declared tools array.
 	if tools != nil {
 		responsesReq["tools"] = p.convertToolsToResponsesFormat(tools)
 		if toolChoice != "" && toolChoice != toolChoiceAuto {
 			responsesReq["tool_choice"] = toolChoice
+		}
+		if p.parallelToolCalls != nil {
+			responsesReq["parallel_tool_calls"] = *p.parallelToolCalls
 		}
 	}
 

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -268,10 +268,16 @@ func (p *ToolProvider) buildToolRequest(
 		applyAudioModalities(openaiReq, p.additionalConfig, "wav")
 	}
 
-	// Add tools if provided
+	// Add tools if provided. parallel_tool_calls belongs strictly inside this
+	// guard: OpenAI rejects it when no tools are declared ("only allowed when
+	// 'tools' are specified"), and an emptied tool set still reaches this
+	// builder since #1735 routes tool-carrying history down the tool path.
 	if tools != nil {
 		openaiReq["tools"] = tools
 		p.addToolChoiceToRequest(openaiReq, toolChoice)
+		if p.parallelToolCalls != nil {
+			openaiReq["parallel_tool_calls"] = *p.parallelToolCalls
+		}
 	}
 
 	return openaiReq


### PR DESCRIPTION
## Summary

Makes OpenAI's `parallel_tool_calls` reachable from config. Refs #1736.

**Framing matters here:** this closes a **plumbing gap** — a documented provider parameter that no PromptKit surface could set. It is *not* a fix for duplicate tool-call emission. I could not reproduce that premise (details in [my analysis on #1736](https://github.com/AltairaLabs/PromptKit/issues/1736#issuecomment-5135364349)): a single logical request produced a single call in 15/15 live runs, and the only two-call case carried *different* arguments, which is correct model behavior.

## The gap

`parallel_tool_calls` appears nowhere in `runtime`/`pkg`/`sdk`. The provider reads a fixed whitelist from `additional_config` (`reasoning_effort`, `reasoning_summary`, `modalities`, `audio_format`, `voice`, `api_version`) with no generic merge, and the typed sampling path has no field. Setting it was silently dropped.

Two things made this cheaper than the issue assumed:

- **No schema change.** `additional_config` is `{"type": "object"}` with no property constraints, so arbitrary keys already validate. No `make schemas` cycle.
- **No new typed surface.** `spec.AdditionalConfig` already reaches the provider at the factory (`openai_tools.go:667`), so declarative config can set it as-is.

```yaml
providers:
  - id: openai
    model: gpt-4o-mini
    additional_config:
      parallel_tool_calls: false
```

## Implementation

`getParallelToolCalls` reads the key into a `*bool` on the provider, mirroring `getReasoningEffort`. `nil` means omit the field entirely and take OpenAI's default; a non-boolean value is ignored with a warning rather than guessed at, so a malformed value degrades to current behavior instead of silently disabling a capability.

Serialized on **both** request builders — chat-completions (`buildToolRequest`) and Responses (`buildResponsesRequest`) — so the same YAML doesn't silently do nothing depending on `api_mode`.

### The guard is load-bearing

The assignment sits strictly inside each builder's `tools != nil` block. OpenAI rejects the parameter when no tools are declared:

```
400 Invalid value for 'parallel_tool_calls': 'parallel_tool_calls' is only
    allowed when 'tools' are specified.
```

And since #1735, an emptied tool set **still routes through the tool-aware path** — so hoisting this out of the guard would reintroduce a 400 on exactly the path that fix repaired. Mutation-checked: hoisting it fails both the unit test (key present when it shouldn't be) and the live test (the real 400).

## Verification

Live, through the provider — not raw HTTP:

```
default (parallel_tool_calls omitted): 2 tool call(s)
parallel_tool_calls=false:             1 tool call(s)
```

Plus a live guard that a configured provider with a nil tool set and tool-carrying history still succeeds — the #1735 interaction.

Tests: 5 unit (parsing incl. wrong-type, both builders, the no-tools guard, unconfigured) + 2 live integration, gated on `OPENAI_API_KEY` and skipping without it. The live test skips rather than passes vacuously if the control fails to provoke parallel calling.

Full runtime suite green; `golangci-lint --new-from-rev` clean; changed-file coverage 91.9% / 84.9%.

## Note for reviewers

Three pre-existing `TestAudioModel_*` tests in this package fail **when an `OPENAI_API_KEY` is present**, with `404` on `gpt-4o-audio-preview` (retired on my account). I verified they fail identically on clean `main`, so they're unrelated to this change — they just normally skip in CI. Worth a separate look at some point.
