### PR TITLE
fix(workflow): run the destination state's turn on transition

### DIFF
--- a/docs/src/content/docs/runtime/reference/pipeline.md
+++ b/docs/src/content/docs/runtime/reference/pipeline.md
@@ -181,6 +181,7 @@ This file contains FFmpeg\-dependent integration code for video frame extraction
   - [func NewFramesToMessageStage\(config FramesToMessageConfig\) \*FramesToMessageStage](<#NewFramesToMessageStage>)
   - [func \(s \*FramesToMessageStage\) GetConfig\(\) FramesToMessageConfig](<#FramesToMessageStage.GetConfig>)
   - [func \(s \*FramesToMessageStage\) Process\(ctx context.Context, input \<\-chan StreamElement, output chan\<\- StreamElement\) error](<#FramesToMessageStage.Process>)
+- [type Handoff](<#Handoff>)
 - [type HashRouter](<#HashRouter>)
   - [func NewHashRouter\(name string, outputNames \[\]string, keyFunc func\(StreamElement\) string\) \*HashRouter](<#NewHashRouter>)
   - [func \(r \*HashRouter\) Process\(ctx context.Context, input \<\-chan StreamElement, output chan\<\- StreamElement\) error](<#HashRouter.Process>)
@@ -294,6 +295,7 @@ This file contains FFmpeg\-dependent integration code for video frame extraction
   - [func NewProviderStageWithHooks\(provider providers.Provider, toolRegistry \*tools.Registry, toolPolicy \*pipeline.ToolPolicy, config \*ProviderConfig, emitter \*events.Emitter, hookRegistry \*hooks.Registry\) \*ProviderStage](<#NewProviderStageWithHooks>)
   - [func NewProviderStageWithTurnState\(provider providers.Provider, toolRegistry \*tools.Registry, toolPolicy \*pipeline.ToolPolicy, config \*ProviderConfig, emitter \*events.Emitter, hookRegistry \*hooks.Registry, turnState \*TurnState\) \*ProviderStage](<#NewProviderStageWithTurnState>)
   - [func \(s \*ProviderStage\) Process\(ctx context.Context, input \<\-chan StreamElement, output chan\<\- StreamElement\) error](<#ProviderStage.Process>)
+  - [func \(s \*ProviderStage\) SetWorkflowStateResolver\(r WorkflowStateResolver\)](<#ProviderStage.SetWorkflowStateResolver>)
 - [type QuerySourceType](<#QuerySourceType>)
 - [type RandomRouter](<#RandomRouter>)
   - [func NewRandomRouter\(name string, outputNames \[\]string\) \*RandomRouter](<#NewRandomRouter>)
@@ -439,6 +441,7 @@ This file contains FFmpeg\-dependent integration code for video frame extraction
   - [func NewWeightedRouter\(name string, weights map\[string\]float64\) \*WeightedRouter](<#NewWeightedRouter>)
   - [func \(r \*WeightedRouter\) Process\(ctx context.Context, input \<\-chan StreamElement, output chan\<\- StreamElement\) error](<#WeightedRouter.Process>)
   - [func \(r \*WeightedRouter\) RegisterOutput\(name string, output chan\<\- StreamElement\)](<#WeightedRouter.RegisterOutput>)
+- [type WorkflowStateResolver](<#WorkflowStateResolver>)
 
 
 ## Constants
@@ -2347,6 +2350,25 @@ func (s *FramesToMessageStage) Process(ctx context.Context, input <-chan StreamE
 
 Process implements the Stage interface. Collects frames and composes them into messages.
 
+<a name="Handoff"></a>
+## type Handoff
+
+Handoff describes a workflow state change that took effect mid\-turn.
+
+Changed is false when no transition was pending, in which case the other fields are meaningless and the caller must leave the turn's system prompt and tool set alone.
+
+```go
+type Handoff struct {
+    // Changed reports whether a pending transition was committed.
+    Changed bool
+    // SystemPrompt is the destination state's rendered system prompt.
+    SystemPrompt string
+    // AllowedTools is the destination state's allowed-tool list, used to
+    // rebuild the provider tool set from the registry.
+    AllowedTools []string
+}
+```
+
 <a name="HashRouter"></a>
 ## type HashRouter
 
@@ -3865,6 +3887,15 @@ func (s *ProviderStage) Process(ctx context.Context, input <-chan StreamElement,
 ```
 
 Process executes the LLM provider call and handles tool execution.
+
+<a name="ProviderStage.SetWorkflowStateResolver"></a>
+### func \(\*ProviderStage\) SetWorkflowStateResolver
+
+```go
+func (s *ProviderStage) SetWorkflowStateResolver(r WorkflowStateResolver)
+```
+
+SetWorkflowStateResolver installs the resolver used to apply workflow state changes mid\-turn. Pass nil to disable. Must be called before the stage runs.
 
 <a name="QuerySourceType"></a>
 ## type QuerySourceType
@@ -5786,5 +5817,34 @@ func (r *WeightedRouter) RegisterOutput(name string, output chan<- StreamElement
 ```
 
 RegisterOutput registers an output channel with a name.
+
+<a name="WorkflowStateResolver"></a>
+## type WorkflowStateResolver
+
+WorkflowStateResolver lets a workflow consumer advance the conversation's state in the middle of a tool loop.
+
+A workflow state change is exactly two things: a different system prompt and a different tool set. Both are already per\-round inputs to the provider loop, so committing a transition between rounds is sufficient to make the next round run as the destination state — no new conversation, no new pipeline, and no user message required. Without this, a transition advances the state machine and the destination state never speaks \(see docs/local\-backlog/WORKFLOW\_IN\_TURN\_STATE\_HANDOFF\_DESIGN.md\).
+
+runtime must not import sdk, so the interface is defined here and implemented by consumers \(SDK WorkflowConversation, Arena's per\-run transition executor\). Nil is the non\-workflow case and is always safe.
+
+```go
+type WorkflowStateResolver interface {
+    // ResolvePendingHandoff commits any transition left pending by the
+    // workflow transition tool and returns the destination state's prompt and
+    // allowed tools. It is called after each round's tool results are appended
+    // and before the next provider call.
+    //
+    // Implementations must return Changed=false — not an error — when no
+    // transition is pending, when the destination state is externally
+    // orchestrated (RFC 0009: the runtime pauses for an injected event),
+    // terminal, or composition-orchestrated.
+    ResolvePendingHandoff(ctx context.Context) (Handoff, error)
+
+    // CurrentStateMeta returns metadata describing the state that is active
+    // right now, for stamping onto the assistant message a round produced.
+    // Returns nil when there is nothing to record.
+    CurrentStateMeta() map[string]any
+}
+```
 
 Generated by [gomarkdoc](<https://github.com/princjef/gomarkdoc>)

--- a/docs/src/content/docs/runtime/reference/pipeline.md
+++ b/docs/src/content/docs/runtime/reference/pipeline.md
@@ -2353,18 +2353,24 @@ Process implements the Stage interface. Collects frames and composes them into m
 <a name="Handoff"></a>
 ## type Handoff
 
-Handoff describes a workflow state change that took effect mid\-turn.
+Handoff describes the prompt and tool set the workflow's current state needs.
 
-Changed is false when no transition was pending, in which case the other fields are meaningless and the caller must leave the turn's system prompt and tool set alone.
+It is a statement of what the turn \*should\* be running, not a record that something changed — the stage compares it against what the turn is actually running and swaps only on a mismatch. That distinction matters: a pipeline re\-execution \(HITL resume, deferred client tool\) re\-runs PromptAssemblyStage, which resets the turn's prompt to the state the pipeline was built for. A "did a transition just happen" signal is unobservable by then; a "what should be running" signal self\-corrects.
 
 ```go
 type Handoff struct {
-    // Changed reports whether a pending transition was committed.
-    Changed bool
-    // SystemPrompt is the destination state's rendered system prompt.
+    // Valid reports whether SystemPrompt and AllowedTools are meaningful.
+    // False when there is no workflow state to apply.
+    Valid bool
+    // Stop ends the turn without a further provider round. Set for states the
+    // runtime must not continue into — externally orchestrated states pause for
+    // an injected event (RFC 0009), and composition states are run by
+    // CompositionStage rather than the tool loop.
+    Stop bool
+    // SystemPrompt is the current state's rendered system prompt.
     SystemPrompt string
-    // AllowedTools is the destination state's allowed-tool list, used to
-    // rebuild the provider tool set from the registry.
+    // AllowedTools is the current state's allowed-tool list, used to rebuild
+    // the provider tool set from the registry.
     AllowedTools []string
 }
 ```
@@ -5821,24 +5827,22 @@ RegisterOutput registers an output channel with a name.
 <a name="WorkflowStateResolver"></a>
 ## type WorkflowStateResolver
 
-WorkflowStateResolver lets a workflow consumer advance the conversation's state in the middle of a tool loop.
+WorkflowStateResolver lets a workflow consumer keep a turn aligned with the workflow's current state.
 
-A workflow state change is exactly two things: a different system prompt and a different tool set. Both are already per\-round inputs to the provider loop, so committing a transition between rounds is sufficient to make the next round run as the destination state — no new conversation, no new pipeline, and no user message required. Without this, a transition advances the state machine and the destination state never speaks \(see docs/local\-backlog/WORKFLOW\_IN\_TURN\_STATE\_HANDOFF\_DESIGN.md\).
+A workflow state change is exactly two things: a different system prompt and a different tool set. Both are already per\-round inputs to the provider tool loop, so reconciling them between rounds is sufficient to make the turn run as the current state — no new conversation, no new pipeline, and no user message required. Without this, a transition advances the state machine and the destination state never speaks \(see docs/local\-backlog/WORKFLOW\_IN\_TURN\_STATE\_HANDOFF\_DESIGN.md\).
 
 runtime must not import sdk, so the interface is defined here and implemented by consumers \(SDK WorkflowConversation, Arena's per\-run transition executor\). Nil is the non\-workflow case and is always safe.
 
 ```go
 type WorkflowStateResolver interface {
-    // ResolvePendingHandoff commits any transition left pending by the
-    // workflow transition tool and returns the destination state's prompt and
-    // allowed tools. It is called after each round's tool results are appended
-    // and before the next provider call.
+    // ResolveCurrentState commits any transition left pending by the workflow
+    // transition tool, then reports the prompt and tools for the state the
+    // workflow is now in.
     //
-    // Implementations must return Changed=false — not an error — when no
-    // transition is pending, when the destination state is externally
-    // orchestrated (RFC 0009: the runtime pauses for an injected event),
-    // terminal, or composition-orchestrated.
-    ResolvePendingHandoff(ctx context.Context) (Handoff, error)
+    // It is called at the start of each pipeline execution and after each
+    // round's tool results, and must be safe to call repeatedly: callers rely
+    // on it being idempotent when nothing has changed.
+    ResolveCurrentState(ctx context.Context) (Handoff, error)
 
     // CurrentStateMeta returns metadata describing the state that is active
     // right now, for stamping onto the assistant message a round produced.

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -618,6 +618,17 @@ func (s *ProviderStage) applyStateHandoff(
 	acc.systemPrompt = handoff.SystemPrompt
 	acc.allowedTools = handoff.AllowedTools
 	loop.providerTools = rebuilt
+
+	// Write through to TurnState as well as the per-execution copy.
+	// accumulateInput re-reads TurnState on every pipeline execution, and a
+	// turn suspended for HITL or a deferred client tool is resumed by
+	// re-executing the SAME pipeline (UnarySession.ResumeWithToolResults).
+	// Without this the resumed execution reverts to the origin state's prompt
+	// while the state machine has already moved on.
+	if s.turnState != nil {
+		s.turnState.SystemPrompt = handoff.SystemPrompt
+		s.turnState.AllowedTools = handoff.AllowedTools
+	}
 	return nil
 }
 

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -552,6 +552,16 @@ func (s *ProviderStage) executeMultiRound(
 	// calling this at loop-start is safe for multi-turn conversations where
 	// the history was persisted by a previous turn.
 	loop.preSeedLog(ctx)
+	// Reconcile before the first round. A resumed execution (HITL approval,
+	// deferred client tool) re-ran PromptAssemblyStage, which reset the prompt
+	// to the state the pipeline was built for even though the workflow has
+	// already moved on. Nothing is "pending" by then, so only a comparison
+	// against the current state recovers it.
+	if stop, hErr := s.applyStateHandoff(ctx, acc, loop); hErr != nil {
+		return loop.messages, hErr
+	} else if stop {
+		return loop.messages, nil
+	}
 	for round := 1; round <= loop.maxRounds; round++ {
 		response, hasToolCalls, err := s.executeRound(
 			ctx, loop.messages, acc.systemPrompt, loop.providerTools, loop.toolChoice, round, acc.metadata)
@@ -565,8 +575,10 @@ func (s *ProviderStage) executeMultiRound(
 		if done, msgs, err := loop.afterRound(ctx, acc.allowedTools, &response, hasToolCalls, round); done {
 			return msgs, err
 		}
-		if err := s.applyStateHandoff(ctx, acc, loop); err != nil {
-			return loop.messages, err
+		if stop, hErr := s.applyStateHandoff(ctx, acc, loop); hErr != nil {
+			return loop.messages, hErr
+		} else if stop {
+			return loop.messages, nil
 		}
 	}
 	return loop.messages, nil
@@ -598,38 +610,45 @@ func (s *ProviderStage) stampWorkflowState(response *types.Message) {
 // No-op without a resolver, or when the resolver reports no pending transition
 // (including the states it declines to advance through: external, terminal,
 // composition).
+// Returns stop=true when the turn must end without a further provider round.
 func (s *ProviderStage) applyStateHandoff(
 	ctx context.Context, acc *providerInput, loop *toolLoop,
-) error {
+) (stop bool, err error) {
 	if s.stateResolver == nil {
-		return nil
+		return false, nil
 	}
-	handoff, err := s.stateResolver.ResolvePendingHandoff(ctx)
+	handoff, err := s.stateResolver.ResolveCurrentState(ctx)
 	if err != nil {
-		return fmt.Errorf("provider stage: workflow handoff: %w", err)
+		return false, fmt.Errorf("provider stage: workflow handoff: %w", err)
 	}
-	if !handoff.Changed {
-		return nil
+	if handoff.Stop {
+		return true, nil
+	}
+	// Compare rather than trust a change flag. PromptAssemblyStage re-runs on
+	// every pipeline execution and resets the prompt to the one the pipeline
+	// was built for, so a resumed turn (HITL, deferred client tool) can find
+	// itself back on the origin state's prompt with nothing "pending" to
+	// signal it. Reconciling against what is actually loaded self-corrects.
+	if !handoff.Valid || handoff.SystemPrompt == acc.systemPrompt {
+		return false, nil
 	}
 	rebuilt, _, err := s.buildProviderTools(handoff.AllowedTools, loop.excluded)
 	if err != nil {
-		return fmt.Errorf("provider stage: workflow handoff: rebuild tools: %w", err)
+		return false, fmt.Errorf("provider stage: workflow handoff: rebuild tools: %w", err)
 	}
 	acc.systemPrompt = handoff.SystemPrompt
 	acc.allowedTools = handoff.AllowedTools
 	loop.providerTools = rebuilt
 
-	// Write through to TurnState as well as the per-execution copy.
-	// accumulateInput re-reads TurnState on every pipeline execution, and a
-	// turn suspended for HITL or a deferred client tool is resumed by
-	// re-executing the SAME pipeline (UnarySession.ResumeWithToolResults).
-	// Without this the resumed execution reverts to the origin state's prompt
-	// while the state machine has already moved on.
+	// Write through to TurnState so anything else reading it this execution
+	// sees the same state. Note this does NOT survive the next execution --
+	// PromptAssemblyStage overwrites it -- which is why the comparison above,
+	// not this write, is what makes resume correct.
 	if s.turnState != nil {
 		s.turnState.SystemPrompt = handoff.SystemPrompt
 		s.turnState.AllowedTools = handoff.AllowedTools
 	}
-	return nil
+	return false, nil
 }
 
 // applyToolSelector narrows acc.allowedTools through the configured
@@ -812,6 +831,16 @@ func (s *ProviderStage) executeStreamingMultiRound(
 		return nil, err
 	}
 	loop.preSeedLog(ctx)
+	// Reconcile before the first round. A resumed execution (HITL approval,
+	// deferred client tool) re-ran PromptAssemblyStage, which reset the prompt
+	// to the state the pipeline was built for even though the workflow has
+	// already moved on. Nothing is "pending" by then, so only a comparison
+	// against the current state recovers it.
+	if stop, hErr := s.applyStateHandoff(ctx, acc, loop); hErr != nil {
+		return loop.messages, hErr
+	} else if stop {
+		return loop.messages, nil
+	}
 	for round := 1; round <= loop.maxRounds; round++ {
 		params := &streamingRoundParams{
 			messages:      loop.messages,
@@ -832,8 +861,10 @@ func (s *ProviderStage) executeStreamingMultiRound(
 		if done, msgs, err := loop.afterRound(ctx, acc.allowedTools, &response, hasToolCalls, round); done {
 			return msgs, err
 		}
-		if err := s.applyStateHandoff(ctx, acc, loop); err != nil {
-			return loop.messages, err
+		if stop, hErr := s.applyStateHandoff(ctx, acc, loop); hErr != nil {
+			return loop.messages, hErr
+		} else if stop {
+			return loop.messages, nil
 		}
 	}
 	return loop.messages, nil

--- a/runtime/pipeline/stage/stages_provider.go
+++ b/runtime/pipeline/stage/stages_provider.go
@@ -58,6 +58,17 @@ type ProviderStage struct {
 	// and ProviderRequestMetadata are sourced from it. Nil-safe (the
 	// stage emits an empty system prompt and no allowed tools).
 	turnState *TurnState
+	// stateResolver advances workflow state between tool-loop rounds, so a
+	// transition's destination state generates the next round instead of the
+	// turn ending with the origin state still in control. Nil for
+	// non-workflow runs. See state_handoff.go.
+	stateResolver WorkflowStateResolver
+}
+
+// SetWorkflowStateResolver installs the resolver used to apply workflow state
+// changes mid-turn. Pass nil to disable. Must be called before the stage runs.
+func (s *ProviderStage) SetWorkflowStateResolver(r WorkflowStateResolver) {
+	s.stateResolver = r
 }
 
 // ProviderConfig contains configuration for the provider stage.
@@ -547,11 +558,67 @@ func (s *ProviderStage) executeMultiRound(
 		if err != nil {
 			return loop.messages, err
 		}
+		// Stamp before afterRound appends the response: the active state right
+		// now is the one that generated this round, and applyStateHandoff may
+		// move it on before the next round runs.
+		s.stampWorkflowState(&response)
 		if done, msgs, err := loop.afterRound(ctx, acc.allowedTools, &response, hasToolCalls, round); done {
 			return msgs, err
 		}
+		if err := s.applyStateHandoff(ctx, acc, loop); err != nil {
+			return loop.messages, err
+		}
 	}
 	return loop.messages, nil
+}
+
+// stampWorkflowState records the workflow state that produced this round's
+// assistant message. A turn can span several states once handoffs are applied
+// mid-loop, so attribution has to be per message rather than per turn. No-op
+// for non-workflow runs.
+func (s *ProviderStage) stampWorkflowState(response *types.Message) {
+	if s.stateResolver == nil || response == nil {
+		return
+	}
+	meta := s.stateResolver.CurrentStateMeta()
+	if len(meta) == 0 {
+		return
+	}
+	if response.Meta == nil {
+		response.Meta = map[string]interface{}{}
+	}
+	response.Meta[workflowStateMetaKey] = meta
+}
+
+// applyStateHandoff commits a workflow transition left pending by this round's
+// tool calls, then swaps the turn's system prompt and tool set to the
+// destination state's so the next round runs as that state. This is what makes
+// the destination state speak without waiting for a user message.
+//
+// No-op without a resolver, or when the resolver reports no pending transition
+// (including the states it declines to advance through: external, terminal,
+// composition).
+func (s *ProviderStage) applyStateHandoff(
+	ctx context.Context, acc *providerInput, loop *toolLoop,
+) error {
+	if s.stateResolver == nil {
+		return nil
+	}
+	handoff, err := s.stateResolver.ResolvePendingHandoff(ctx)
+	if err != nil {
+		return fmt.Errorf("provider stage: workflow handoff: %w", err)
+	}
+	if !handoff.Changed {
+		return nil
+	}
+	rebuilt, _, err := s.buildProviderTools(handoff.AllowedTools, loop.excluded)
+	if err != nil {
+		return fmt.Errorf("provider stage: workflow handoff: rebuild tools: %w", err)
+	}
+	acc.systemPrompt = handoff.SystemPrompt
+	acc.allowedTools = handoff.AllowedTools
+	loop.providerTools = rebuilt
+	return nil
 }
 
 // applyToolSelector narrows acc.allowedTools through the configured
@@ -747,8 +814,15 @@ func (s *ProviderStage) executeStreamingMultiRound(
 		if err != nil {
 			return loop.messages, err
 		}
+		// Same per-round stamp/handoff as the unary loop — the next round's
+		// streamingRoundParams re-read acc.systemPrompt and loop.providerTools,
+		// so a mid-loop swap takes effect there.
+		s.stampWorkflowState(&response)
 		if done, msgs, err := loop.afterRound(ctx, acc.allowedTools, &response, hasToolCalls, round); done {
 			return msgs, err
+		}
+		if err := s.applyStateHandoff(ctx, acc, loop); err != nil {
+			return loop.messages, err
 		}
 	}
 	return loop.messages, nil

--- a/runtime/pipeline/stage/state_handoff.go
+++ b/runtime/pipeline/stage/state_handoff.go
@@ -2,46 +2,54 @@ package stage
 
 import "context"
 
-// Handoff describes a workflow state change that took effect mid-turn.
+// Handoff describes the prompt and tool set the workflow's current state needs.
 //
-// Changed is false when no transition was pending, in which case the other
-// fields are meaningless and the caller must leave the turn's system prompt
-// and tool set alone.
+// It is a statement of what the turn *should* be running, not a record that
+// something changed — the stage compares it against what the turn is actually
+// running and swaps only on a mismatch. That distinction matters: a pipeline
+// re-execution (HITL resume, deferred client tool) re-runs PromptAssemblyStage,
+// which resets the turn's prompt to the state the pipeline was built for. A
+// "did a transition just happen" signal is unobservable by then; a "what should
+// be running" signal self-corrects.
 type Handoff struct {
-	// Changed reports whether a pending transition was committed.
-	Changed bool
-	// SystemPrompt is the destination state's rendered system prompt.
+	// Valid reports whether SystemPrompt and AllowedTools are meaningful.
+	// False when there is no workflow state to apply.
+	Valid bool
+	// Stop ends the turn without a further provider round. Set for states the
+	// runtime must not continue into — externally orchestrated states pause for
+	// an injected event (RFC 0009), and composition states are run by
+	// CompositionStage rather than the tool loop.
+	Stop bool
+	// SystemPrompt is the current state's rendered system prompt.
 	SystemPrompt string
-	// AllowedTools is the destination state's allowed-tool list, used to
-	// rebuild the provider tool set from the registry.
+	// AllowedTools is the current state's allowed-tool list, used to rebuild
+	// the provider tool set from the registry.
 	AllowedTools []string
 }
 
-// WorkflowStateResolver lets a workflow consumer advance the conversation's
-// state in the middle of a tool loop.
+// WorkflowStateResolver lets a workflow consumer keep a turn aligned with the
+// workflow's current state.
 //
 // A workflow state change is exactly two things: a different system prompt and
-// a different tool set. Both are already per-round inputs to the provider loop,
-// so committing a transition between rounds is sufficient to make the next
-// round run as the destination state — no new conversation, no new pipeline,
-// and no user message required. Without this, a transition advances the state
-// machine and the destination state never speaks (see
+// a different tool set. Both are already per-round inputs to the provider tool
+// loop, so reconciling them between rounds is sufficient to make the turn run
+// as the current state — no new conversation, no new pipeline, and no user
+// message required. Without this, a transition advances the state machine and
+// the destination state never speaks (see
 // docs/local-backlog/WORKFLOW_IN_TURN_STATE_HANDOFF_DESIGN.md).
 //
-// runtime must not import sdk, so the interface is defined here and
-// implemented by consumers (SDK WorkflowConversation, Arena's per-run
-// transition executor). Nil is the non-workflow case and is always safe.
+// runtime must not import sdk, so the interface is defined here and implemented
+// by consumers (SDK WorkflowConversation, Arena's per-run transition executor).
+// Nil is the non-workflow case and is always safe.
 type WorkflowStateResolver interface {
-	// ResolvePendingHandoff commits any transition left pending by the
-	// workflow transition tool and returns the destination state's prompt and
-	// allowed tools. It is called after each round's tool results are appended
-	// and before the next provider call.
+	// ResolveCurrentState commits any transition left pending by the workflow
+	// transition tool, then reports the prompt and tools for the state the
+	// workflow is now in.
 	//
-	// Implementations must return Changed=false — not an error — when no
-	// transition is pending, when the destination state is externally
-	// orchestrated (RFC 0009: the runtime pauses for an injected event),
-	// terminal, or composition-orchestrated.
-	ResolvePendingHandoff(ctx context.Context) (Handoff, error)
+	// It is called at the start of each pipeline execution and after each
+	// round's tool results, and must be safe to call repeatedly: callers rely
+	// on it being idempotent when nothing has changed.
+	ResolveCurrentState(ctx context.Context) (Handoff, error)
 
 	// CurrentStateMeta returns metadata describing the state that is active
 	// right now, for stamping onto the assistant message a round produced.

--- a/runtime/pipeline/stage/state_handoff.go
+++ b/runtime/pipeline/stage/state_handoff.go
@@ -1,0 +1,56 @@
+package stage
+
+import "context"
+
+// Handoff describes a workflow state change that took effect mid-turn.
+//
+// Changed is false when no transition was pending, in which case the other
+// fields are meaningless and the caller must leave the turn's system prompt
+// and tool set alone.
+type Handoff struct {
+	// Changed reports whether a pending transition was committed.
+	Changed bool
+	// SystemPrompt is the destination state's rendered system prompt.
+	SystemPrompt string
+	// AllowedTools is the destination state's allowed-tool list, used to
+	// rebuild the provider tool set from the registry.
+	AllowedTools []string
+}
+
+// WorkflowStateResolver lets a workflow consumer advance the conversation's
+// state in the middle of a tool loop.
+//
+// A workflow state change is exactly two things: a different system prompt and
+// a different tool set. Both are already per-round inputs to the provider loop,
+// so committing a transition between rounds is sufficient to make the next
+// round run as the destination state — no new conversation, no new pipeline,
+// and no user message required. Without this, a transition advances the state
+// machine and the destination state never speaks (see
+// docs/local-backlog/WORKFLOW_IN_TURN_STATE_HANDOFF_DESIGN.md).
+//
+// runtime must not import sdk, so the interface is defined here and
+// implemented by consumers (SDK WorkflowConversation, Arena's per-run
+// transition executor). Nil is the non-workflow case and is always safe.
+type WorkflowStateResolver interface {
+	// ResolvePendingHandoff commits any transition left pending by the
+	// workflow transition tool and returns the destination state's prompt and
+	// allowed tools. It is called after each round's tool results are appended
+	// and before the next provider call.
+	//
+	// Implementations must return Changed=false — not an error — when no
+	// transition is pending, when the destination state is externally
+	// orchestrated (RFC 0009: the runtime pauses for an injected event),
+	// terminal, or composition-orchestrated.
+	ResolvePendingHandoff(ctx context.Context) (Handoff, error)
+
+	// CurrentStateMeta returns metadata describing the state that is active
+	// right now, for stamping onto the assistant message a round produced.
+	// Returns nil when there is nothing to record.
+	CurrentStateMeta() map[string]any
+}
+
+// workflowStateMetaKey is the message metadata key under which the active
+// workflow state is recorded for each assistant message. Consumers read it to
+// attribute output to the state that generated it; a turn may span several
+// states, so per-turn attribution is not sufficient.
+const workflowStateMetaKey = "current_workflow_state"

--- a/runtime/pipeline/stage/state_handoff_test.go
+++ b/runtime/pipeline/stage/state_handoff_test.go
@@ -1,0 +1,212 @@
+package stage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/tools"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// handoffProvider records the system prompt it is called with on each round and
+// scripts a tool call on round 1 so the loop runs a second round.
+type handoffProvider struct {
+	*mock.ToolProvider
+	seenPrompts []string
+}
+
+// SupportsStreaming false pins these tests to the unary tool loop
+// (executeMultiRound). The streaming loop is covered separately — the two are
+// parallel implementations, so both need the handoff wiring.
+func (p *handoffProvider) SupportsStreaming() bool { return false }
+
+// Predict records too, so a test failure distinguishes "wrong method routed"
+// from "provider never called".
+func (p *handoffProvider) Predict(
+	_ context.Context, req providers.PredictionRequest,
+) (providers.PredictionResponse, error) {
+	p.seenPrompts = append(p.seenPrompts, "PREDICT:"+req.System)
+	return providers.PredictionResponse{Content: "plain"}, nil
+}
+
+func (p *handoffProvider) PredictWithTools(
+	_ context.Context,
+	req providers.PredictionRequest,
+	_ providers.ProviderTools,
+	_ string,
+) (providers.PredictionResponse, []types.MessageToolCall, error) {
+	p.seenPrompts = append(p.seenPrompts, req.System)
+
+	// Round 1 transitions; every later round answers plainly so the loop ends.
+	if len(p.seenPrompts) == 1 {
+		calls := []types.MessageToolCall{{
+			ID:   "call-1",
+			Name: "workflow__transition",
+			Args: []byte(`{"event":"Escalate","context":"caller verified"}`),
+		}}
+		return providers.PredictionResponse{ToolCalls: calls}, calls, nil
+	}
+	return providers.PredictionResponse{Content: "destination speaking"}, nil, nil
+}
+
+// fakeResolver reports a single handoff, then no further changes.
+type fakeResolver struct {
+	handoff Handoff
+	err     error
+	meta    map[string]any
+	calls   int
+}
+
+func (f *fakeResolver) ResolvePendingHandoff(_ context.Context) (Handoff, error) {
+	f.calls++
+	if f.err != nil {
+		return Handoff{}, f.err
+	}
+	if f.calls > 1 {
+		return Handoff{Changed: false}, nil
+	}
+	return f.handoff, nil
+}
+
+func (f *fakeResolver) CurrentStateMeta() map[string]any { return f.meta }
+
+func newHandoffStage(t *testing.T, resolver WorkflowStateResolver) (*ProviderStage, *handoffProvider) {
+	t.Helper()
+
+	registry := tools.NewRegistry()
+	require.NoError(t, registry.Register(&tools.ToolDescriptor{
+		Name:        "workflow__transition",
+		Description: "Transition the workflow",
+		InputSchema: []byte(`{"type":"object"}`),
+	}))
+
+	provider := &handoffProvider{ToolProvider: mock.NewToolProvider("mock", "mock-model", false, nil)}
+
+	turnState := NewTurnState()
+	turnState.SystemPrompt = "ORIGIN PROMPT"
+	turnState.AllowedTools = []string{"workflow__transition"}
+
+	stage := NewProviderStageWithTurnState(provider, registry, nil, &ProviderConfig{
+		MaxTokens: 100,
+	}, nil, nil, turnState)
+	stage.SetWorkflowStateResolver(resolver)
+
+	return stage, provider
+}
+
+func runHandoffTurn(t *testing.T, stage *ProviderStage) {
+	t.Helper()
+
+	input := make(chan StreamElement, 1)
+	userMsg := types.Message{Role: "user", Content: "someone charged my account"}
+	input <- NewMessageElement(&userMsg)
+	close(input)
+
+	output := make(chan StreamElement, 32)
+	require.NoError(t, stage.Process(context.Background(), input, output))
+	for range output { //nolint:revive // draining
+	}
+}
+
+// The core guarantee: after the transition tool result, the next provider round
+// runs under the DESTINATION state's system prompt. Without the handoff the
+// second round repeats the origin prompt, which is the bug this fixes — the
+// origin agent gets the last word and the destination state never speaks.
+func TestProviderStage_HandoffSwapsSystemPromptMidTurn(t *testing.T) {
+	resolver := &fakeResolver{handoff: Handoff{
+		Changed:      true,
+		SystemPrompt: "DESTINATION PROMPT",
+		AllowedTools: []string{"workflow__transition"},
+	}}
+
+	stage, provider := newHandoffStage(t, resolver)
+	runHandoffTurn(t, stage)
+
+	require.Len(t, provider.seenPrompts, 2,
+		"transition tool call must produce a second round")
+	require.Equal(t, "ORIGIN PROMPT", provider.seenPrompts[0])
+	require.Equal(t, "DESTINATION PROMPT", provider.seenPrompts[1],
+		"round after the transition must run as the destination state")
+}
+
+// A resolver reporting no change must leave the turn untouched — this is the
+// path every non-workflow and non-transitioning turn takes.
+func TestProviderStage_NoHandoffLeavesPromptUnchanged(t *testing.T) {
+	resolver := &fakeResolver{handoff: Handoff{Changed: false, SystemPrompt: "SHOULD NOT APPLY"}}
+
+	stage, provider := newHandoffStage(t, resolver)
+	runHandoffTurn(t, stage)
+
+	require.Len(t, provider.seenPrompts, 2)
+	require.Equal(t, "ORIGIN PROMPT", provider.seenPrompts[0])
+	require.Equal(t, "ORIGIN PROMPT", provider.seenPrompts[1],
+		"Changed=false must not alter the system prompt")
+}
+
+// A nil resolver is the non-workflow case and must be inert.
+func TestProviderStage_NilResolverIsInert(t *testing.T) {
+	stage, provider := newHandoffStage(t, nil)
+	runHandoffTurn(t, stage)
+
+	require.Len(t, provider.seenPrompts, 2)
+	require.Equal(t, "ORIGIN PROMPT", provider.seenPrompts[1])
+}
+
+// A resolver error must abort the turn rather than silently continuing under
+// the wrong state's prompt.
+func TestProviderStage_HandoffErrorAbortsTurn(t *testing.T) {
+	resolver := &fakeResolver{err: context.DeadlineExceeded}
+
+	stage, provider := newHandoffStage(t, resolver)
+
+	input := make(chan StreamElement, 1)
+	userMsg := types.Message{Role: "user", Content: "hello"}
+	input <- NewMessageElement(&userMsg)
+	close(input)
+
+	output := make(chan StreamElement, 32)
+	err := stage.Process(context.Background(), input, output)
+	for range output { //nolint:revive // draining
+	}
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "workflow handoff")
+	require.Len(t, provider.seenPrompts, 1,
+		"no further round may run after a failed handoff")
+}
+
+// Each assistant message carries the state that produced it. A turn can span
+// states, so per-turn attribution is not sufficient.
+func TestProviderStage_StampsStatePerAssistantMessage(t *testing.T) {
+	resolver := &fakeResolver{
+		handoff: Handoff{Changed: true, SystemPrompt: "DESTINATION PROMPT"},
+		meta:    map[string]any{"current_state": "handoff"},
+	}
+	stage, _ := newHandoffStage(t, resolver)
+
+	response := types.Message{Role: "assistant", Content: "hi"}
+	stage.stampWorkflowState(&response)
+
+	require.Equal(t, map[string]any{"current_state": "handoff"},
+		response.Meta[workflowStateMetaKey])
+}
+
+func TestProviderStage_StampIsNoOpWithoutResolverOrMeta(t *testing.T) {
+	t.Run("nil resolver", func(t *testing.T) {
+		stage, _ := newHandoffStage(t, nil)
+		response := types.Message{Role: "assistant", Content: "hi"}
+		stage.stampWorkflowState(&response)
+		require.Nil(t, response.Meta)
+	})
+
+	t.Run("empty meta", func(t *testing.T) {
+		stage, _ := newHandoffStage(t, &fakeResolver{})
+		response := types.Message{Role: "assistant", Content: "hi"}
+		stage.stampWorkflowState(&response)
+		require.Nil(t, response.Meta)
+	})
+}

--- a/runtime/pipeline/stage/state_handoff_test.go
+++ b/runtime/pipeline/stage/state_handoff_test.go
@@ -133,6 +133,35 @@ func TestProviderStage_HandoffSwapsSystemPromptMidTurn(t *testing.T) {
 		"round after the transition must run as the destination state")
 }
 
+// A handoff must survive re-execution of the same pipeline.
+//
+// HITL and deferred client tools suspend a turn and resume it via
+// ResumeWithToolResults, which re-runs the SAME pipeline; accumulateInput
+// rebuilds the per-execution state from TurnState every time. If the handoff
+// only mutates the per-execution copy, the resumed execution silently reverts
+// to the origin state's prompt while the state machine has already moved on.
+func TestProviderStage_HandoffSurvivesPipelineReExecution(t *testing.T) {
+	resolver := &fakeResolver{handoff: Handoff{
+		Changed:      true,
+		SystemPrompt: "DESTINATION PROMPT",
+		AllowedTools: []string{"workflow__transition"},
+	}}
+
+	stage, provider := newHandoffStage(t, resolver)
+
+	// First turn: transitions mid-flight.
+	runHandoffTurn(t, stage)
+	require.Equal(t, "DESTINATION PROMPT", provider.seenPrompts[1])
+
+	// Re-execute the same pipeline, as a HITL resume does. The resolver now
+	// reports no further change, so the prompt must come from the state the
+	// handoff left us in.
+	runHandoffTurn(t, stage)
+
+	require.Equal(t, "DESTINATION PROMPT", provider.seenPrompts[2],
+		"re-execution must not revert to the origin state's prompt")
+}
+
 // A resolver reporting no change must leave the turn untouched — this is the
 // path every non-workflow and non-transitioning turn takes.
 func TestProviderStage_NoHandoffLeavesPromptUnchanged(t *testing.T) {

--- a/runtime/pipeline/stage/state_handoff_test.go
+++ b/runtime/pipeline/stage/state_handoff_test.go
@@ -195,6 +195,89 @@ func TestProviderStage_StampsStatePerAssistantMessage(t *testing.T) {
 		response.Meta[workflowStateMetaKey])
 }
 
+// streamingHandoffProvider drives the OTHER tool loop.
+// executeAndEmit routes on SupportsStreaming(), and the streaming loop is a
+// parallel implementation of executeMultiRound — it rebuilds
+// streamingRoundParams per round rather than sharing code, so the handoff
+// wiring has to be verified there independently.
+type streamingHandoffProvider struct {
+	*mock.ToolProvider
+	seenPrompts []string
+}
+
+func (p *streamingHandoffProvider) SupportsStreaming() bool { return true }
+
+func (p *streamingHandoffProvider) PredictStreamWithTools(
+	_ context.Context,
+	req providers.PredictionRequest,
+	_ providers.ProviderTools,
+	_ string,
+) (<-chan providers.StreamChunk, error) {
+	p.seenPrompts = append(p.seenPrompts, req.System)
+	round := len(p.seenPrompts)
+
+	out := make(chan providers.StreamChunk, 2)
+	go func() {
+		defer close(out)
+		if round == 1 {
+			reason := "tool_calls"
+			out <- providers.StreamChunk{
+				ToolCalls: []types.MessageToolCall{{
+					ID:   "call-1",
+					Name: "workflow__transition",
+					Args: []byte(`{"event":"Escalate","context":"caller verified"}`),
+				}},
+				FinishReason: &reason,
+			}
+			return
+		}
+		reason := "stop"
+		out <- providers.StreamChunk{
+			Content:      "destination speaking",
+			Delta:        "destination speaking",
+			FinishReason: &reason,
+		}
+	}()
+	return out, nil
+}
+
+// The streaming loop must apply the handoff exactly as the unary loop does.
+func TestProviderStage_StreamingLoopSwapsSystemPromptMidTurn(t *testing.T) {
+	resolver := &fakeResolver{handoff: Handoff{
+		Changed:      true,
+		SystemPrompt: "DESTINATION PROMPT",
+		AllowedTools: []string{"workflow__transition"},
+	}}
+
+	registry := tools.NewRegistry()
+	require.NoError(t, registry.Register(&tools.ToolDescriptor{
+		Name:        "workflow__transition",
+		Description: "Transition the workflow",
+		InputSchema: []byte(`{"type":"object"}`),
+	}))
+
+	provider := &streamingHandoffProvider{
+		ToolProvider: mock.NewToolProvider("mock", "mock-model", false, nil),
+	}
+
+	turnState := NewTurnState()
+	turnState.SystemPrompt = "ORIGIN PROMPT"
+	turnState.AllowedTools = []string{"workflow__transition"}
+
+	stage := NewProviderStageWithTurnState(provider, registry, nil, &ProviderConfig{
+		MaxTokens: 100,
+	}, nil, nil, turnState)
+	stage.SetWorkflowStateResolver(resolver)
+
+	runHandoffTurn(t, stage)
+
+	require.Len(t, provider.seenPrompts, 2,
+		"the streaming loop must run a second round after the transition")
+	require.Equal(t, "ORIGIN PROMPT", provider.seenPrompts[0])
+	require.Equal(t, "DESTINATION PROMPT", provider.seenPrompts[1],
+		"streaming round after the transition must run as the destination state")
+}
+
 func TestProviderStage_StampIsNoOpWithoutResolverOrMeta(t *testing.T) {
 	t.Run("nil resolver", func(t *testing.T) {
 		stage, _ := newHandoffStage(t, nil)

--- a/runtime/pipeline/stage/state_handoff_test.go
+++ b/runtime/pipeline/stage/state_handoff_test.go
@@ -24,8 +24,6 @@ type handoffProvider struct {
 // parallel implementations, so both need the handoff wiring.
 func (p *handoffProvider) SupportsStreaming() bool { return false }
 
-// Predict records too, so a test failure distinguishes "wrong method routed"
-// from "provider never called".
 func (p *handoffProvider) Predict(
 	_ context.Context, req providers.PredictionRequest,
 ) (providers.PredictionResponse, error) {
@@ -41,7 +39,8 @@ func (p *handoffProvider) PredictWithTools(
 ) (providers.PredictionResponse, []types.MessageToolCall, error) {
 	p.seenPrompts = append(p.seenPrompts, req.System)
 
-	// Round 1 transitions; every later round answers plainly so the loop ends.
+	// Transition on the first round only; later rounds answer plainly so the
+	// loop terminates.
 	if len(p.seenPrompts) == 1 {
 		calls := []types.MessageToolCall{{
 			ID:   "call-1",
@@ -53,28 +52,45 @@ func (p *handoffProvider) PredictWithTools(
 	return providers.PredictionResponse{Content: "destination speaking"}, nil, nil
 }
 
-// fakeResolver reports a single handoff, then no further changes.
+// fakeResolver returns a scripted sequence of Handoffs, repeating the last.
+// The resolver contract is "what should this turn be running", so a real
+// implementation returns the ORIGIN state's prompt until the transition
+// commits and the DESTINATION's afterwards — the sequence models that.
 type fakeResolver struct {
-	handoff Handoff
-	err     error
-	meta    map[string]any
-	calls   int
+	sequence []Handoff
+	err      error
+	meta     map[string]any
+	calls    int
 }
 
-func (f *fakeResolver) ResolvePendingHandoff(_ context.Context) (Handoff, error) {
-	f.calls++
+func (f *fakeResolver) ResolveCurrentState(_ context.Context) (Handoff, error) {
 	if f.err != nil {
 		return Handoff{}, f.err
 	}
-	if f.calls > 1 {
-		return Handoff{Changed: false}, nil
+	f.calls++
+	if len(f.sequence) == 0 {
+		return Handoff{}, nil
 	}
-	return f.handoff, nil
+	idx := f.calls - 1
+	if idx >= len(f.sequence) {
+		idx = len(f.sequence) - 1
+	}
+	return f.sequence[idx], nil
 }
 
 func (f *fakeResolver) CurrentStateMeta() map[string]any { return f.meta }
 
-func newHandoffStage(t *testing.T, resolver WorkflowStateResolver) (*ProviderStage, *handoffProvider) {
+// originThenDestination is the common script: the workflow is in the origin
+// state when the turn starts, and in the destination state once the transition
+// tool has run.
+func originThenDestination() []Handoff {
+	return []Handoff{
+		{Valid: true, SystemPrompt: "ORIGIN PROMPT", AllowedTools: []string{"workflow__transition"}},
+		{Valid: true, SystemPrompt: "DESTINATION PROMPT", AllowedTools: []string{"workflow__transition"}},
+	}
+}
+
+func newHandoffStage(t *testing.T, resolver WorkflowStateResolver) (*ProviderStage, *handoffProvider, *TurnState) {
 	t.Helper()
 
 	registry := tools.NewRegistry()
@@ -95,7 +111,7 @@ func newHandoffStage(t *testing.T, resolver WorkflowStateResolver) (*ProviderSta
 	}, nil, nil, turnState)
 	stage.SetWorkflowStateResolver(resolver)
 
-	return stage, provider
+	return stage, provider, turnState
 }
 
 func runHandoffTurn(t *testing.T, stage *ProviderStage) {
@@ -117,13 +133,9 @@ func runHandoffTurn(t *testing.T, stage *ProviderStage) {
 // second round repeats the origin prompt, which is the bug this fixes — the
 // origin agent gets the last word and the destination state never speaks.
 func TestProviderStage_HandoffSwapsSystemPromptMidTurn(t *testing.T) {
-	resolver := &fakeResolver{handoff: Handoff{
-		Changed:      true,
-		SystemPrompt: "DESTINATION PROMPT",
-		AllowedTools: []string{"workflow__transition"},
-	}}
+	resolver := &fakeResolver{sequence: originThenDestination()}
 
-	stage, provider := newHandoffStage(t, resolver)
+	stage, provider, _ := newHandoffStage(t, resolver)
 	runHandoffTurn(t, stage)
 
 	require.Len(t, provider.seenPrompts, 2,
@@ -133,52 +145,63 @@ func TestProviderStage_HandoffSwapsSystemPromptMidTurn(t *testing.T) {
 		"round after the transition must run as the destination state")
 }
 
-// A handoff must survive re-execution of the same pipeline.
-//
-// HITL and deferred client tools suspend a turn and resume it via
-// ResumeWithToolResults, which re-runs the SAME pipeline; accumulateInput
-// rebuilds the per-execution state from TurnState every time. If the handoff
-// only mutates the per-execution copy, the resumed execution silently reverts
-// to the origin state's prompt while the state machine has already moved on.
+// A resumed execution re-runs PromptAssemblyStage, which resets the turn's
+// prompt to the state the pipeline was BUILT for — even though the workflow has
+// already moved on and nothing is "pending" any more. Only a comparison against
+// the current state recovers it, which is why the resolver reports what should
+// be running rather than what changed.
 func TestProviderStage_HandoffSurvivesPipelineReExecution(t *testing.T) {
-	resolver := &fakeResolver{handoff: Handoff{
-		Changed:      true,
-		SystemPrompt: "DESTINATION PROMPT",
-		AllowedTools: []string{"workflow__transition"},
-	}}
+	resolver := &fakeResolver{sequence: originThenDestination()}
 
-	stage, provider := newHandoffStage(t, resolver)
+	stage, provider, turnState := newHandoffStage(t, resolver)
 
-	// First turn: transitions mid-flight.
 	runHandoffTurn(t, stage)
 	require.Equal(t, "DESTINATION PROMPT", provider.seenPrompts[1])
 
-	// Re-execute the same pipeline, as a HITL resume does. The resolver now
-	// reports no further change, so the prompt must come from the state the
-	// handoff left us in.
+	// Simulate what PromptAssemblyStage does on the next execution of the same
+	// pipeline: reload the build-time prompt over whatever the handoff set.
+	turnState.SystemPrompt = "ORIGIN PROMPT"
+
 	runHandoffTurn(t, stage)
 
 	require.Equal(t, "DESTINATION PROMPT", provider.seenPrompts[2],
-		"re-execution must not revert to the origin state's prompt")
+		"a re-executed turn must be reconciled back to the current state")
 }
 
-// A resolver reporting no change must leave the turn untouched — this is the
-// path every non-workflow and non-transitioning turn takes.
-func TestProviderStage_NoHandoffLeavesPromptUnchanged(t *testing.T) {
-	resolver := &fakeResolver{handoff: Handoff{Changed: false, SystemPrompt: "SHOULD NOT APPLY"}}
+// Reporting the state the turn is already running must not disturb it.
+func TestProviderStage_MatchingStateLeavesPromptUnchanged(t *testing.T) {
+	resolver := &fakeResolver{sequence: []Handoff{
+		{Valid: true, SystemPrompt: "ORIGIN PROMPT", AllowedTools: []string{"workflow__transition"}},
+	}}
 
-	stage, provider := newHandoffStage(t, resolver)
+	stage, provider, _ := newHandoffStage(t, resolver)
 	runHandoffTurn(t, stage)
 
 	require.Len(t, provider.seenPrompts, 2)
 	require.Equal(t, "ORIGIN PROMPT", provider.seenPrompts[0])
 	require.Equal(t, "ORIGIN PROMPT", provider.seenPrompts[1],
-		"Changed=false must not alter the system prompt")
+		"an unchanged state must not alter the system prompt")
+}
+
+// Stop ends the turn rather than running another round under a prompt the
+// runtime must not use — externally orchestrated states pause for an injected
+// event, composition states are run by CompositionStage.
+func TestProviderStage_StopEndsTurnWithoutFurtherRound(t *testing.T) {
+	resolver := &fakeResolver{sequence: []Handoff{
+		{Valid: true, SystemPrompt: "ORIGIN PROMPT", AllowedTools: []string{"workflow__transition"}},
+		{Stop: true},
+	}}
+
+	stage, provider, _ := newHandoffStage(t, resolver)
+	runHandoffTurn(t, stage)
+
+	require.Len(t, provider.seenPrompts, 1,
+		"no round may run after the resolver reports Stop")
 }
 
 // A nil resolver is the non-workflow case and must be inert.
 func TestProviderStage_NilResolverIsInert(t *testing.T) {
-	stage, provider := newHandoffStage(t, nil)
+	stage, provider, _ := newHandoffStage(t, nil)
 	runHandoffTurn(t, stage)
 
 	require.Len(t, provider.seenPrompts, 2)
@@ -190,7 +213,7 @@ func TestProviderStage_NilResolverIsInert(t *testing.T) {
 func TestProviderStage_HandoffErrorAbortsTurn(t *testing.T) {
 	resolver := &fakeResolver{err: context.DeadlineExceeded}
 
-	stage, provider := newHandoffStage(t, resolver)
+	stage, provider, _ := newHandoffStage(t, resolver)
 
 	input := make(chan StreamElement, 1)
 	userMsg := types.Message{Role: "user", Content: "hello"}
@@ -204,24 +227,8 @@ func TestProviderStage_HandoffErrorAbortsTurn(t *testing.T) {
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "workflow handoff")
-	require.Len(t, provider.seenPrompts, 1,
-		"no further round may run after a failed handoff")
-}
-
-// Each assistant message carries the state that produced it. A turn can span
-// states, so per-turn attribution is not sufficient.
-func TestProviderStage_StampsStatePerAssistantMessage(t *testing.T) {
-	resolver := &fakeResolver{
-		handoff: Handoff{Changed: true, SystemPrompt: "DESTINATION PROMPT"},
-		meta:    map[string]any{"current_state": "handoff"},
-	}
-	stage, _ := newHandoffStage(t, resolver)
-
-	response := types.Message{Role: "assistant", Content: "hi"}
-	stage.stampWorkflowState(&response)
-
-	require.Equal(t, map[string]any{"current_state": "handoff"},
-		response.Meta[workflowStateMetaKey])
+	require.Empty(t, provider.seenPrompts,
+		"the loop-start reconcile must fail before any provider round")
 }
 
 // streamingHandoffProvider drives the OTHER tool loop.
@@ -272,11 +279,7 @@ func (p *streamingHandoffProvider) PredictStreamWithTools(
 
 // The streaming loop must apply the handoff exactly as the unary loop does.
 func TestProviderStage_StreamingLoopSwapsSystemPromptMidTurn(t *testing.T) {
-	resolver := &fakeResolver{handoff: Handoff{
-		Changed:      true,
-		SystemPrompt: "DESTINATION PROMPT",
-		AllowedTools: []string{"workflow__transition"},
-	}}
+	resolver := &fakeResolver{sequence: originThenDestination()}
 
 	registry := tools.NewRegistry()
 	require.NoError(t, registry.Register(&tools.ToolDescriptor{
@@ -307,16 +310,32 @@ func TestProviderStage_StreamingLoopSwapsSystemPromptMidTurn(t *testing.T) {
 		"streaming round after the transition must run as the destination state")
 }
 
+// Each assistant message carries the state that produced it. A turn can span
+// states, so per-turn attribution is not sufficient.
+func TestProviderStage_StampsStatePerAssistantMessage(t *testing.T) {
+	resolver := &fakeResolver{
+		sequence: originThenDestination(),
+		meta:     map[string]any{"current_state": "handoff"},
+	}
+	stage, _, _ := newHandoffStage(t, resolver)
+
+	response := types.Message{Role: "assistant", Content: "hi"}
+	stage.stampWorkflowState(&response)
+
+	require.Equal(t, map[string]any{"current_state": "handoff"},
+		response.Meta[workflowStateMetaKey])
+}
+
 func TestProviderStage_StampIsNoOpWithoutResolverOrMeta(t *testing.T) {
 	t.Run("nil resolver", func(t *testing.T) {
-		stage, _ := newHandoffStage(t, nil)
+		stage, _, _ := newHandoffStage(t, nil)
 		response := types.Message{Role: "assistant", Content: "hi"}
 		stage.stampWorkflowState(&response)
 		require.Nil(t, response.Meta)
 	})
 
 	t.Run("empty meta", func(t *testing.T) {
-		stage, _ := newHandoffStage(t, &fakeResolver{})
+		stage, _, _ := newHandoffStage(t, &fakeResolver{})
 		response := types.Message{Role: "assistant", Content: "hi"}
 		stage.stampWorkflowState(&response)
 		require.Nil(t, response.Meta)

--- a/sdk/conversation.go
+++ b/sdk/conversation.go
@@ -113,6 +113,13 @@ type Conversation struct {
 	toolRegistry   *tools.Registry       // Registry for tools (pre-populated from pack)
 	serverExecutor *tools.ServerExecutor // Long-running server executor (may be nil)
 
+	// workflowResolver lets the provider tool loop apply workflow state
+	// changes mid-turn. The pipeline is built against this holder before the
+	// real resolver exists (it needs the TransitionExecutor, created after
+	// Open returns); WorkflowConversation populates it in
+	// registerWorkflowTools. Empty for plain conversations.
+	workflowResolver *workflowResolverHolder
+
 	// Configuration from options (includes provider)
 	config *config
 
@@ -540,6 +547,7 @@ func (c *Conversation) buildPipelineConfig(
 		Provider:              c.config.getAgentProvider(),
 		ToolRegistry:          toolRegistry,
 		PromptRegistry:        c.promptRegistry,
+		WorkflowStateResolver: c.workflowResolver,
 		TaskType:              c.promptName,
 		Variables:             vars,
 		VariableProviders:     appendSendScopedProvider(c.config.variableProviders), // dynamic + per-send resolution
@@ -1191,11 +1199,13 @@ func (c *Conversation) Fork() (*Conversation, error) {
 	// Create the forked conversation
 	forkPendingStore, forkOwnsPending := newPendingStore(c.config)
 	fork := &Conversation{
-		pack:             c.pack,
-		prompt:           c.prompt,
-		promptName:       c.promptName,
-		promptRegistry:   c.promptRegistry,
-		toolRegistry:     forkRegistry,
+		pack:           c.pack,
+		prompt:         c.prompt,
+		promptName:     c.promptName,
+		promptRegistry: c.promptRegistry,
+		toolRegistry:   forkRegistry,
+		// A fork gets its own holder: workflow state is not shared across forks.
+		workflowResolver: &workflowResolverHolder{},
 		config:           c.config,
 		mode:             c.mode,
 		handlers:         handlers,

--- a/sdk/examples/hitl/README.md
+++ b/sdk/examples/hitl/README.md
@@ -8,6 +8,49 @@ Approval workflows for sensitive operations with the PromptKit SDK.
 - Implementing approval check functions
 - Handling pending tool calls
 - Resolving or rejecting tools
+- Combining approval with a workflow, so the state the approval unlocks speaks
+  for itself (`hitl-workflow.pack.json`)
+
+## Two packs
+
+| Pack | Shows |
+|---|---|
+| `hitl.pack.json` | Approval on its own: one agent, one gated tool. |
+| `hitl-workflow.pack.json` | Approval inside a workflow — `triage` processes the refund, and once approved hands off to a `confirmation` state that confirms to the customer in the same turn. |
+
+### Approval inside a workflow
+
+The workflow pack is the more realistic shape: approving a refund is not the
+end of the interaction, it is the thing that unblocks the next stage.
+
+```
+turn 1   triage         → calls process_refund ($150)
+                        → over the limit, suspends for approval
+         [human approves]
+resume   triage         → calls workflow__transition(Approved)
+         confirmation   → "Your $150 refund for order 12345 is on its way…"
+```
+
+Two details worth noticing:
+
+- The confirmation state speaks **in the resumed turn**. There is no second
+  user message — the customer never has to say "and then?" to hear the outcome.
+- What the triage agent wrote in the transition's `context` argument arrives in
+  the confirmation prompt as `{{workflow_context}}`. That is how one stage
+  briefs the next.
+
+Resuming after approval is `ResolveTool` followed by `Continue`, reaching
+through `wc.ActiveConversation()`:
+
+```go
+pending := resp.PendingTools()
+conv := wc.ActiveConversation()
+conv.ResolveTool(ctx, pending[0].ID)
+resumed, _ := conv.Continue(ctx)   // confirmation state's reply
+```
+
+`workflow_hitl_test.go` runs this end to end against a scripted provider, so it
+doubles as the integration test for the interaction.
 
 ## Prerequisites
 

--- a/sdk/examples/hitl/hitl-workflow.pack.json
+++ b/sdk/examples/hitl/hitl-workflow.pack.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "id": "hitl-workflow-example",
+  "name": "HITL Workflow Example",
+  "version": "1.0.0",
+  "description": "Human-in-the-Loop approval inside a workflow: the approved refund transitions to a confirmation state, which speaks for itself",
+  "template_engine": {
+    "version": "v1",
+    "syntax": "{{variable}}"
+  },
+  "prompts": {
+    "triage": {
+      "id": "triage",
+      "name": "Refund Triage",
+      "version": "1.0.0",
+      "system_template": "You are a refund triage agent. Use process_refund to process a refund request. Once a refund has been processed, call workflow__transition with the Approved event and a short summary of what was refunded.",
+      "tools": ["process_refund"]
+    },
+    "confirmation": {
+      "id": "confirmation",
+      "name": "Refund Confirmation",
+      "version": "1.0.0",
+      "system_template": "You are the refund confirmation agent. A refund has just been approved and processed. Confirm it warmly to the customer and tell them when to expect the money.\n\nWhat the triage agent handed over: {{workflow_context}}"
+    }
+  },
+  "tools": {
+    "process_refund": {
+      "name": "process_refund",
+      "description": "Process a refund for a customer order",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "order_id": {
+            "type": "string",
+            "description": "The order ID to refund"
+          },
+          "amount": {
+            "type": "number",
+            "description": "The refund amount in dollars"
+          },
+          "reason": {
+            "type": "string",
+            "description": "The reason for the refund"
+          }
+        },
+        "required": ["order_id", "amount", "reason"]
+      }
+    }
+  },
+  "workflow": {
+    "version": 1,
+    "entry": "triage",
+    "states": {
+      "triage": {
+        "prompt_task": "triage",
+        "description": "Take the refund request and process it, subject to approval",
+        "on_event": {
+          "Approved": "confirmation"
+        }
+      },
+      "confirmation": {
+        "prompt_task": "confirmation",
+        "description": "Confirm the completed refund to the customer",
+        "terminal": true
+      }
+    }
+  }
+}

--- a/sdk/examples/hitl/workflow_hitl_test.go
+++ b/sdk/examples/hitl/workflow_hitl_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/sdk"
+	sdktools "github.com/AltairaLabs/PromptKit/sdk/tools"
+)
+
+// scriptedProvider records the system prompt of every round and replies from a
+// fixed script, so the test asserts on which workflow state generated each
+// round rather than on model behaviour.
+type scriptedProvider struct {
+	*mock.ToolProvider
+	seenPrompts []string
+}
+
+func (p *scriptedProvider) SupportsStreaming() bool { return false }
+
+func (p *scriptedProvider) Predict(
+	_ context.Context, req providers.PredictionRequest,
+) (providers.PredictionResponse, error) {
+	p.seenPrompts = append(p.seenPrompts, req.System)
+	return providers.PredictionResponse{Content: "no tools"}, nil
+}
+
+func (p *scriptedProvider) PredictWithTools(
+	_ context.Context,
+	req providers.PredictionRequest,
+	_ providers.ProviderTools,
+	_ string,
+) (providers.PredictionResponse, []types.MessageToolCall, error) {
+	p.seenPrompts = append(p.seenPrompts, req.System)
+
+	switch len(p.seenPrompts) {
+	case 1:
+		// Ask for a refund large enough to need a human.
+		calls := []types.MessageToolCall{{
+			ID:   "call-refund",
+			Name: "process_refund",
+			Args: []byte(`{"order_id":"12345","amount":150,"reason":"damaged product"}`),
+		}}
+		return providers.PredictionResponse{ToolCalls: calls}, calls, nil
+	case 2:
+		// Resumed after approval: hand off to the confirmation state.
+		calls := []types.MessageToolCall{{
+			ID:   "call-transition",
+			Name: "workflow__transition",
+			Args: []byte(`{"event":"Approved","context":"Refunded $150 on order 12345 for a damaged product."}`),
+		}}
+		return providers.PredictionResponse{ToolCalls: calls}, calls, nil
+	default:
+		return providers.PredictionResponse{
+			Content: "Your $150 refund for order 12345 is on its way — allow 3-5 business days.",
+		}, nil, nil
+	}
+}
+
+// The end-to-end interaction the example demonstrates, and the regression test
+// for the two bugs it exposed:
+//
+//   - A turn suspended for human approval resumes by re-executing the SAME
+//     pipeline, which re-runs PromptAssemblyStage and resets the system prompt.
+//     The resumed turn must still be running the workflow's current state.
+//   - When the resumed turn transitions, the destination state must generate
+//     the reply in that same turn rather than leaving the conversation silent.
+func TestHITLWorkflow_ConfirmationStateSpeaksAfterApproval(t *testing.T) {
+	provider := &scriptedProvider{
+		ToolProvider: mock.NewToolProvider("mock", "mock-model", false, nil),
+	}
+
+	wc, err := sdk.OpenWorkflow("./hitl-workflow.pack.json",
+		sdk.WithProvider(provider),
+		sdk.WithSkipSchemaValidation(),
+	)
+	require.NoError(t, err)
+	defer func() { _ = wc.Close() }()
+
+	conv := wc.ActiveConversation()
+	conv.OnToolAsync(
+		"process_refund",
+		func(args map[string]any) sdktools.PendingResult {
+			if amount, _ := args["amount"].(float64); amount > 100 {
+				return sdktools.PendingResult{
+					Reason:  "high_value_refund",
+					Message: "Refund over $100 requires human approval",
+				}
+			}
+			return sdktools.PendingResult{}
+		},
+		func(args map[string]any) (any, error) {
+			return map[string]any{
+				"status":    "completed",
+				"refund_id": "RF-12345",
+				"amount":    args["amount"],
+			}, nil
+		},
+	)
+
+	ctx := context.Background()
+	require.Equal(t, "triage", wc.CurrentState())
+
+	// Turn 1 suspends on the approval.
+	resp, err := wc.Send(ctx, "I need a refund of $150 for order #12345, the product was damaged")
+	require.NoError(t, err)
+
+	pending := resp.PendingTools()
+	require.Len(t, pending, 1, "the high-value refund must await approval")
+	require.Equal(t, "process_refund", pending[0].Name)
+	require.Equal(t, "triage", wc.CurrentState(), "state must not move while awaiting approval")
+
+	// The human approves, and the conversation resumes.
+	_, err = conv.ResolveTool(ctx, pending[0].ID)
+	require.NoError(t, err)
+
+	resumed, err := conv.Continue(ctx)
+	require.NoError(t, err)
+
+	// The workflow advanced and the CONFIRMATION state produced the reply,
+	// inside the resumed turn, with no further user message.
+	require.Equal(t, "confirmation", wc.CurrentState())
+	require.Contains(t, resumed.Text(), "refund",
+		"the confirmation state must have generated the reply")
+
+	require.Len(t, provider.seenPrompts, 3)
+	require.Contains(t, provider.seenPrompts[0], "refund triage agent",
+		"round 1 runs as triage")
+	require.Contains(t, provider.seenPrompts[1], "refund triage agent",
+		"the resumed round must still be triage, not whatever the pipeline was rebuilt with")
+	require.Contains(t, provider.seenPrompts[2], "refund confirmation agent",
+		"the round after the transition must run as the confirmation state")
+
+	// The brief the triage agent wrote is what the confirmation state was
+	// given -- {{workflow_context}} in its template.
+	require.Contains(t, provider.seenPrompts[2], "Refunded $150 on order 12345",
+		"the transition's context argument must reach the destination prompt")
+}

--- a/sdk/internal/pipeline/builder.go
+++ b/sdk/internal/pipeline/builder.go
@@ -48,6 +48,12 @@ type Config struct {
 	// ToolPolicy for tool usage constraints (optional)
 	ToolPolicy *rtpipeline.ToolPolicy
 
+	// WorkflowStateResolver applies workflow state changes between tool-loop
+	// rounds, so a transition's destination state generates the next round
+	// rather than the turn ending with the origin state in control. Optional;
+	// nil for non-workflow conversations.
+	WorkflowStateResolver stage.WorkflowStateResolver
+
 	// TokenBudget for context management (0 = no limit)
 	TokenBudget int
 
@@ -547,7 +553,7 @@ func buildProviderStages(cfg *Config, turnState *stage.TurnState) ([]stage.Stage
 		if cfg.CompactionEnabled == nil || *cfg.CompactionEnabled {
 			providerConfig.Compactor = buildCompactionStrategy(cfg)
 		}
-		return []stage.Stage{stage.NewProviderStageWithTurnState(
+		providerStage := stage.NewProviderStageWithTurnState(
 			cfg.Provider,
 			cfg.ToolRegistry,
 			cfg.ToolPolicy,
@@ -555,7 +561,11 @@ func buildProviderStages(cfg *Config, turnState *stage.TurnState) ([]stage.Stage
 			cfg.EventEmitter,
 			cfg.HookRegistry,
 			turnState,
-		)}, nil
+		)
+		if cfg.WorkflowStateResolver != nil {
+			providerStage.SetWorkflowStateResolver(cfg.WorkflowStateResolver)
+		}
+		return []stage.Stage{providerStage}, nil
 	}
 	return nil, nil
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -256,6 +256,7 @@ func initConversation(
 		promptName:       promptName,
 		promptRegistry:   pack.ToPromptRegistry(p), // Create registry for PromptAssemblyMiddleware
 		toolRegistry:     toolReg,
+		workflowResolver: &workflowResolverHolder{},
 		config:           cfg,
 		handlers:         make(map[string]ToolHandler),
 		ctxHandlers:      make(map[string]ToolHandlerCtx),

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -568,6 +568,16 @@ func (wc *WorkflowConversation) registerWorkflowTools() {
 	wc.artifactExec = workflow.NewArtifactExecutor(wc.machine)
 	registry.RegisterExecutor(wc.artifactExec)
 	workflow.RegisterArtifactTool(registry, wc.workflowSpec)
+
+	// Hand the provider tool loop a resolver so a transition applies mid-turn
+	// and the destination state generates the next round. The pipeline was
+	// built against the conversation's holder before transExec existed, so
+	// populating it here is what activates the handoff.
+	if wc.activeConv.workflowResolver != nil {
+		wc.activeConv.workflowResolver.set(newWorkflowStateResolver(
+			wc.machine, wc.workflowSpec, wc.transExec, wc.activeConv.promptRegistry,
+		))
+	}
 }
 
 // onTransitionCommitted runs the post-commit work after a deferred

--- a/sdk/workflow_handoff_test.go
+++ b/sdk/workflow_handoff_test.go
@@ -1,0 +1,103 @@
+package sdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// handoffSDKProvider records the system prompt per round and transitions on the
+// first round, so a single Send spans two workflow states.
+type handoffSDKProvider struct {
+	*mock.ToolProvider
+	seenPrompts []string
+}
+
+// Pin to the unary tool loop for determinism.
+func (p *handoffSDKProvider) SupportsStreaming() bool { return false }
+
+func (p *handoffSDKProvider) Predict(
+	_ context.Context, req providers.PredictionRequest,
+) (providers.PredictionResponse, error) {
+	p.seenPrompts = append(p.seenPrompts, req.System)
+	return providers.PredictionResponse{Content: "no tools available"}, nil
+}
+
+func (p *handoffSDKProvider) PredictWithTools(
+	_ context.Context,
+	req providers.PredictionRequest,
+	_ providers.ProviderTools,
+	_ string,
+) (providers.PredictionResponse, []types.MessageToolCall, error) {
+	p.seenPrompts = append(p.seenPrompts, req.System)
+
+	if len(p.seenPrompts) == 1 {
+		calls := []types.MessageToolCall{{
+			ID:   "call-1",
+			Name: "workflow__transition",
+			Args: []byte(`{"event":"InfoComplete","context":"name and account collected"}`),
+		}}
+		return providers.PredictionResponse{ToolCalls: calls}, calls, nil
+	}
+	return providers.PredictionResponse{Content: "destination speaking"}, nil, nil
+}
+
+// The end-to-end guarantee. One Send: the LLM transitions intake -> processing,
+// and the PROCESSING state produces the reply, in the same turn, with no second
+// user message. Before this, Send returned the intake state's text and the
+// processing state stayed silent until the user typed again.
+func TestWorkflowConversation_DestinationStateSpeaksInSameSend(t *testing.T) {
+	packPath := writeWorkflowTestPack(t, workflowPackJSON)
+	provider := &handoffSDKProvider{
+		ToolProvider: mock.NewToolProvider("mock", "mock-model", false, nil),
+	}
+
+	wc, err := OpenWorkflow(packPath, WithProvider(provider), WithSkipSchemaValidation())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, wc.Close()) }()
+
+	require.Equal(t, "intake", wc.CurrentState())
+
+	resp, err := wc.Send(context.Background(), "I need help with my account")
+	require.NoError(t, err)
+
+	require.Equal(t, "processing", wc.CurrentState(),
+		"the transition must have been committed")
+
+	require.Len(t, provider.seenPrompts, 2,
+		"the transition tool call must produce a second round")
+	require.Equal(t, "You gather information.", provider.seenPrompts[0],
+		"round 1 runs as the origin state")
+	require.Equal(t, "You process requests.", provider.seenPrompts[1],
+		"round 2 must run as the DESTINATION state -- this is the fix")
+
+	require.Contains(t, resp.Text(), "destination speaking",
+		"Send must return the destination state's reply, not the origin's")
+}
+
+// A turn with no transition must behave exactly as before: one round, one
+// state, origin prompt throughout.
+func TestWorkflowConversation_NoTransitionIsUnchanged(t *testing.T) {
+	packPath := writeWorkflowTestPack(t, workflowPackJSON)
+	provider := &handoffSDKProvider{
+		ToolProvider: mock.NewToolProvider("mock", "mock-model", false, nil),
+	}
+	// Consume the scripted transition so the first real round answers plainly.
+	provider.seenPrompts = append(provider.seenPrompts, "PRIMED")
+
+	wc, err := OpenWorkflow(packPath, WithProvider(provider), WithSkipSchemaValidation())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, wc.Close()) }()
+
+	_, err = wc.Send(context.Background(), "hello")
+	require.NoError(t, err)
+
+	require.Equal(t, "intake", wc.CurrentState(), "state must not move")
+	require.Len(t, provider.seenPrompts, 2, "primed entry plus one real round")
+	require.Equal(t, "You gather information.", provider.seenPrompts[1])
+}

--- a/sdk/workflow_state_resolver.go
+++ b/sdk/workflow_state_resolver.go
@@ -48,13 +48,13 @@ func (h *workflowResolverHolder) get() stage.WorkflowStateResolver {
 	return h.inner
 }
 
-// ResolvePendingHandoff implements stage.WorkflowStateResolver.
-func (h *workflowResolverHolder) ResolvePendingHandoff(ctx context.Context) (stage.Handoff, error) {
+// ResolveCurrentState implements stage.WorkflowStateResolver.
+func (h *workflowResolverHolder) ResolveCurrentState(ctx context.Context) (stage.Handoff, error) {
 	inner := h.get()
 	if inner == nil {
 		return stage.Handoff{}, nil
 	}
-	return inner.ResolvePendingHandoff(ctx)
+	return inner.ResolveCurrentState(ctx)
 }
 
 // CurrentStateMeta implements stage.WorkflowStateResolver.
@@ -79,6 +79,12 @@ type workflowStateResolver struct {
 	transExec *workflow.TransitionExecutor
 	registry  *prompt.Registry
 	renderer  *template.Renderer
+
+	// contextSummary is the brief the outgoing state wrote for the incoming
+	// one (the transition tool's `context` argument). Retained across calls
+	// because ResolveCurrentState re-renders on every execution, including
+	// resumes long after the transition committed and cleared the record.
+	contextSummary string
 }
 
 func newWorkflowStateResolver(
@@ -96,51 +102,68 @@ func newWorkflowStateResolver(
 	}
 }
 
-// ResolvePendingHandoff implements stage.WorkflowStateResolver.
-func (r *workflowStateResolver) ResolvePendingHandoff(_ context.Context) (stage.Handoff, error) {
-	if r.transExec == nil {
-		return stage.Handoff{}, nil
-	}
-	pending := r.transExec.Pending()
-	if pending == nil {
-		return stage.Handoff{}, nil
-	}
-	// Capture before committing — CommitPending clears the pending record, and
-	// the LLM's `context` argument is the brief for the destination state.
-	contextSummary := pending.ContextSummary
-
-	result, err := r.transExec.CommitPending()
-	if err != nil {
-		return stage.Handoff{}, err
-	}
-	if result == nil {
-		return stage.Handoff{}, nil
-	}
-
-	dest := r.spec.States[result.To]
-	if dest == nil {
-		return stage.Handoff{}, fmt.Errorf("destination state %q not found in spec", result.To)
+// ResolveCurrentState implements stage.WorkflowStateResolver.
+//
+// It reports what the turn *should* be running rather than whether something
+// just changed, so a re-executed pipeline (HITL resume, deferred client tool)
+// — which re-runs PromptAssemblyStage and resets the prompt to the pipeline's
+// build-time state — is corrected on the next call. Safe to call repeatedly.
+func (r *workflowStateResolver) ResolveCurrentState(_ context.Context) (stage.Handoff, error) {
+	// Commit any transition the tool left pending. Capture the brief first:
+	// CommitPending clears the record, and the LLM's `context` argument is
+	// what the outgoing state wrote for the incoming one.
+	justTransitioned := false
+	if r.transExec != nil {
+		if pending := r.transExec.Pending(); pending != nil {
+			r.contextSummary = pending.ContextSummary
+			if _, err := r.transExec.CommitPending(); err != nil {
+				return stage.Handoff{}, err
+			}
+			justTransitioned = true
+		}
 	}
 
-	// States the turn must not continue into. The transition is committed
-	// either way — only the in-turn continuation is suppressed.
+	if r.machine == nil {
+		return stage.Handoff{}, nil
+	}
+	name := r.machine.CurrentState()
+	current := r.spec.States[name]
+	if current == nil {
+		return stage.Handoff{}, fmt.Errorf("current state %q not found in spec", name)
+	}
+
+	// States the turn must not auto-advance INTO. This applies only when we
+	// arrived here by committing a transition during this turn — an
+	// externally orchestrated state still handles ordinary user turns
+	// normally. RFC 0009 says the runtime pauses there for an injected event,
+	// which constrains where transitions come from, not whether the state may
+	// converse. Treating it as "never run" ends a plain Send with no rounds
+	// and an empty response.
 	//
-	//   external    — RFC 0009: the runtime pauses for an injected event.
+	//   external    — RFC 0009: wait for the injected event, don't run on.
 	//   composition — CompositionStage runs the state itself.
-	//   no prompt   — nothing to render.
-	switch {
-	case dest.Orchestration == workflow.OrchestrationExternal,
-		dest.Orchestration == workflow.OrchestrationComposition,
-		dest.PromptTask == "":
+	if justTransitioned {
+		switch current.Orchestration {
+		case workflow.OrchestrationExternal, workflow.OrchestrationComposition:
+			return stage.Handoff{Stop: true}, nil
+		case workflow.OrchestrationInternal, workflow.OrchestrationHybrid:
+			// Both are runtime-driven: continue the turn as this state.
+			// (The zero value "" also lands here — it means internal.)
+		}
+	}
+
+	// Nothing to render: leave the turn on whatever prompt it already has
+	// rather than blanking it.
+	if current.PromptTask == "" {
 		return stage.Handoff{}, nil
 	}
 
-	systemPrompt, allowedTools, err := r.renderState(dest, contextSummary)
+	systemPrompt, allowedTools, err := r.renderState(current, r.contextSummary)
 	if err != nil {
 		return stage.Handoff{}, err
 	}
 	return stage.Handoff{
-		Changed:      true,
+		Valid:        true,
 		SystemPrompt: systemPrompt,
 		AllowedTools: allowedTools,
 	}, nil

--- a/sdk/workflow_state_resolver.go
+++ b/sdk/workflow_state_resolver.go
@@ -1,0 +1,205 @@
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"sync"
+
+	"github.com/AltairaLabs/PromptKit/runtime/pipeline/stage"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/runtime/template"
+	"github.com/AltairaLabs/PromptKit/runtime/workflow"
+)
+
+// workflowResolverHolder is a stable stage.WorkflowStateResolver that the
+// pipeline can be built against before the real resolver exists.
+//
+// Open() builds the pipeline — and therefore the ProviderStage — before
+// WorkflowConversation has created the TransitionExecutor the resolver needs.
+// Every Conversation is built against a holder; a workflow populates it in
+// registerWorkflowTools, and a plain conversation leaves it empty, in which
+// case it reports no handoff and no state metadata.
+type workflowResolverHolder struct {
+	mu    sync.RWMutex
+	inner stage.WorkflowStateResolver
+}
+
+func (h *workflowResolverHolder) set(inner stage.WorkflowStateResolver) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.inner = inner
+}
+
+// get is nil-receiver safe. A nil *workflowResolverHolder is NOT nil once
+// boxed into the stage.WorkflowStateResolver interface, so the pipeline
+// builder installs it and the tool loop calls straight through — any
+// Conversation built without a holder (tests, and any construction path that
+// predates this field) would otherwise panic on the first round.
+func (h *workflowResolverHolder) get() stage.WorkflowStateResolver {
+	if h == nil {
+		return nil
+	}
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.inner
+}
+
+// ResolvePendingHandoff implements stage.WorkflowStateResolver.
+func (h *workflowResolverHolder) ResolvePendingHandoff(ctx context.Context) (stage.Handoff, error) {
+	inner := h.get()
+	if inner == nil {
+		return stage.Handoff{}, nil
+	}
+	return inner.ResolvePendingHandoff(ctx)
+}
+
+// CurrentStateMeta implements stage.WorkflowStateResolver.
+func (h *workflowResolverHolder) CurrentStateMeta() map[string]any {
+	inner := h.get()
+	if inner == nil {
+		return nil
+	}
+	return inner.CurrentStateMeta()
+}
+
+// workflowStateResolver implements stage.WorkflowStateResolver for the SDK.
+//
+// It commits the transition the workflow tool left pending and renders the
+// destination state's system prompt, so the provider tool loop's next round
+// runs as that state. Without it a transition advances the state machine and
+// the destination state never speaks — see
+// docs/local-backlog/WORKFLOW_IN_TURN_STATE_HANDOFF_DESIGN.md.
+type workflowStateResolver struct {
+	machine   *workflow.StateMachine
+	spec      *workflow.Spec
+	transExec *workflow.TransitionExecutor
+	registry  *prompt.Registry
+	renderer  *template.Renderer
+}
+
+func newWorkflowStateResolver(
+	machine *workflow.StateMachine,
+	spec *workflow.Spec,
+	transExec *workflow.TransitionExecutor,
+	registry *prompt.Registry,
+) *workflowStateResolver {
+	return &workflowStateResolver{
+		machine:   machine,
+		spec:      spec,
+		transExec: transExec,
+		registry:  registry,
+		renderer:  template.NewRenderer(),
+	}
+}
+
+// ResolvePendingHandoff implements stage.WorkflowStateResolver.
+func (r *workflowStateResolver) ResolvePendingHandoff(_ context.Context) (stage.Handoff, error) {
+	if r.transExec == nil {
+		return stage.Handoff{}, nil
+	}
+	pending := r.transExec.Pending()
+	if pending == nil {
+		return stage.Handoff{}, nil
+	}
+	// Capture before committing — CommitPending clears the pending record, and
+	// the LLM's `context` argument is the brief for the destination state.
+	contextSummary := pending.ContextSummary
+
+	result, err := r.transExec.CommitPending()
+	if err != nil {
+		return stage.Handoff{}, err
+	}
+	if result == nil {
+		return stage.Handoff{}, nil
+	}
+
+	dest := r.spec.States[result.To]
+	if dest == nil {
+		return stage.Handoff{}, fmt.Errorf("destination state %q not found in spec", result.To)
+	}
+
+	// States the turn must not continue into. The transition is committed
+	// either way — only the in-turn continuation is suppressed.
+	//
+	//   external    — RFC 0009: the runtime pauses for an injected event.
+	//   composition — CompositionStage runs the state itself.
+	//   no prompt   — nothing to render.
+	switch {
+	case dest.Orchestration == workflow.OrchestrationExternal,
+		dest.Orchestration == workflow.OrchestrationComposition,
+		dest.PromptTask == "":
+		return stage.Handoff{}, nil
+	}
+
+	systemPrompt, allowedTools, err := r.renderState(dest, contextSummary)
+	if err != nil {
+		return stage.Handoff{}, err
+	}
+	return stage.Handoff{
+		Changed:      true,
+		SystemPrompt: systemPrompt,
+		AllowedTools: allowedTools,
+	}, nil
+}
+
+// renderState loads and renders the destination state's prompt with the
+// carry-forward context and current artifact values bound, mirroring what
+// openConvForCurrentState injects when it opens a conversation for a state.
+func (r *workflowStateResolver) renderState(
+	dest *workflow.State, contextSummary string,
+) (systemPrompt string, allowedTools []string, err error) {
+	if r.registry == nil {
+		return "", nil, fmt.Errorf("no prompt registry configured")
+	}
+
+	vars := map[string]string{}
+	for name, value := range r.machine.Artifacts() {
+		vars["artifacts."+name] = value
+	}
+	if contextSummary != "" {
+		vars[workflowContextVar] = contextSummary
+	}
+
+	tmpl, err := r.registry.LoadTemplate(dest.PromptTask, vars, "")
+	if err != nil {
+		return "", nil, fmt.Errorf("load prompt %q for state: %w", dest.PromptTask, err)
+	}
+
+	// Same precedence as TemplateStage: template defaults, then fragments,
+	// then the values we bind for this handoff.
+	merged := make(map[string]string, len(tmpl.DefaultVars)+len(tmpl.FragmentVars)+len(vars))
+	maps.Copy(merged, tmpl.DefaultVars)
+	maps.Copy(merged, tmpl.FragmentVars)
+	maps.Copy(merged, vars)
+
+	rendered, err := r.renderer.RenderDetailed(tmpl.RawTemplate, merged)
+	if err != nil {
+		// Match TemplateStage's degrade-to-raw behavior rather than failing the
+		// turn: a template that renders badly should still hand off.
+		return tmpl.RawTemplate, tmpl.AllowedTools, nil //nolint:nilerr // deliberate degrade
+	}
+	return rendered.Text, tmpl.AllowedTools, nil
+}
+
+// CurrentStateMeta implements stage.WorkflowStateResolver. The returned map is
+// stamped onto each assistant message so output can be attributed to the state
+// that produced it, which per-turn attribution cannot do once a turn spans
+// states.
+func (r *workflowStateResolver) CurrentStateMeta() map[string]any {
+	if r.machine == nil {
+		return nil
+	}
+	name := r.machine.CurrentState()
+	meta := map[string]any{"current_state": name}
+	if state := r.spec.States[name]; state != nil {
+		if state.Description != "" {
+			meta["description"] = state.Description
+		}
+		meta["terminal"] = state.Terminal || len(state.OnEvent) == 0
+	}
+	return meta
+}

--- a/sdk/workflow_state_resolver_test.go
+++ b/sdk/workflow_state_resolver_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/AltairaLabs/PromptKit/runtime/persistence/memory"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 	"github.com/AltairaLabs/PromptKit/runtime/workflow"
 )
 
@@ -43,27 +45,67 @@ func newPendingResolver(t *testing.T, spec *workflow.Spec) *workflowStateResolve
 	return newWorkflowStateResolver(machine, spec, transExec, nil)
 }
 
-func TestWorkflowStateResolver_NoPendingTransition(t *testing.T) {
+// testRegistry builds a prompt registry with one template per named task.
+func testRegistry(t *testing.T, templates map[string]string) *prompt.Registry {
+	t.Helper()
+
+	repo := memory.NewPromptRepository()
+	for taskType, tmpl := range templates {
+		repo.RegisterPrompt(taskType, &prompt.Config{
+			APIVersion: "promptkit.altairalabs.ai/v1alpha1",
+			Kind:       "Prompt",
+			Spec: prompt.Spec{
+				TaskType:       taskType,
+				Version:        "1.0.0",
+				SystemTemplate: tmpl,
+			},
+		})
+	}
+	return prompt.NewRegistryWithRepository(repo)
+}
+
+// With nothing pending, the resolver reports the state the workflow is already
+// in. It is not a change notification -- a re-executed pipeline depends on
+// getting the current state back every time.
+func TestWorkflowStateResolver_ReportsCurrentStateWithNothingPending(t *testing.T) {
 	spec := resolverSpec(&workflow.State{PromptTask: "dest"})
 	machine := workflow.NewStateMachine(spec)
 	transExec := workflow.NewTransitionExecutor(machine, spec)
-	resolver := newWorkflowStateResolver(machine, spec, transExec, nil)
+	registry := testRegistry(t, map[string]string{"origin": "ORIGIN PROMPT"})
+	resolver := newWorkflowStateResolver(machine, spec, transExec, registry)
 
-	handoff, err := resolver.ResolvePendingHandoff(context.Background())
-
-	require.NoError(t, err)
-	require.False(t, handoff.Changed, "no pending transition must not change the turn")
-	require.Equal(t, "origin", machine.CurrentState())
+	// Repeated calls must be idempotent: the loop calls this every round.
+	for i := range 3 {
+		handoff, err := resolver.ResolveCurrentState(context.Background())
+		require.NoError(t, err, "call %d", i)
+		require.True(t, handoff.Valid)
+		require.Equal(t, "ORIGIN PROMPT", handoff.SystemPrompt)
+	}
+	require.Equal(t, "origin", machine.CurrentState(), "state must not move")
 }
 
-func TestWorkflowStateResolver_NilExecutorIsInert(t *testing.T) {
+// After the transition tool has run, the resolver reports the destination --
+// and keeps reporting it, which is what lets a resumed execution recover.
+func TestWorkflowStateResolver_ReportsDestinationAfterCommit(t *testing.T) {
 	spec := resolverSpec(&workflow.State{PromptTask: "dest"})
-	resolver := newWorkflowStateResolver(workflow.NewStateMachine(spec), spec, nil, nil)
+	registry := testRegistry(t, map[string]string{
+		"origin": "ORIGIN PROMPT",
+		"dest":   "DESTINATION PROMPT",
+	})
+	resolver := newPendingResolver(t, spec)
+	resolver.registry = registry
 
-	handoff, err := resolver.ResolvePendingHandoff(context.Background())
-
+	handoff, err := resolver.ResolveCurrentState(context.Background())
 	require.NoError(t, err)
-	require.False(t, handoff.Changed)
+	require.True(t, handoff.Valid)
+	require.Equal(t, "DESTINATION PROMPT", handoff.SystemPrompt)
+	require.Equal(t, "dest", resolver.machine.CurrentState())
+
+	// Nothing pending now, but the answer must not revert.
+	handoff, err = resolver.ResolveCurrentState(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "DESTINATION PROMPT", handoff.SystemPrompt,
+		"a later call must still report the destination -- this is what recovers a resumed turn")
 }
 
 // The states the turn must not continue into. In every case the transition is
@@ -85,11 +127,7 @@ func TestWorkflowStateResolver_CommitsButDoesNotContinue(t *testing.T) {
 			dest: &workflow.State{PromptTask: "dest", Orchestration: workflow.OrchestrationComposition},
 			why:  "CompositionStage runs the state itself",
 		},
-		{
-			name: "no prompt_task",
-			dest: &workflow.State{},
-			why:  "nothing to render",
-		},
+
 	}
 
 	for _, tc := range cases {
@@ -97,10 +135,11 @@ func TestWorkflowStateResolver_CommitsButDoesNotContinue(t *testing.T) {
 			spec := resolverSpec(tc.dest)
 			resolver := newPendingResolver(t, spec)
 
-			handoff, err := resolver.ResolvePendingHandoff(context.Background())
+			handoff, err := resolver.ResolveCurrentState(context.Background())
 
 			require.NoError(t, err)
-			require.False(t, handoff.Changed, tc.why)
+			require.True(t, handoff.Stop, tc.why)
+			require.False(t, handoff.Valid)
 			require.Equal(t, "dest", resolver.machine.CurrentState(),
 				"the transition must still be committed")
 			require.Nil(t, resolver.transExec.Pending(),
@@ -121,7 +160,7 @@ func TestWorkflowStateResolver_UnknownDestinationErrors(t *testing.T) {
 	}
 	resolver := newPendingResolver(t, spec)
 
-	_, err := resolver.ResolvePendingHandoff(context.Background())
+	_, err := resolver.ResolveCurrentState(context.Background())
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "ghost")
@@ -133,7 +172,7 @@ func TestWorkflowStateResolver_NoRegistryErrors(t *testing.T) {
 	spec := resolverSpec(&workflow.State{PromptTask: "dest"})
 	resolver := newPendingResolver(t, spec)
 
-	_, err := resolver.ResolvePendingHandoff(context.Background())
+	_, err := resolver.ResolveCurrentState(context.Background())
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "prompt registry")
@@ -172,9 +211,9 @@ func TestWorkflowResolverHolder_NilReceiverIsSafe(t *testing.T) {
 	var holder *workflowResolverHolder
 
 	require.NotPanics(t, func() {
-		handoff, err := holder.ResolvePendingHandoff(context.Background())
+		handoff, err := holder.ResolveCurrentState(context.Background())
 		require.NoError(t, err)
-		require.False(t, handoff.Changed)
+		require.False(t, handoff.Valid)
 		require.Nil(t, holder.CurrentStateMeta())
 		holder.set(nil)
 	})
@@ -184,9 +223,9 @@ func TestWorkflowResolverHolder_NilReceiverIsSafe(t *testing.T) {
 func TestWorkflowResolverHolder_EmptyThenPopulated(t *testing.T) {
 	holder := &workflowResolverHolder{}
 
-	handoff, err := holder.ResolvePendingHandoff(context.Background())
+	handoff, err := holder.ResolveCurrentState(context.Background())
 	require.NoError(t, err)
-	require.False(t, handoff.Changed, "empty holder must report no handoff")
+	require.False(t, handoff.Valid, "empty holder must report no state")
 	require.Nil(t, holder.CurrentStateMeta())
 
 	spec := resolverSpec(&workflow.State{PromptTask: "dest"})
@@ -195,4 +234,37 @@ func TestWorkflowResolverHolder_EmptyThenPopulated(t *testing.T) {
 
 	require.Equal(t, "origin", holder.CurrentStateMeta()["current_state"],
 		"once populated the holder must delegate")
+}
+
+// A state with no prompt_task has nothing to render. The turn keeps whatever
+// prompt it already has rather than being blanked or stopped.
+func TestWorkflowStateResolver_NoPromptTaskLeavesTurnAlone(t *testing.T) {
+	spec := resolverSpec(&workflow.State{})
+	resolver := newPendingResolver(t, spec)
+
+	handoff, err := resolver.ResolveCurrentState(context.Background())
+
+	require.NoError(t, err)
+	require.False(t, handoff.Valid)
+	require.False(t, handoff.Stop)
+	require.Equal(t, "dest", resolver.machine.CurrentState(),
+		"the transition must still be committed")
+}
+
+// An externally orchestrated state still handles ordinary user turns. Only
+// auto-advancing INTO it mid-turn is suppressed -- treating it as never-run
+// ends a plain Send with no rounds and an empty response.
+func TestWorkflowStateResolver_ExternalStateStillServesItsOwnTurns(t *testing.T) {
+	spec := resolverSpec(&workflow.State{PromptTask: "dest"})
+	spec.States["origin"].Orchestration = workflow.OrchestrationExternal
+	machine := workflow.NewStateMachine(spec)
+	registry := testRegistry(t, map[string]string{"origin": "ORIGIN PROMPT"})
+	resolver := newWorkflowStateResolver(machine, spec, nil, registry)
+
+	handoff, err := resolver.ResolveCurrentState(context.Background())
+
+	require.NoError(t, err)
+	require.False(t, handoff.Stop, "no transition committed: the state serves this turn")
+	require.True(t, handoff.Valid)
+	require.Equal(t, "ORIGIN PROMPT", handoff.SystemPrompt)
 }

--- a/sdk/workflow_state_resolver_test.go
+++ b/sdk/workflow_state_resolver_test.go
@@ -1,0 +1,198 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/workflow"
+)
+
+// resolverSpec builds a two-state workflow whose destination is configured by
+// the caller, so each test can vary only the thing under test.
+func resolverSpec(dest *workflow.State) *workflow.Spec {
+	return &workflow.Spec{
+		Version: 2,
+		Entry:   "origin",
+		States: map[string]*workflow.State{
+			"origin": {
+				PromptTask: "origin",
+				OnEvent:    map[string]string{"Go": "dest"},
+			},
+			"dest": dest,
+		},
+	}
+}
+
+// newPendingResolver returns a resolver whose transition tool has already been
+// called, i.e. a transition is pending commit.
+func newPendingResolver(t *testing.T, spec *workflow.Spec) *workflowStateResolver {
+	t.Helper()
+
+	machine := workflow.NewStateMachine(spec)
+	transExec := workflow.NewTransitionExecutor(machine, spec)
+
+	args := json.RawMessage(`{"event":"Go","context":"caller verified"}`)
+	_, err := transExec.Execute(context.Background(), nil, args)
+	require.NoError(t, err)
+	require.NotNil(t, transExec.Pending(), "transition must be pending before commit")
+
+	// Registry is nil: these cases must decide before reaching prompt rendering.
+	return newWorkflowStateResolver(machine, spec, transExec, nil)
+}
+
+func TestWorkflowStateResolver_NoPendingTransition(t *testing.T) {
+	spec := resolverSpec(&workflow.State{PromptTask: "dest"})
+	machine := workflow.NewStateMachine(spec)
+	transExec := workflow.NewTransitionExecutor(machine, spec)
+	resolver := newWorkflowStateResolver(machine, spec, transExec, nil)
+
+	handoff, err := resolver.ResolvePendingHandoff(context.Background())
+
+	require.NoError(t, err)
+	require.False(t, handoff.Changed, "no pending transition must not change the turn")
+	require.Equal(t, "origin", machine.CurrentState())
+}
+
+func TestWorkflowStateResolver_NilExecutorIsInert(t *testing.T) {
+	spec := resolverSpec(&workflow.State{PromptTask: "dest"})
+	resolver := newWorkflowStateResolver(workflow.NewStateMachine(spec), spec, nil, nil)
+
+	handoff, err := resolver.ResolvePendingHandoff(context.Background())
+
+	require.NoError(t, err)
+	require.False(t, handoff.Changed)
+}
+
+// The states the turn must not continue into. In every case the transition is
+// still committed — only the in-turn continuation is suppressed, so the state
+// machine has advanced even though the turn ends.
+func TestWorkflowStateResolver_CommitsButDoesNotContinue(t *testing.T) {
+	cases := []struct {
+		name string
+		dest *workflow.State
+		why  string
+	}{
+		{
+			name: "external orchestration",
+			dest: &workflow.State{PromptTask: "dest", Orchestration: workflow.OrchestrationExternal},
+			why:  "RFC 0009: the runtime pauses for an externally injected event",
+		},
+		{
+			name: "composition orchestration",
+			dest: &workflow.State{PromptTask: "dest", Orchestration: workflow.OrchestrationComposition},
+			why:  "CompositionStage runs the state itself",
+		},
+		{
+			name: "no prompt_task",
+			dest: &workflow.State{},
+			why:  "nothing to render",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := resolverSpec(tc.dest)
+			resolver := newPendingResolver(t, spec)
+
+			handoff, err := resolver.ResolvePendingHandoff(context.Background())
+
+			require.NoError(t, err)
+			require.False(t, handoff.Changed, tc.why)
+			require.Equal(t, "dest", resolver.machine.CurrentState(),
+				"the transition must still be committed")
+			require.Nil(t, resolver.transExec.Pending(),
+				"pending transition must be cleared by the commit")
+		})
+	}
+}
+
+// A destination that is missing from the spec is a config error, not a silent
+// no-op — continuing under the origin prompt would hide it.
+func TestWorkflowStateResolver_UnknownDestinationErrors(t *testing.T) {
+	spec := &workflow.Spec{
+		Version: 2,
+		Entry:   "origin",
+		States: map[string]*workflow.State{
+			"origin": {PromptTask: "origin", OnEvent: map[string]string{"Go": "ghost"}},
+		},
+	}
+	resolver := newPendingResolver(t, spec)
+
+	_, err := resolver.ResolvePendingHandoff(context.Background())
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ghost")
+}
+
+// Rendering without a registry is a hard error rather than a silent handoff to
+// an empty prompt.
+func TestWorkflowStateResolver_NoRegistryErrors(t *testing.T) {
+	spec := resolverSpec(&workflow.State{PromptTask: "dest"})
+	resolver := newPendingResolver(t, spec)
+
+	_, err := resolver.ResolvePendingHandoff(context.Background())
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "prompt registry")
+}
+
+func TestWorkflowStateResolver_CurrentStateMeta(t *testing.T) {
+	spec := resolverSpec(&workflow.State{PromptTask: "dest", Description: "the destination"})
+	machine := workflow.NewStateMachine(spec)
+	resolver := newWorkflowStateResolver(machine, spec, nil, nil)
+
+	meta := resolver.CurrentStateMeta()
+
+	require.Equal(t, "origin", meta["current_state"])
+	require.Equal(t, false, meta["terminal"], "origin has outgoing events")
+
+	// After transitioning, the meta must follow the machine — this is what
+	// makes per-message attribution correct across a multi-state turn.
+	_, err := machine.ProcessEvent("Go")
+	require.NoError(t, err)
+
+	meta = resolver.CurrentStateMeta()
+	require.Equal(t, "dest", meta["current_state"])
+	require.Equal(t, "the destination", meta["description"])
+	require.Equal(t, true, meta["terminal"], "dest has no outgoing events")
+}
+
+func TestWorkflowStateResolver_CurrentStateMetaNilMachine(t *testing.T) {
+	resolver := &workflowStateResolver{}
+	require.Nil(t, resolver.CurrentStateMeta())
+}
+
+// A nil *workflowResolverHolder is non-nil once boxed into the interface, so
+// the pipeline installs it and the tool loop calls through on every round. Any
+// Conversation built without a holder must therefore not panic.
+func TestWorkflowResolverHolder_NilReceiverIsSafe(t *testing.T) {
+	var holder *workflowResolverHolder
+
+	require.NotPanics(t, func() {
+		handoff, err := holder.ResolvePendingHandoff(context.Background())
+		require.NoError(t, err)
+		require.False(t, handoff.Changed)
+		require.Nil(t, holder.CurrentStateMeta())
+		holder.set(nil)
+	})
+}
+
+// An empty holder (the plain-conversation case) is inert until populated.
+func TestWorkflowResolverHolder_EmptyThenPopulated(t *testing.T) {
+	holder := &workflowResolverHolder{}
+
+	handoff, err := holder.ResolvePendingHandoff(context.Background())
+	require.NoError(t, err)
+	require.False(t, handoff.Changed, "empty holder must report no handoff")
+	require.Nil(t, holder.CurrentStateMeta())
+
+	spec := resolverSpec(&workflow.State{PromptTask: "dest"})
+	machine := workflow.NewStateMachine(spec)
+	holder.set(newWorkflowStateResolver(machine, spec, nil, nil))
+
+	require.Equal(t, "origin", holder.CurrentStateMeta()["current_state"],
+		"once populated the holder must delegate")
+}


### PR DESCRIPTION
## The bug

When the LLM calls `workflow__transition`, the state machine advances and then nothing happens. The destination state's prompt is never run — `Send` returns and the conversation waits for a user message that, outside a scripted test, never comes.

```
Building stage-based pipeline  task_type=gather_info     ← round 1, intake
workflow state transition      from=intake to=processing
                                                          ← silence
```

The `*Response` handed back is the **origin** state's. The destination has said nothing.

## Why it shipped

Arena validated it, and the gap was structurally invisible there:

- Arena iterates *scripted* turns (`conversation_executor.go:95`), so an agent-initiated turn cannot be represented.
- Every workflow assertion reads the transition history, not the messages — `transitioned_to` checks `Extras["workflow_transitions"]` for a record with `to == target`. A transition producing **zero output** satisfies all of them.

Hence the filler turns in the examples (`"continue"`, `"wrap up when ready"`, `"thanks"`): extra scripted turns were the only lever available to advance a loop. `workflow-agent-loops` looks like an autonomous agent loop but is a human pressing enter four times.

This is not a PromptPack gap — RFC 0005 states it *"does not define runtime execution semantics"*, and RFC 0009 repeats it. The handoff turn is delegated to the runtime; PromptKit never implemented it.

## The fix

A state change is only two things: a different system prompt and a different tool set. **Both are already per-round inputs to the provider tool loop.** So on the transition tool result, commit and swap them — the next round, *which already runs*, becomes the destination state's turn.

```
round 1  system = triage        assistant: [workflow__transition]
         tool: transition_scheduled
         ◄── commit; swap prompt + tools
round 2  system = handoff       assistant: "I'm the escalations agent…"
```

No new conversation, no new pipeline, no synthetic user message, no `Response` change, and no new loop cap (`MaxRounds` already bounds it).

## Notable details

- **Both tool loops.** The streaming loop (`stages_provider.go:804-821`) is a *parallel implementation* of `executeMultiRound`, not shared code — and it's the path the default mock provider takes. Wired and tested independently.
- **Reconcile, don't signal.** The resolver reports *what the turn should be running*, not *what changed*. A resumed turn (HITL approval, deferred client tool) re-executes the same pipeline, which re-runs `PromptAssemblyStage` and resets the prompt with nothing left "pending" — only a comparison against the current state recovers it.
- **`Stop` is transition-scoped.** External/composition states are not auto-advanced *into*, but still serve ordinary user turns. Treating them as never-run ended a plain `Send` with zero rounds (caught by `sdk/integration TestWorkflow_BasicLifecycle`).
- **Per-message state stamping.** A turn can now span states, so attribution moved from per-turn to per-assistant-message.

## Testing

- Unary and streaming loops, both mutation-verified: removing the handoff fails with `DESTINATION PROMPT → ORIGIN PROMPT`.
- `sdk/examples/hitl` gains an approval-inside-a-workflow pack and an end-to-end test — triage suspends for approval, resumes, transitions, and the confirmation state speaks in the same turn. Also mutation-verified (`confirmation → triage`).
- Full runtime + SDK + integration suites green.

## Not included

- **Arena is not wired.** Until it is, arena keeps validating the old behavior. Tracked separately.
- Duplex/realtime is out of scope: mid-session prompt swapping is only feasible where PromptKit owns the turn boundary (VAD providers, not ASM). Workflows don't run on duplex today.
- Known adjacent gaps: `engine.budget.max_tool_calls` is inert (no consumer ever increments it), `ResumeWorkflow` drops the conversation ID (`sdk/workflow.go:313`), and `sdk/CLAUDE.md`'s "Pipeline Built Per Send()" is inaccurate.
