### PR TITLE
fix: point CodeGen switcher at the live host

### DIFF
--- a/docs/src/components/FamilyBar.astro
+++ b/docs/src/components/FamilyBar.astro
@@ -14,7 +14,7 @@ const inHouse = [
   { name: 'Omnia', cat: 'Platform', dot: '#93C5FD', href: 'https://omnia.altairalabs.ai' },
   { name: 'PromptKit', cat: 'Runtime', dot: '#C4B5FD', href: '/', current: true },
   { name: 'PromptArena', cat: 'Studio', dot: '#67E8F9', href: 'https://promptarena.altairalabs.ai' },
-  { name: 'CodeGen', cat: 'Codegen', dot: '#7DD3A8', href: 'https://codegen.altairalabs.ai' },
+  { name: 'CodeGen', cat: 'Codegen', dot: '#7DD3A8', href: 'https://codegen-sandbox.altairalabs.ai' },
 ];
 ---
 


### PR DESCRIPTION
## Problem

The product switcher (`FamilyBar`) links CodeGen at `codegen.altairalabs.ai`. That host does not resolve — it's NXDOMAIN, so curl reports `000` rather than a 404, and the browser shows a connection error rather than a missing page.

```console
$ curl -s -o /dev/null -w '%{http_code}' -L https://codegen.altairalabs.ai
000
$ curl -s -o /dev/null -w '%{http_code}' -L https://codegen-sandbox.altairalabs.ai
200
```

The switcher appears on every page of this docs site, so the dead link is site-wide.

## Fix

Point CodeGen at `codegen-sandbox.altairalabs.ai`.

The same wrong URL is present in the `FamilyBar` of Omnia, PromptArena and PromptKit docs; companion PRs fix each. `promptpack-spec` already had the correct host, along with a comment flagging that the others needed correcting.

## Verification

Every link in the switcher was checked, not just the changed one:

| Status | URL |
|---|---|
| 200 | https://altairalabs.ai |
| 200 | https://altairalabs.ai/blog |
| 200 | https://codegen-sandbox.altairalabs.ai |
| 200 | https://omnia.altairalabs.ai |
| 200 | https://promptarena.altairalabs.ai |
| 200 | https://promptkit.altairalabs.ai |
| 200 | https://promptpack.org |
