### PR TITLE
chore(schemas): resync arena.json with promptarena

### DIFF
--- a/schemas/v1alpha1/arena.json
+++ b/schemas/v1alpha1/arena.json
@@ -3945,7 +3945,7 @@
             "dir": "out",
             "formats": [
               "json",
-              "html"
+              "markdown"
             ]
           },
           "temperature": 0.7


### PR DESCRIPTION
## Problem

The nightly **Schema Validation** workflow has been failing on `main` (runs [31569890186](https://github.com/AltairaLabs/PromptKit/actions/runs/31569890186), [31464328990](https://github.com/AltairaLabs/PromptKit/actions/runs/31464328990)):

```
::error::schemas/v1alpha1 is out of sync with promptarena — run 'make schemas' and commit
Files /tmp/tmp.OlftVnkIlx/arena.json and schemas/v1alpha1/arena.json differ
```

## Root cause

promptarena (the schema owner) regenerated `arena.json`. The only drift is one line inside the schema's embedded **example** block:

```diff
             "formats": [
               "json",
-              "html"
+              "markdown"
             ]
```

`OutputConfig.formats` is declared as a free-form `array of string`, so this is an example-only change — no structural or validation impact. The committed copy was simply stale, which is exactly the drift the scheduled run exists to catch (#1700).

## Fix

Refetched with `make schemas`.

## Verification

- `make schemas-check` → ✓ Schemas are in sync with promptarena
- `go -C pkg test ./... -count=1` → all packages ok (`pkg/config` is the validator that loads these schemas)
