### PR TITLE
fix(guardrails): gate the streaming chunk check on the declared direction

### DIFF
--- a/runtime/hooks/guardrails/adapter.go
+++ b/runtime/hooks/guardrails/adapter.go
@@ -224,9 +224,20 @@ func (a *GuardrailHookAdapter) evaluate(
 // When a guardrail triggers, it truncates the chunk content and returns
 // an Enforced decision so the provider stage can stop reading but continue
 // the pipeline.
+//
+// A chunk is assistant output, so this is the streaming half of AfterCall and
+// gates on direction identically. Without that gate a guardrail declared
+// `direction: input` still scored the model's reply — but only when streaming —
+// and the firing was recorded as an "output" one, since the chunk path stamps
+// that side unconditionally. So an input-only guardrail could block a response
+// it was never meant to judge, under a direction it never declared.
 func (a *GuardrailHookAdapter) OnChunk(
 	ctx context.Context, chunk *providers.StreamChunk,
 ) hooks.Decision {
+	if a.direction == DirectionInput {
+		return hooks.Allow
+	}
+
 	streamable, ok := a.handler.(evals.StreamableEvalHandler)
 	if !ok {
 		return hooks.Allow

--- a/runtime/hooks/guardrails/adapter_test.go
+++ b/runtime/hooks/guardrails/adapter_test.go
@@ -550,6 +550,58 @@ func TestGuardrailHookAdapter_OnChunk_StreamableFail(t *testing.T) {
 	}
 }
 
+// TestGuardrailHookAdapter_OnChunk_HonorsDirection pins that OnChunk gates on
+// the declared direction exactly as AfterCall does.
+//
+// A chunk is assistant output. An input-direction guardrail judges the user's
+// message and has no business scoring the model's reply — but OnChunk used to
+// run for every adapter that implemented StreamableEvalHandler, so declaring
+// `direction: input` silently produced an output guardrail on the streaming path
+// only. The firing was then recorded with direction "output"
+// (recordGuardrailFiring tags the chunk path unconditionally), so it did not
+// even report the side it was declared for.
+//
+// The stub always fails, so an ungated OnChunk cannot look like a pass: the
+// input case can only return Allow by skipping evaluation altogether.
+func TestGuardrailHookAdapter_OnChunk_HonorsDirection(t *testing.T) {
+	tests := []struct {
+		direction string
+		wantAllow bool
+	}{
+		{direction: DirectionInput, wantAllow: true},
+		{direction: DirectionOutput, wantAllow: false},
+		{direction: DirectionBoth, wantAllow: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.direction, func(t *testing.T) {
+			handler := &streamableStubHandler{
+				typeName:      "test_direction",
+				result:        &evals.EvalResult{Score: floatPtr(1.0)},
+				partialResult: &evals.EvalResult{Score: floatPtr(0.0), Explanation: "would fire"},
+			}
+			adapter := &GuardrailHookAdapter{
+				handler:   handler,
+				evalType:  "test_direction",
+				params:    map[string]any{},
+				direction: tc.direction,
+			}
+
+			chunk := &providers.StreamChunk{Content: "some output", Delta: "output"}
+			decision := adapter.OnChunk(context.Background(), chunk)
+
+			if decision.Allow != tc.wantAllow {
+				t.Errorf("direction %q: got Allow=%v, want %v",
+					tc.direction, decision.Allow, tc.wantAllow)
+			}
+			if tc.wantAllow && chunk.Content != "some output" {
+				t.Errorf("direction %q: an input guardrail must not rewrite an output chunk, got %q",
+					tc.direction, chunk.Content)
+			}
+		})
+	}
+}
+
 func TestGuardrailHookAdapter_OnChunk_StreamableError(t *testing.T) {
 	handler := &streamableStubHandler{
 		typeName:   "test_streamable_err",


### PR DESCRIPTION
`GuardrailHookAdapter.OnChunk` ran for every adapter implementing `StreamableEvalHandler`, without consulting `a.direction`. A chunk is assistant output, so `OnChunk` is the streaming half of `AfterCall` — but a guardrail declared `direction: input` still scored the model's reply, and **only when streaming**. The same pack behaved differently on the two provider paths.

The recorded firing was also wrong: the chunk path stamps `direction: "output"` unconditionally, so an input-only guardrail could block a response it was never meant to judge, under a side it never declared — and a direction-qualified `guardrail_triggered` assertion would match it as an output firing.

Gate on direction exactly as `AfterCall` does.

## How it was found

Mutation-checking the pack-validator test added in #1743: flipping the factory's default direction to `input` failed only the two non-streaming cases. It now fails all four.

Before:
```
--- FAIL: .../non-streaming_banned_words
--- FAIL: .../non-streaming_length
```
After:
```
--- FAIL: .../non-streaming_banned_words
--- FAIL: .../streaming_banned_words
--- FAIL: .../non-streaming_length
--- FAIL: .../streaming_length
```

## Test

`TestGuardrailHookAdapter_OnChunk_HonorsDirection` covers all three directions. The stub always fails, so an ungated `OnChunk` cannot look like a pass — the `input` case can only return Allow by skipping evaluation. It also asserts the chunk content is left alone, which is what the old code got wrong (it rewrote the chunk with the blocked message).

Verified failing before the fix:
```
direction "input": got Allow=false, want true
direction "input": an input guardrail must not rewrite an output chunk,
  got "Sorry, we can't provide this response as it would violate our content policy."
```
