### PR TITLE
fix: remove inaccurate licensing claim from product switcher

### DIFF
--- a/docs/src/components/FamilyBar.astro
+++ b/docs/src/components/FamilyBar.astro
@@ -40,7 +40,6 @@ const inHouse = [
         <div class="fb-menu" role="menu" hidden>
           <div class="fb-menu-head">
             <div class="fb-menu-title">Switch product</div>
-            <div class="fb-menu-sub">Every product open source · Apache-2.0</div>
           </div>
           <div class="fb-menu-body">
             <div class="fb-group">In-house <span>· built &amp; maintained by AltairaLabs</span></div>


### PR DESCRIPTION
The product switcher's menu subtitle read `Every product open source · Apache-2.0`. That is inaccurate in three separate ways:

| Product | Reality |
|---|---|
| Omnia | repo is **private** — not open source in any usable sense |
| PromptPack | licensed **MIT**, not Apache-2.0 |
| Codegen Sandbox | public repo with **no LICENSE file** (all rights reserved) |
| PromptKit | Apache-2.0 |
| PromptArena | Apache-2.0 |

One hardcoded string stood in for six independent per-product facts, so it could not have stayed correct — and nothing compared it against the repos it described, so the drift was undetectable.

**Removed rather than reworded.** A licensing statement should be derived per product from each repo's actual LICENSE, not asserted globally in markup. That is planned as part of moving this component into a shared package with a per-product licence field verified against the source repos in CI.

This component is copy-pasted across omnia, promptarena, promptkit and promptpack-spec — the same change is going to all four. Separately, AltairaLabs/codegen-sandbox is getting an Apache-2.0 LICENSE added.