### PR TITLE
fix(openai): recognize the current gpt-audio model family

### DIFF
--- a/runtime/providers/openai/openai_contract_test.go
+++ b/runtime/providers/openai/openai_contract_test.go
@@ -119,7 +119,7 @@ func TestAudioModel_Predict_TextResponse(t *testing.T) {
 	defer logger.SetVerbose(false)
 
 	provider := NewProviderWithConfig(
-		"audio-test", "gpt-4o-audio-preview", "https://api.openai.com/v1",
+		"audio-test", "gpt-audio", "https://api.openai.com/v1",
 		providers.ProviderDefaults{
 			Temperature: 0.1,
 			MaxTokens:   200,
@@ -184,10 +184,13 @@ func TestAudioModel_Predict_TextResponse(t *testing.T) {
 	}
 }
 
-// TestAudioModel_Mini_BrooklynBridge investigates the gpt-4o-mini-audio-preview
-// model's ability to process a real speech audio clip (Brooklyn Bridge sample).
-// This test exists to diagnose why the mini model fails the capability matrix
-// content_matches assertion while the full model passes.
+// TestAudioModel_Mini_BrooklynBridge investigates the mini audio model's ability
+// to process a real speech audio clip (Brooklyn Bridge sample). This test exists
+// to diagnose why the mini model fails the capability matrix content_matches
+// assertion while the full model passes.
+//
+// Targets the current gpt-audio family; the gpt-4o-*-audio-preview models this
+// originally used are retired and now 404 (#1739).
 func TestAudioModel_Mini_BrooklynBridge(t *testing.T) {
 	if os.Getenv("OPENAI_API_KEY") == "" {
 		t.Skip("OPENAI_API_KEY not set")
@@ -196,7 +199,7 @@ func TestAudioModel_Mini_BrooklynBridge(t *testing.T) {
 	logger.SetVerbose(true)
 	defer logger.SetVerbose(false)
 
-	models := []string{"gpt-4o-audio-preview", "gpt-4o-mini-audio-preview"}
+	models := []string{"gpt-audio", "gpt-audio-mini"}
 
 	// Generate a test WAV with a 440Hz tone. This isn't speech, so transcription
 	// won't produce Brooklyn Bridge keywords — but it tests whether the model
@@ -287,7 +290,7 @@ func TestAudioModel_Predict_AudioOutputWithTranscript(t *testing.T) {
 	defer logger.SetVerbose(false)
 
 	provider := NewProviderWithConfig(
-		"audio-test", "gpt-4o-audio-preview", "https://api.openai.com/v1",
+		"audio-test", "gpt-audio", "https://api.openai.com/v1",
 		providers.ProviderDefaults{
 			Temperature: 0.1,
 			MaxTokens:   200,

--- a/runtime/providers/openai/openai_multimodal.go
+++ b/runtime/providers/openai/openai_multimodal.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -53,9 +54,24 @@ func (p *Provider) GetMultimodalCapabilities() providers.MultimodalCapabilities 
 // declare its capabilities. Prefer the declared `capabilities` list; this only
 // recognizes models by name for callers (e.g. some SDK usages) that omit it.
 func isAudioModel(model string) bool {
+	// Current family: the bare "gpt-audio", plus everything hyphen-suffixed off
+	// it — size variants (gpt-audio-mini), point releases (gpt-audio-1.5) and
+	// dated snapshots (gpt-audio-2025-08-28, gpt-audio-mini-2025-12-15). Matched
+	// by shape rather than enumerated, because an exact list silently disables
+	// audio for every model released after it was written — which is how
+	// "gpt-audio" itself came to be unrecognized (#1739). Requiring the hyphen
+	// keeps neighboring names like "gpt-audiofoo" out.
+	//
+	// Realtime models are deliberately excluded: they are a separate WebSocket
+	// surface, not the chat-completions audio path this gates.
+	if model == "gpt-audio" || strings.HasPrefix(model, "gpt-audio-") {
+		return true
+	}
+	// Retired 4o-era previews. They 404 at the API now, but stay recognized so
+	// a config still naming one keeps today's behavior instead of silently
+	// changing shape on upgrade.
 	switch model {
-	case "gpt-4o-audio-preview", "gpt-4o-mini-audio-preview",
-		"gpt-audio-1.5", "gpt-audio-mini":
+	case "gpt-4o-audio-preview", "gpt-4o-mini-audio-preview":
 		return true
 	default:
 		return false

--- a/runtime/providers/openai/openai_multimodal_test.go
+++ b/runtime/providers/openai/openai_multimodal_test.go
@@ -843,10 +843,19 @@ func TestIsAudioModel(t *testing.T) {
 		model    string
 		expected bool
 	}{
+		// Retired 4o-era previews stay recognized: they 404 at the API now, but
+		// dropping them would silently change behavior for configs still naming them.
 		{"gpt-4o-audio-preview", true},
 		{"gpt-4o-mini-audio-preview", true},
+		// Current family. "gpt-audio" is the plain base name and was previously
+		// unrecognized, which silently disabled audio for anyone using it (#1739).
+		{"gpt-audio", true},
 		{"gpt-audio-1.5", true},
 		{"gpt-audio-mini", true},
+		// Dated snapshots — what pinned production configs actually reference.
+		{"gpt-audio-2025-08-28", true},
+		{"gpt-audio-mini-2025-10-06", true},
+		{"gpt-audio-mini-2025-12-15", true},
 		{"gpt-4o", false},
 		{"gpt-4o-mini", false},
 		{"gpt-4-turbo", false},
@@ -854,6 +863,12 @@ func TestIsAudioModel(t *testing.T) {
 		{"o1", false},
 		{"o1-mini", false},
 		{"", false},
+		// Realtime is a separate WebSocket surface, not the chat-completions
+		// audio path this heuristic gates.
+		{"gpt-realtime", false},
+		{"gpt-realtime-mini", false},
+		// Keeps the family match from swallowing unrelated neighboring names.
+		{"gpt-audioxyz-not-a-model", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

`isAudioModel` matched an exact list that had drifted out of date, silently disabling audio for OpenAI's current base audio model. Closes #1739.

## The bug

```go
case "gpt-4o-audio-preview", "gpt-4o-mini-audio-preview",
	"gpt-audio-1.5", "gpt-audio-mini":
```

Against what's actually served today (verified via `GET /v1/models`):

| Model | Was matched? | Status |
|---|---|---|
| `gpt-audio` | ❌ | **current base model** |
| `gpt-audio-1.5` | ✅ | current |
| `gpt-audio-mini` | ✅ | current |
| `gpt-audio-2025-08-28` | ❌ | current dated snapshot |
| `gpt-audio-mini-2025-10-06` | ❌ | current dated snapshot |
| `gpt-audio-mini-2025-12-15` | ❌ | current dated snapshot |
| `gpt-4o-audio-preview` | ✅ | retired, 404s |
| `gpt-4o-mini-audio-preview` | ✅ | retired, 404s |

**The failure mode is silence.** `supportsAudioInput()` treats a declared `capabilities` list as authoritative and otherwise falls back to this heuristic, which gates `applyAudioModalities`. A provider configured for `gpt-audio` with no declared capabilities therefore sent requests with no `modalities`/`audio` — no error, just not what the caller asked for. `capabilities: [audio]` worked around it, which is probably why nobody hit it.

## Fix

Match the family by shape rather than enumerating it:

```go
if model == "gpt-audio" || strings.HasPrefix(model, "gpt-audio-") {
	return true
}
```

- Covers the bare name, size variants, point releases, and every dated snapshot — including ones not released yet. An exact list silently disables audio for everything published after it was written, which is precisely how `gpt-audio` came to be missing.
- Requiring the hyphen keeps unrelated neighbors out (`gpt-audiofoo` stays false) — there's a test row pinning that.
- **Realtime stays excluded.** `gpt-realtime*` is a separate WebSocket surface, not the chat-completions path this gates. Also pinned by tests.
- **Retired 4o-era names still match**, so a config still naming one keeps today's behavior instead of silently changing shape on upgrade. That branch stays covered by the existing `TestOpenAIProvider_AudioModelCapabilities`.

## Tests

Extended the existing `TestIsAudioModel` table rather than adding a parallel test — it and `TestMultimodal_DeclaredCapabilitiesAuthoritative` already covered this ground. Watched the four new positive rows fail before the fix, pass after; the negative guards passed throughout.

The three `TestAudioModel_*` contract tests targeted the retired models and 404'd against the live API whenever an `OPENAI_API_KEY` was present — invisible in CI, where they skip. Repointed at `gpt-audio` / `gpt-audio-mini`:

```
--- PASS: TestAudioModel_Predict_TextResponse (1.85s)
--- PASS: TestAudioModel_Mini_BrooklynBridge/gpt-audio (1.07s)
--- PASS: TestAudioModel_Mini_BrooklynBridge/gpt-audio-mini (1.87s)
--- PASS: TestAudioModel_Predict_AudioOutputWithTranscript (2.87s)
```

The whole `providers/openai` package now passes **with** a key present; it did not before this change.

Full runtime suite green; `golangci-lint --new-from-rev` clean; changed-file coverage 96.2%.

## Worth noting

A hardcoded model list will drift again — this buys time, it doesn't solve the category. Declaring `capabilities` explicitly stays the reliable path. It may be worth logging when the heuristic (rather than a declaration) is what decided audio support, so the next drift is visible instead of silent; I haven't done that here to keep the change scoped.
