### PR TITLE
docs(sdk): state what ValidateOptions does not check

### DIFF
--- a/docs/src/content/docs/sdk/reference/conversation-manager.md
+++ b/docs/src/content/docs/sdk/reference/conversation-manager.md
@@ -630,6 +630,13 @@ ValidateOptions reports whether an option set would be accepted by Open, without
 
 Call it once at startup with the same options the server will later pass to Open. Provider options are applied eagerly inside Open, and a server that opens a conversation per request would otherwise surface a bad binding as a failure on every request rather than as a startup error.
 
+It checks that the set constructs — an unregistered or misspelled provider type, an option that fails to build, a violated cross\-option constraint. It does not check that the resulting providers will work:
+
+- Credentials are resolved, not verified. A missing key resolves to a no\-op credential and an invalid key resolves fine, so a provider that will fail authentication on its first real call still validates.
+- Nothing is contacted. Endpoint reachability, region, IAM policy and whether the configured model exists are all out of scope.
+
+So a nil return means "this configuration builds", not "this deployment will serve traffic". Callers gating a deploy on it should say so.
+
 Anything constructed during validation is discarded.
 
 <a name="A2AAgentBuilder"></a>

--- a/sdk/provider_introspection.go
+++ b/sdk/provider_introspection.go
@@ -53,6 +53,19 @@ func RegisteredProviderTypes() map[string][]string {
 // opens a conversation per request would otherwise surface a bad binding as a
 // failure on every request rather than as a startup error.
 //
+// It checks that the set constructs — an unregistered or misspelled provider
+// type, an option that fails to build, a violated cross-option constraint. It
+// does not check that the resulting providers will work:
+//
+//   - Credentials are resolved, not verified. A missing key resolves to a
+//     no-op credential and an invalid key resolves fine, so a provider that
+//     will fail authentication on its first real call still validates.
+//   - Nothing is contacted. Endpoint reachability, region, IAM policy and
+//     whether the configured model exists are all out of scope.
+//
+// So a nil return means "this configuration builds", not "this deployment
+// will serve traffic". Callers gating a deploy on it should say so.
+//
 // Anything constructed during validation is discarded.
 func ValidateOptions(opts ...Option) error {
 	_, err := applyOptions("", opts)

--- a/sdk/provider_introspection_test.go
+++ b/sdk/provider_introspection_test.go
@@ -110,6 +110,24 @@ func TestValidateOptions_TracksRegisteredProviderTypes(t *testing.T) {
 	assert.Contains(t, err.Error(), "polly", "error must name the offending type")
 }
 
+// TestValidateOptions_ChecksConstructionNotCredentials pins the documented
+// boundary of what validation covers. Both calls carry an unusable credential;
+// only the one naming an unregistered type is rejected. A caller gating a
+// deploy on ValidateOptions depends on knowing which side of this line it sits
+// on, so the limitation is pinned rather than left to the doc comment.
+func TestValidateOptions_ChecksConstructionNotCredentials(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-not-a-real-key")
+
+	assert.NoError(t,
+		ValidateOptions(WithTTSProvider(ProviderSpec{ID: "voice", Type: "openai"})),
+		"an unusable credential must still validate — validity is not checked")
+
+	// "transcribe" is the STT type a Bedrock deployment would reach for (#1774).
+	err := ValidateOptions(WithSTTProvider(ProviderSpec{ID: "ears", Type: "transcribe"}))
+	require.Error(t, err, "an unregistered type must be rejected")
+	assert.Contains(t, err.Error(), "transcribe")
+}
+
 // Validation must apply the same cross-option checks Open does, or a set that
 // passes here would still fail at request time.
 func TestValidateOptions_AppliesCrossOptionChecks(t *testing.T) {


### PR DESCRIPTION
## Why

`ValidateOptions` (#1777) documented what it checks but not what it doesn't, and the gap is the kind a caller fills in optimistically. Its intended consumer is a deploy adapter gating a release — exactly the reader most likely to treat a nil return as "this deployment will work."

Verified rather than assumed: with `OPENAI_API_KEY` unset, `ValidateOptions(WithTTSProvider{Type: "openai"})` returns `nil`. A missing key resolves to a no-op credential, and an invalid key resolves fine, so a provider guaranteed to fail authentication on its first real call validates clean.

## What the boundary actually is

| Caught | Not caught |
|---|---|
| Unregistered or misspelled provider type | Missing or invalid credentials |
| An option that fails to construct | Endpoint reachability, region, IAM policy |
| Violated cross-option constraints | Whether the model exists on that platform |

This is still the failure mode that prompted the work — every broken role in #1774 was an unregistered type — but "validates" must not be read as "will serve traffic."

## Changes

Doc comment on `ValidateOptions` states the two exclusions explicitly, and closes on the distinction a caller needs: a nil return means the configuration builds, not that the deployment will work.

Pinned with a test rather than left to prose, since a doc comment cannot fail: both calls carry an unusable credential, and only the one naming an unregistered type is rejected. The unregistered type is `transcribe` — the STT type a Bedrock deployment reaches for, per #1774's table — so the test doubles as a record of that gap.

SDK reference regenerated for the godoc change.

Refs #1776
