### PR TITLE
feat(sdk): provider-type introspection and boot-time option validation

### DIFF
--- a/docs/src/content/docs/runtime/reference/providers.md
+++ b/docs/src/content/docs/runtime/reference/providers.md
@@ -64,6 +64,8 @@ This file contains exported test helpers that can be used by provider implementa
 - [func ReadResponseBody\(body io.Reader\) \(\[\]byte, error\)](<#ReadResponseBody>)
 - [func RegisterEmbeddingProviderFactory\(providerType string, factory EmbeddingProviderFactory\)](<#RegisterEmbeddingProviderFactory>)
 - [func RegisterProviderFactory\(providerType string, factory ProviderFactory\)](<#RegisterProviderFactory>)
+- [func RegisteredEmbeddingProviderTypes\(\) \[\]string](<#RegisteredEmbeddingProviderTypes>)
+- [func RegisteredProviderTypes\(\) \[\]string](<#RegisteredProviderTypes>)
 - [func ResetDefaultStreamMetrics\(\)](<#ResetDefaultStreamMetrics>)
 - [func ResolveEmbeddingCredential\(ctx context.Context, providerType string, cfgDir string, cred \*credentials.CredentialConfig, platform \*credentials.PlatformConfig\) \(credentials.Credential, error\)](<#ResolveEmbeddingCredential>)
 - [func RunProviderContractTests\(t \*testing.T, config ProviderContractTests\)](<#RunProviderContractTests>)
@@ -738,6 +740,24 @@ func RegisterProviderFactory(providerType string, factory ProviderFactory)
 ```
 
 RegisterProviderFactory registers a factory function for a provider type
+
+<a name="RegisteredEmbeddingProviderTypes"></a>
+## func RegisteredEmbeddingProviderTypes
+
+```go
+func RegisteredEmbeddingProviderTypes() []string
+```
+
+RegisteredEmbeddingProviderTypes returns the embedding provider types with a registered factory, sorted. Use it to check a configured type before CreateEmbeddingProviderFromSpec rather than constructing and parsing the error.
+
+<a name="RegisteredProviderTypes"></a>
+## func RegisteredProviderTypes
+
+```go
+func RegisteredProviderTypes() []string
+```
+
+RegisteredProviderTypes returns the completion \(chat\) provider types with a registered factory, sorted. This is the registry CreateProviderFromSpec resolves against for the llm, image and video roles alike — a type listed here will construct for any of them.
 
 <a name="ResetDefaultStreamMetrics"></a>
 ## func ResetDefaultStreamMetrics

--- a/docs/src/content/docs/runtime/reference/tts.md
+++ b/docs/src/content/docs/runtime/reference/tts.md
@@ -76,6 +76,7 @@ The package includes implementations for:
 - [func CostInfoToMetaMap\(ci \*types.CostInfo\) map\[string\]any](<#CostInfoToMetaMap>)
 - [func PricingFromSpec\(spec ProviderSpec\) \*base.PricingDescriptor](<#PricingFromSpec>)
 - [func RegisterFactory\(providerType string, factory Factory\)](<#RegisterFactory>)
+- [func RegisteredTypes\(\) \[\]string](<#RegisteredTypes>)
 - [func ResolveCredential\(ctx context.Context, providerType string, cfgDir string, cred \*credentials.CredentialConfig\) \(credentials.Credential, error\)](<#ResolveCredential>)
 - [func SynthesizeWithRetry\(ctx context.Context, svc Service, text string, config SynthesisConfig, retry RetryConfig\) \(io.ReadCloser, error\)](<#SynthesizeWithRetry>)
 - [func WithCartesiaWSURL\(url string\) func\(\*CartesiaService\)](<#WithCartesiaWSURL>)
@@ -361,6 +362,15 @@ func RegisterFactory(providerType string, factory Factory)
 ```
 
 RegisterFactory registers a factory for the given provider type. Typically called from per\-provider package init\(\).
+
+<a name="RegisteredTypes"></a>
+## func RegisteredTypes
+
+```go
+func RegisteredTypes() []string
+```
+
+RegisteredTypes returns the TTS provider types with a registered factory, sorted. Use it to check a configured type before CreateFromSpec rather than constructing and parsing the error.
 
 <a name="ResolveCredential"></a>
 ## func ResolveCredential

--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -123,7 +123,9 @@ All pack examples conform to the PromptPack Specification v1.1.0: https://github
 - [Variables](<#variables>)
 - [func Evaluate\(ctx context.Context, opts EvaluateOpts\) \(\[\]evals.EvalResult, error\)](<#Evaluate>)
 - [func GracefulShutdown\(mgr \*ShutdownManager, timeout time.Duration\)](<#GracefulShutdown>)
+- [func RegisteredProviderTypes\(\) map\[string\]\[\]string](<#RegisteredProviderTypes>)
 - [func ValidateEvalTypes\(opts ValidateEvalTypesOpts\) \(\[\]evals.EvalDef, error\)](<#ValidateEvalTypes>)
+- [func ValidateOptions\(opts ...Option\) error](<#ValidateOptions>)
 - [type A2AAgentBuilder](<#A2AAgentBuilder>)
   - [func NewA2AAgent\(url string\) \*A2AAgentBuilder](<#NewA2AAgent>)
   - [func \(b \*A2AAgentBuilder\) Build\(\) \*tools.A2AConfig](<#A2AAgentBuilder.Build>)
@@ -591,6 +593,21 @@ GracefulShutdown listens for SIGTERM and SIGINT, then calls mgr.Shutdown with th
 go sdk.GracefulShutdown(mgr, 30*time.Second)
 ```
 
+<a name="RegisteredProviderTypes"></a>
+## func RegisteredProviderTypes
+
+```go
+func RegisteredProviderTypes() map[string][]string
+```
+
+RegisteredProviderTypes returns, per provider role, the types that have a registered factory in this binary — the types a With\*Provider option \(or a role in a \*.provider.yaml\) will successfully construct. Each list is sorted, and the result is a snapshot the caller may modify freely.
+
+Registration is the only gate on construction, so this answers "will this binding build?" exactly. It does not rank types by suitability: llm, image and video share one completion\-provider registry, so all three report the same set even though a given type may only be useful for one of them.
+
+The registries are populated by package init\(\), which means the answer depends on which provider packages the binary imports. Callers that need a type not listed here should add its blank import.
+
+Intended for deploy\-time and boot\-time validation — a caller can check a configured type without constructing a provider and string\-matching the error. See ValidateOptions to check a whole option set.
+
 <a name="ValidateEvalTypes"></a>
 ## func ValidateEvalTypes
 
@@ -601,6 +618,19 @@ func ValidateEvalTypes(opts ValidateEvalTypesOpts) ([]evals.EvalDef, error)
 ValidateEvalTypes checks that every eval type referenced in the resolved eval definitions has a registered handler in the EvalTypeRegistry. Returns a list of eval IDs whose types are missing, or nil if all are valid.
 
 This is useful as a preflight check — e.g. at startup or in CI — to catch configuration errors \(typos, missing RuntimeConfig bindings\) before evals are actually executed.
+
+<a name="ValidateOptions"></a>
+## func ValidateOptions
+
+```go
+func ValidateOptions(opts ...Option) error
+```
+
+ValidateOptions reports whether an option set would be accepted by Open, without loading a pack or starting a conversation. It runs exactly the option\-application phase Open runs: every option is applied \(so providers are constructed and credentials resolved\) and the cross\-option constraints are then checked.
+
+Call it once at startup with the same options the server will later pass to Open. Provider options are applied eagerly inside Open, and a server that opens a conversation per request would otherwise surface a bad binding as a failure on every request rather than as a startup error.
+
+Anything constructed during validation is discarded.
 
 <a name="A2AAgentBuilder"></a>
 ## type A2AAgentBuilder

--- a/runtime/classify/factory.go
+++ b/runtime/classify/factory.go
@@ -33,6 +33,11 @@ func RegisterFactory(providerType string, f Factory) {
 	classifyRegistry.Register(providerType, f)
 }
 
+// RegisteredTypes returns the inference provider types with a registered
+// factory, sorted. Use it to check a configured type before CreateFromSpec
+// rather than constructing and parsing the error.
+func RegisteredTypes() []string { return classifyRegistry.Types() }
+
 // CreateFromSpec builds a Backend for the spec's Type.
 //
 //nolint:gocritic // spec is a value-semantics builder; callers assemble inline.

--- a/runtime/classify/factory_test.go
+++ b/runtime/classify/factory_test.go
@@ -2,6 +2,7 @@ package classify_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/classify"
@@ -174,6 +175,23 @@ func TestBuildRegistry_AllTaskDefaults(t *testing.T) {
 	}
 	if _, err := reg.Embedder(""); err != nil {
 		t.Fatalf("default embedder: %v", err)
+	}
+}
+
+// TestRegisteredTypes asserts the lister reads the package's own factory
+// registry — a lister pointed at a fresh registry would not see a type
+// registered through classify.RegisterFactory.
+func TestRegisteredTypes(t *testing.T) {
+	classify.RegisterFactory("fakelisted", func(_ classify.ProviderSpec) (classify.Backend, error) {
+		return fakeText{}, nil
+	})
+
+	got := classify.RegisteredTypes()
+	if !slices.Contains(got, "fakelisted") {
+		t.Errorf("RegisteredTypes() = %v, missing %q", got, "fakelisted")
+	}
+	if !slices.IsSorted(got) {
+		t.Errorf("RegisteredTypes() = %v, not sorted", got)
 	}
 }
 

--- a/runtime/providers/base/factory.go
+++ b/runtime/providers/base/factory.go
@@ -3,6 +3,7 @@ package base
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/AltairaLabs/PromptKit/runtime/credentials"
@@ -50,6 +51,21 @@ func (r *FactoryRegistry[T]) Register(implType string, f Factory[T]) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.factories[implType] = f
+}
+
+// Types returns the implementation types with a registered factory, sorted.
+// Callers use it to discover what Create will accept without attempting a
+// construction and string-matching the error — e.g. a deploy adapter
+// validating provider bindings before serving traffic.
+func (r *FactoryRegistry[T]) Types() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	types := make([]string, 0, len(r.factories))
+	for t := range r.factories {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+	return types
 }
 
 // Create dispatches to the registered factory for spec.Type.

--- a/runtime/providers/base/factory_test.go
+++ b/runtime/providers/base/factory_test.go
@@ -3,6 +3,8 @@ package base_test
 import (
 	"context"
 	"errors"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/credentials"
@@ -39,6 +41,54 @@ func TestFactoryRegistry_FactoryErrorPropagates(t *testing.T) {
 	_, err := r.Create(base.CapabilitySpec{Type: "broken"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestFactoryRegistry_TypesListsRegisteredTypesSorted(t *testing.T) {
+	r := base.NewFactoryRegistry[*fakeService]()
+	// Registered out of order, and with enough entries that a map-iteration
+	// order would be vanishingly unlikely to come out sorted by chance.
+	for _, name := range []string{"openai", "cartesia", "elevenlabs", "polly", "deepgram", "azure"} {
+		r.Register(name, func(_ base.CapabilitySpec) (*fakeService, error) { return &fakeService{}, nil })
+	}
+
+	assert.Equal(t, []string{"azure", "cartesia", "deepgram", "elevenlabs", "openai", "polly"}, r.Types())
+}
+
+func TestFactoryRegistry_TypesEmptyRegistry(t *testing.T) {
+	assert.Empty(t, base.NewFactoryRegistry[*fakeService]().Types())
+}
+
+func TestFactoryRegistry_TypesReflectsLaterRegistration(t *testing.T) {
+	r := base.NewFactoryRegistry[*fakeService]()
+	r.Register("first", func(_ base.CapabilitySpec) (*fakeService, error) { return &fakeService{}, nil })
+	require.Equal(t, []string{"first"}, r.Types())
+
+	// Types must read the live map, not a snapshot taken at construction.
+	r.Register("second", func(_ base.CapabilitySpec) (*fakeService, error) { return &fakeService{}, nil })
+	assert.Equal(t, []string{"first", "second"}, r.Types())
+}
+
+func TestFactoryRegistry_TypesIsRaceSafeWithRegister(t *testing.T) {
+	// Fails under -race if Types reads the map without holding the lock.
+	r := base.NewFactoryRegistry[*fakeService]()
+	f := func(_ base.CapabilitySpec) (*fakeService, error) { return &fakeService{}, nil }
+	r.Register("seed", f)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := range 50 {
+			r.Register("t"+strconv.Itoa(i), f)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 50 {
+			assert.NotEmpty(t, r.Types())
+		}
+	}()
+	wg.Wait()
 }
 
 func TestAPIKeyFromCredential_Nil(t *testing.T) {

--- a/runtime/providers/embedding_factory.go
+++ b/runtime/providers/embedding_factory.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/AltairaLabs/PromptKit/runtime/credentials"
@@ -57,6 +58,21 @@ func RegisterEmbeddingProviderFactory(providerType string, factory EmbeddingProv
 	embeddingFactoriesMu.Lock()
 	defer embeddingFactoriesMu.Unlock()
 	embeddingFactories[providerType] = factory
+}
+
+// RegisteredEmbeddingProviderTypes returns the embedding provider types with
+// a registered factory, sorted. Use it to check a configured type before
+// CreateEmbeddingProviderFromSpec rather than constructing and parsing the
+// error.
+func RegisteredEmbeddingProviderTypes() []string {
+	embeddingFactoriesMu.RLock()
+	defer embeddingFactoriesMu.RUnlock()
+	types := make([]string, 0, len(embeddingFactories))
+	for t := range embeddingFactories {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+	return types
 }
 
 // CreateEmbeddingProviderFromSpec returns an EmbeddingProvider

--- a/runtime/providers/embedding_factory_test.go
+++ b/runtime/providers/embedding_factory_test.go
@@ -2,6 +2,7 @@ package providers_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/credentials"
@@ -13,6 +14,30 @@ import (
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/openai"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/voyageai"
 )
+
+// TestRegisteredEmbeddingProviderTypes asserts the lister reads the live
+// embedding factory map: the four side-effect-imported providers above are
+// present, and a type registered at runtime shows up too. A lister backed by
+// a fresh map or a construction-time snapshot fails one or both.
+func TestRegisteredEmbeddingProviderTypes(t *testing.T) {
+	got := providers.RegisteredEmbeddingProviderTypes()
+	for _, want := range []string{"gemini", "ollama", "openai", "voyageai"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("RegisteredEmbeddingProviderTypes() = %v, missing %q", got, want)
+		}
+	}
+	if !slices.IsSorted(got) {
+		t.Errorf("RegisteredEmbeddingProviderTypes() = %v, not sorted", got)
+	}
+
+	providers.RegisterEmbeddingProviderFactory("fakelisted",
+		func(_ providers.EmbeddingProviderSpec) (providers.EmbeddingProvider, error) {
+			return nil, nil
+		})
+	if got := providers.RegisteredEmbeddingProviderTypes(); !slices.Contains(got, "fakelisted") {
+		t.Errorf("after registration, RegisteredEmbeddingProviderTypes() = %v, missing %q", got, "fakelisted")
+	}
+}
 
 // Each per-provider test exercises every conditional branch of the
 // registered factory closure (model, base_url, credential, and any

--- a/runtime/providers/registry.go
+++ b/runtime/providers/registry.go
@@ -3,6 +3,8 @@ package providers
 import (
 	"context"
 	"net/http"
+	"sort"
+	"sync"
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/credentials"
@@ -33,11 +35,34 @@ type Registry struct {
 // ProviderFactory is a function that creates a provider from a spec
 type ProviderFactory func(spec ProviderSpec) (Provider, error)
 
-var providerFactories = make(map[string]ProviderFactory)
+// providerFactories is populated from per-provider package init() functions.
+// The mutex guards it because RegisteredProviderTypes ranges over the map,
+// and tests register factories after init has run.
+var (
+	providerFactoriesMu sync.RWMutex
+	providerFactories   = make(map[string]ProviderFactory)
+)
 
 // RegisterProviderFactory registers a factory function for a provider type
 func RegisterProviderFactory(providerType string, factory ProviderFactory) {
+	providerFactoriesMu.Lock()
+	defer providerFactoriesMu.Unlock()
 	providerFactories[providerType] = factory
+}
+
+// RegisteredProviderTypes returns the completion (chat) provider types with a
+// registered factory, sorted. This is the registry CreateProviderFromSpec
+// resolves against for the llm, image and video roles alike — a type listed
+// here will construct for any of them.
+func RegisteredProviderTypes() []string {
+	providerFactoriesMu.RLock()
+	defer providerFactoriesMu.RUnlock()
+	types := make([]string, 0, len(providerFactories))
+	for t := range providerFactories {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+	return types
 }
 
 // NewRegistry creates a new provider registry.
@@ -322,7 +347,9 @@ func CreateProviderFromSpec(spec ProviderSpec) (Provider, error) {
 	spec.BaseURL = baseURL
 
 	// Look up the factory for this provider type
+	providerFactoriesMu.RLock()
 	factory, exists := providerFactories[spec.Type]
+	providerFactoriesMu.RUnlock()
 	if !exists {
 		return nil, &UnsupportedProviderError{ProviderType: spec.Type}
 	}

--- a/runtime/providers/registry_types_test.go
+++ b/runtime/providers/registry_types_test.go
@@ -1,0 +1,41 @@
+package providers
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestRegisteredProviderTypes asserts the lister reads the live completion
+// (chat) factory map rather than a fresh map or a construction-time snapshot.
+// This is the registry WithLLMProvider/WithImageProvider resolve against, so
+// it is what a caller must consult to know whether those options will
+// construct.
+func TestRegisteredProviderTypes(t *testing.T) {
+	const fake = "fakelisted"
+	original, had := providerFactories[fake]
+	t.Cleanup(func() {
+		if had {
+			providerFactories[fake] = original
+			return
+		}
+		delete(providerFactories, fake)
+	})
+
+	before := RegisteredProviderTypes()
+	if slices.Contains(before, fake) {
+		t.Fatalf("RegisteredProviderTypes() = %v, already contains %q", before, fake)
+	}
+	if !slices.IsSorted(before) {
+		t.Errorf("RegisteredProviderTypes() = %v, not sorted", before)
+	}
+
+	RegisterProviderFactory(fake, func(_ ProviderSpec) (Provider, error) { return nil, nil })
+
+	after := RegisteredProviderTypes()
+	if !slices.Contains(after, fake) {
+		t.Errorf("after registration, RegisteredProviderTypes() = %v, missing %q", after, fake)
+	}
+	if !slices.IsSorted(after) {
+		t.Errorf("RegisteredProviderTypes() = %v, not sorted", after)
+	}
+}

--- a/runtime/stt/factory.go
+++ b/runtime/stt/factory.go
@@ -23,6 +23,11 @@ func RegisterFactory(providerType string, factory Factory) {
 	sttRegistry.Register(providerType, factory)
 }
 
+// RegisteredTypes returns the STT provider types with a registered factory,
+// sorted. Use it to check a configured type before CreateFromSpec rather than
+// constructing and parsing the error.
+func RegisteredTypes() []string { return sttRegistry.Types() }
+
 // CreateFromSpec returns a Service implementation for the given spec.
 //
 //nolint:gocritic // spec is a value-semantics builder; callers assemble inline.

--- a/runtime/stt/register_test.go
+++ b/runtime/stt/register_test.go
@@ -2,12 +2,26 @@ package stt_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/credentials"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/base"
 	"github.com/AltairaLabs/PromptKit/runtime/stt"
 )
+
+// TestRegisteredTypes asserts the lister is wired to the same registry the
+// package's own init() registers into — a lister pointed at a fresh registry
+// would come back empty.
+func TestRegisteredTypes(t *testing.T) {
+	got := stt.RegisteredTypes()
+	if !slices.Contains(got, "openai") {
+		t.Errorf("RegisteredTypes() = %v, missing %q", got, "openai")
+	}
+	if !slices.IsSorted(got) {
+		t.Errorf("RegisteredTypes() = %v, not sorted", got)
+	}
+}
 
 func TestSTTRegister_OpenAI_AllOptions(t *testing.T) {
 	cred := credentials.NewAPIKeyCredential("sk-stub")

--- a/runtime/tts/factory.go
+++ b/runtime/tts/factory.go
@@ -24,6 +24,11 @@ func RegisterFactory(providerType string, factory Factory) {
 	ttsRegistry.Register(providerType, factory)
 }
 
+// RegisteredTypes returns the TTS provider types with a registered factory,
+// sorted. Use it to check a configured type before CreateFromSpec rather than
+// constructing and parsing the error.
+func RegisteredTypes() []string { return ttsRegistry.Types() }
+
 // CreateFromSpec returns a Service implementation for the given spec.
 //
 //nolint:gocritic // spec is a value-semantics builder; callers assemble inline.

--- a/runtime/tts/register_test.go
+++ b/runtime/tts/register_test.go
@@ -2,6 +2,7 @@ package tts_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/credentials"
@@ -17,6 +18,21 @@ func TestResolveCredential(t *testing.T) {
 	}
 	if got := tts.APIKeyFromCredential(cred); got != "sk-env" {
 		t.Errorf("got %q want sk-env", got)
+	}
+}
+
+// TestRegisteredTypes asserts the lister is wired to the same registry the
+// package's own init() functions register into — a lister pointed at a fresh
+// or unrelated registry would come back without these.
+func TestRegisteredTypes(t *testing.T) {
+	got := tts.RegisteredTypes()
+	for _, want := range []string{"cartesia", "elevenlabs", "openai"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("RegisteredTypes() = %v, missing %q", got, want)
+		}
+	}
+	if !slices.IsSorted(got) {
+		t.Errorf("RegisteredTypes() = %v, not sorted", got)
 	}
 }
 

--- a/sdk/provider_introspection.go
+++ b/sdk/provider_introspection.go
@@ -1,0 +1,60 @@
+package sdk
+
+import (
+	"slices"
+
+	pkgconfig "github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/classify"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/stt"
+	"github.com/AltairaLabs/PromptKit/runtime/tts"
+)
+
+// RegisteredProviderTypes returns, per provider role, the types that have a
+// registered factory in this binary — the types a With*Provider option (or a
+// role in a *.provider.yaml) will successfully construct. Each list is sorted,
+// and the result is a snapshot the caller may modify freely.
+//
+// Registration is the only gate on construction, so this answers "will this
+// binding build?" exactly. It does not rank types by suitability: llm, image
+// and video share one completion-provider registry, so all three report the
+// same set even though a given type may only be useful for one of them.
+//
+// The registries are populated by package init(), which means the answer
+// depends on which provider packages the binary imports. Callers that need a
+// type not listed here should add its blank import.
+//
+// Intended for deploy-time and boot-time validation — a caller can check a
+// configured type without constructing a provider and string-matching the
+// error. See ValidateOptions to check a whole option set.
+func RegisteredProviderTypes() map[string][]string {
+	completion := providers.RegisteredProviderTypes()
+	return map[string][]string{
+		// llm/image/video all resolve through createProviderFromConfig, which
+		// dispatches on the single completion-provider registry.
+		pkgconfig.RoleLLM:       completion,
+		pkgconfig.RoleImage:     slices.Clone(completion),
+		pkgconfig.RoleVideo:     slices.Clone(completion),
+		pkgconfig.RoleTTS:       tts.RegisteredTypes(),
+		pkgconfig.RoleSTT:       stt.RegisteredTypes(),
+		pkgconfig.RoleEmbedding: providers.RegisteredEmbeddingProviderTypes(),
+		pkgconfig.RoleInference: classify.RegisteredTypes(),
+	}
+}
+
+// ValidateOptions reports whether an option set would be accepted by Open,
+// without loading a pack or starting a conversation. It runs exactly the
+// option-application phase Open runs: every option is applied (so providers
+// are constructed and credentials resolved) and the cross-option constraints
+// are then checked.
+//
+// Call it once at startup with the same options the server will later pass to
+// Open. Provider options are applied eagerly inside Open, and a server that
+// opens a conversation per request would otherwise surface a bad binding as a
+// failure on every request rather than as a startup error.
+//
+// Anything constructed during validation is discarded.
+func ValidateOptions(opts ...Option) error {
+	_, err := applyOptions("", opts)
+	return err
+}

--- a/sdk/provider_introspection_test.go
+++ b/sdk/provider_introspection_test.go
@@ -1,0 +1,114 @@
+package sdk
+
+import (
+	"slices"
+	"testing"
+
+	pkgconfig "github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisteredProviderTypes_CoversEveryRole(t *testing.T) {
+	got := RegisteredProviderTypes()
+
+	wantRoles := []string{
+		pkgconfig.RoleLLM, pkgconfig.RoleImage, pkgconfig.RoleVideo,
+		pkgconfig.RoleTTS, pkgconfig.RoleSTT,
+		pkgconfig.RoleEmbedding, pkgconfig.RoleInference,
+	}
+	gotRoles := make([]string, 0, len(got))
+	for role := range got {
+		gotRoles = append(gotRoles, role)
+	}
+	slices.Sort(wantRoles)
+	slices.Sort(gotRoles)
+	assert.Equal(t, wantRoles, gotRoles,
+		"every role applyProviderConfig routes must be listed, and no others")
+}
+
+// Each role must read its own registry. Asserting a type unique to one
+// capability catches a lister wired to the wrong registry — the TTS and STT
+// sets overlap on "openai", so only "cartesia" distinguishes them.
+func TestRegisteredProviderTypes_RolesReadTheirOwnRegistry(t *testing.T) {
+	got := RegisteredProviderTypes()
+
+	assert.Contains(t, got[pkgconfig.RoleTTS], "cartesia")
+	assert.NotContains(t, got[pkgconfig.RoleSTT], "cartesia",
+		"STT must not report TTS-only types")
+	assert.Contains(t, got[pkgconfig.RoleSTT], "openai")
+
+	// Registered by the blank imports in runtime_config.go.
+	assert.Contains(t, got[pkgconfig.RoleEmbedding], "voyageai")
+	assert.NotContains(t, got[pkgconfig.RoleLLM], "voyageai",
+		"completion role must not report embedding-only types")
+	assert.Contains(t, got[pkgconfig.RoleLLM], "openai")
+}
+
+// llm/image/video all resolve against the same completion-provider registry,
+// so they must report identical sets rather than silently diverging.
+func TestRegisteredProviderTypes_CompletionRolesShareOneRegistry(t *testing.T) {
+	got := RegisteredProviderTypes()
+	assert.Equal(t, got[pkgconfig.RoleLLM], got[pkgconfig.RoleImage])
+	assert.Equal(t, got[pkgconfig.RoleLLM], got[pkgconfig.RoleVideo])
+}
+
+func TestRegisteredProviderTypes_SortedPerRole(t *testing.T) {
+	for role, types := range RegisteredProviderTypes() {
+		assert.True(t, slices.IsSorted(types), "role %q: %v not sorted", role, types)
+	}
+}
+
+// The caller must not be able to corrupt the registries through the returned
+// map — it is a snapshot, not a view.
+func TestRegisteredProviderTypes_ReturnsIndependentCopy(t *testing.T) {
+	first := RegisteredProviderTypes()
+	require.NotEmpty(t, first[pkgconfig.RoleLLM])
+	first[pkgconfig.RoleLLM][0] = "mutated"
+	delete(first, pkgconfig.RoleTTS)
+
+	second := RegisteredProviderTypes()
+	assert.NotEqual(t, "mutated", second[pkgconfig.RoleLLM][0])
+	assert.NotEmpty(t, second[pkgconfig.RoleTTS])
+}
+
+func TestValidateOptions_RejectsUnregisteredProviderTypeWithoutAPack(t *testing.T) {
+	// The point of the call: no pack path, no conversation, no request.
+	err := ValidateOptions(WithEmbeddingProvider(ProviderSpec{
+		ID:   "embed",
+		Type: "titan",
+		// Platform set exactly as a Bedrock deployment would; it must not
+		// rescue an unregistered type.
+		Platform: &pkgconfig.PlatformConfig{Type: "bedrock", Region: "us-west-2"},
+	}))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "titan", "error must name the offending type")
+}
+
+func TestValidateOptions_AcceptsRegisteredProviderSet(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+
+	err := ValidateOptions(
+		WithTTSProvider(ProviderSpec{ID: "voice", Type: "openai"}),
+		WithSTTProvider(ProviderSpec{ID: "ears", Type: "openai"}),
+	)
+
+	assert.NoError(t, err)
+}
+
+// Validation must apply the same cross-option checks Open does, or a set that
+// passes here would still fail at request time.
+func TestValidateOptions_AppliesCrossOptionChecks(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+
+	// The type is registered and constructs fine; the set is still invalid,
+	// because an embedding provider sets the retrieval slot and that requires
+	// a context window. Open enforces this after applying options — if
+	// validation stopped at per-option construction it would pass here and
+	// fail at request time.
+	err := ValidateOptions(WithEmbeddingProvider(ProviderSpec{ID: "embed", Type: "openai"}))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "WithContextWindow")
+}

--- a/sdk/provider_introspection_test.go
+++ b/sdk/provider_introspection_test.go
@@ -86,15 +86,28 @@ func TestValidateOptions_RejectsUnregisteredProviderTypeWithoutAPack(t *testing.
 	assert.Contains(t, err.Error(), "titan", "error must name the offending type")
 }
 
-func TestValidateOptions_AcceptsRegisteredProviderSet(t *testing.T) {
+// TestValidateOptions_TracksRegisteredProviderTypes pins the contract the two
+// APIs jointly promise: registration is the only gate on construction, so what
+// RegisteredProviderTypes lists is exactly what ValidateOptions accepts. The
+// two calls differ only in the provider type, so acceptance cannot be
+// unconditional — a ValidateOptions that ignored the type, always returned nil,
+// or always errored fails one of the three assertions, and a lister that drifts
+// from the validator fails the requires.
+func TestValidateOptions_TracksRegisteredProviderTypes(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "sk-test")
 
-	err := ValidateOptions(
+	listed := RegisteredProviderTypes()[pkgconfig.RoleTTS]
+	require.Contains(t, listed, "openai")
+	require.NotContains(t, listed, "polly", "test needs a type that is genuinely unregistered")
+
+	assert.NoError(t, ValidateOptions(
 		WithTTSProvider(ProviderSpec{ID: "voice", Type: "openai"}),
 		WithSTTProvider(ProviderSpec{ID: "ears", Type: "openai"}),
-	)
+	), "every listed type must validate")
 
-	assert.NoError(t, err)
+	err := ValidateOptions(WithTTSProvider(ProviderSpec{ID: "voice", Type: "polly"}))
+	require.Error(t, err, "an unlisted type must not validate")
+	assert.Contains(t, err.Error(), "polly", "error must name the offending type")
 }
 
 // Validation must apply the same cross-option checks Open does, or a set that


### PR DESCRIPTION
## What

Two things a deploy adapter needs and could not get: ask which provider types are registered, and validate an option set before serving traffic.

### Listers

Every factory registry was `init()`-populated and private, so the only way to discover support was to construct and string-match the error.

| Added | Covers |
|---|---|
| `base.FactoryRegistry[T].Types()` | tts / stt / image / inference in one method |
| `providers.RegisteredEmbeddingProviderTypes()` | embedding |
| `providers.RegisteredProviderTypes()` | completion (chat) |
| `tts.RegisteredTypes()` / `stt.RegisteredTypes()` / `classify.RegisteredTypes()` | thin wrappers, matching the existing `CreateFromSpec` shape |
| `sdk.RegisteredProviderTypes()` | `map[role][]string` over all of the above |

Registration is the only gate on construction, so the result answers "will this binding build?" exactly. `llm`/`image`/`video` share one completion registry and therefore report identical sets — documented rather than papered over, since that is precisely what determines whether the option constructs.

What it reports today, from a binary importing the SDK:

```
llm        [claude gemini imagen mock ollama openai]
image      [claude gemini imagen mock ollama openai]
video      [claude gemini imagen mock ollama openai]
tts        [cartesia elevenlabs openai]
stt        [openai]
embedding  [gemini ollama openai voyageai]
inference  [huggingface]
```

That table is the one #1774 had to reconstruct by probing each role and reading error strings. It independently confirms two rows of that report: `inference` really does only have `huggingface`, and `stt` only `openai`.

### Validation

`sdk.ValidateOptions(opts...)` runs Open's option-application phase — every option applied, then the cross-option constraints — without loading a pack or opening a conversation.

It reuses `applyOptions`, so it cannot drift from what `Open` actually enforces. That matters for the second half: per-option construction alone is not enough. An embedding provider with a valid type still fails Open, because it sets the retrieval slot and that requires a context window. A validator that stopped at construction would pass a set that fails at request time; there is a test pinning this.

## Why it is worth doing separately from the Bedrock work

Provider options are applied eagerly in `sdk.Open`, and A2A/server deployments open a conversation **per request** — so an unconstructible binding is not a startup error, it is a failure on every request, in production, surfaced to the end user. Nothing here needs a new provider to exist, and it lets `promptarena-deploy-agentcore` replace its hardcoded non-`llm` warning (AltairaLabs/promptarena-deploy-agentcore#88) with a real check.

## Incidental

`providerFactories` (the completion registry) had no mutex, unlike the embedding and `base` registries. `RegisteredProviderTypes` ranges over it and tests register factories after `init` has run, so it gained an `RWMutex`; the existing lookup in `CreateProviderFromSpec` now takes the read lock.

## Testing

TDD throughout — every assertion was watched failing against a stub before the implementation existed.

- `Types()` is sorted, reads the live map rather than a construction-time snapshot, and is race-safe against concurrent `Register` (that last one fails under `-race` without the lock).
- Each role reads its own registry: `tts` contains `cartesia` and `stt` does not, so a lister wired to the wrong registry fails rather than passing on the shared `openai` entry.
- The returned map is an independent copy — a caller mutating it cannot corrupt the registries.
- `ValidateOptions` rejects an unregistered type with no pack present (a `Platform` set to Bedrock does not rescue it), accepts a registered set, and still applies the cross-option checks.

Full `runtime` and `sdk` suites pass; `golangci-lint --new-from-rev=main` is clean on both modules; both reference-drift gates regenerated and up to date.

Closes #1776
