### PR TITLE
feat(providers): add Bedrock-native embedding provider (Titan/Cohere)

### DIFF
--- a/runtime/providers/bedrock/embedding.go
+++ b/runtime/providers/bedrock/embedding.go
@@ -1,0 +1,263 @@
+// Package bedrock provides embedding generation via AWS Bedrock's
+// platform-native models. Unlike the OpenAI-compatible providers, Bedrock
+// embeddings use per-family request and response bodies posted to
+// /model/{modelId}/invoke, so they need their own provider type rather than a
+// transport-level rewrite of the OpenAI wire format.
+//
+// Two families are supported, selected from the model id:
+//
+//   - Amazon Titan (amazon.titan-embed-*): one text per call, {"inputText": …}
+//   - Cohere (cohere.embed-*): natively batched, {"texts": […], "input_type": …}
+//
+// Authentication is AWS SigV4, applied by the HTTP client's transport (see
+// providers.ResolveEmbeddingTransport with platform "bedrock"), so this
+// package never handles credentials directly.
+package bedrock
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// Model family prefixes used to select the wire format.
+const (
+	titanModelPrefix  = "amazon.titan-embed"
+	cohereModelPrefix = "cohere.embed"
+)
+
+// DefaultModel is Amazon's current general-purpose embedding model.
+const DefaultModel = "amazon.titan-embed-text-v2:0"
+
+// Dimension defaults per family. Titan v2 emits 1024 by default (configurable
+// to 512/256); Titan v1 emits 1536; Cohere v3 emits 1024.
+const (
+	titanV2Dimensions  = 1024
+	titanV1Dimensions  = 1536
+	cohereDimensions   = 1024
+	titanV1ModelSuffix = "text-v1"
+)
+
+// Batch limits. Titan's InvokeModel body carries a single string, so a
+// multi-text request must fan out; Cohere accepts an array.
+const (
+	titanMaxBatch  = 1
+	cohereMaxBatch = 96
+)
+
+// DefaultInputType is Cohere's required input_type for indexing documents.
+// Use "search_query" when embedding a query for retrieval.
+const DefaultInputType = "search_document"
+
+const bedrockTimeout = 60 * time.Second
+
+// EmbeddingProvider implements embedding generation via AWS Bedrock.
+type EmbeddingProvider struct {
+	*providers.BaseEmbeddingProvider
+	inputType string
+	// dimsExplicit records that the caller set Dimensions, so the family
+	// default must not overwrite it — tracking the intent rather than
+	// comparing against a default value, which cannot distinguish "unset"
+	// from "set to the same number".
+	dimsExplicit bool
+}
+
+// EmbeddingOption configures the EmbeddingProvider.
+type EmbeddingOption func(*EmbeddingProvider)
+
+// WithModel sets the Bedrock model id (e.g. amazon.titan-embed-text-v2:0).
+func WithModel(model string) EmbeddingOption {
+	return func(p *EmbeddingProvider) { p.ProviderModel = model }
+}
+
+// WithBaseURL overrides the Bedrock runtime host. The provider appends
+// /model/{modelId}/invoke per request.
+func WithBaseURL(url string) EmbeddingOption {
+	return func(p *EmbeddingProvider) { p.BaseURL = url }
+}
+
+// WithHTTPClient sets the HTTP client. For real use this must be the
+// SigV4-applying client from providers.ResolveEmbeddingTransport.
+func WithHTTPClient(client *http.Client) EmbeddingOption {
+	return func(p *EmbeddingProvider) { p.HTTPClient = client }
+}
+
+// WithDimensions overrides the reported embedding dimensionality.
+func WithDimensions(dims int) EmbeddingOption {
+	return func(p *EmbeddingProvider) {
+		p.Dimensions = dims
+		p.dimsExplicit = true
+	}
+}
+
+// WithInputType sets Cohere's input_type ("search_document" or
+// "search_query"). Ignored by Titan, which has no equivalent.
+func WithInputType(inputType string) EmbeddingOption {
+	return func(p *EmbeddingProvider) { p.inputType = inputType }
+}
+
+// WithPlatformAuth marks the provider as authenticated by its HTTP client's
+// transport. Bedrock has no API-key mode, so this is always the case in real
+// use; the flag exists for symmetry with the other embedding providers.
+func WithPlatformAuth() EmbeddingOption {
+	return func(p *EmbeddingProvider) { p.PlatformAuth = true }
+}
+
+// NewEmbeddingProvider creates a Bedrock embedding provider. It fails when the
+// model is not a recognized embedding family, rather than guessing a wire
+// format that the endpoint would reject at request time.
+func NewEmbeddingProvider(opts ...EmbeddingOption) (*EmbeddingProvider, error) {
+	p := &EmbeddingProvider{
+		BaseEmbeddingProvider: providers.NewBaseEmbeddingProvider(
+			"bedrock-embedding", DefaultModel, "", titanV2Dimensions, titanMaxBatch, bedrockTimeout,
+		),
+		inputType: DefaultInputType,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	dims, batch, err := familyDefaults(p.ProviderModel)
+	if err != nil {
+		return nil, err
+	}
+	p.BatchSize = batch
+	if !p.dimsExplicit {
+		p.Dimensions = dims
+	}
+	return p, nil
+}
+
+// familyDefaults returns the dimension and batch defaults for a model id, and
+// an error when the model is not a known Bedrock embedding family.
+func familyDefaults(model string) (dims, batch int, err error) {
+	switch {
+	case strings.HasPrefix(model, titanModelPrefix):
+		if strings.Contains(model, titanV1ModelSuffix) {
+			return titanV1Dimensions, titanMaxBatch, nil
+		}
+		return titanV2Dimensions, titanMaxBatch, nil
+	case strings.HasPrefix(model, cohereModelPrefix):
+		return cohereDimensions, cohereMaxBatch, nil
+	default:
+		return 0, 0, fmt.Errorf(
+			"unsupported bedrock embedding model %q: expected an %s* or %s* model",
+			model, titanModelPrefix, cohereModelPrefix)
+	}
+}
+
+// invokeURL builds the Bedrock InvokeModel URL for a model. The model id is
+// part of the path (and may contain ':'), which the SigV4 signer URI-encodes.
+func (p *EmbeddingProvider) invokeURL(model string) string {
+	return strings.TrimSuffix(p.BaseURL, "/") + "/model/" + model + "/invoke"
+}
+
+// titanRequest is Amazon Titan's InvokeModel body: exactly one text.
+type titanRequest struct {
+	InputText string `json:"inputText"`
+}
+
+type titanResponse struct {
+	Embedding           []float32 `json:"embedding"`
+	InputTextTokenCount int       `json:"inputTextTokenCount"`
+}
+
+// cohereRequest is Cohere's InvokeModel body. input_type is required.
+type cohereRequest struct {
+	Texts     []string `json:"texts"`
+	InputType string   `json:"input_type"`
+}
+
+type cohereResponse struct {
+	Embeddings [][]float32 `json:"embeddings"`
+}
+
+// Embed generates embeddings for the given texts.
+func (p *EmbeddingProvider) Embed(
+	ctx context.Context, req providers.EmbeddingRequest,
+) (providers.EmbeddingResponse, error) {
+	return p.EmbedWithEmptyCheck(ctx, req, p.embedTexts)
+}
+
+func (p *EmbeddingProvider) embedTexts(
+	ctx context.Context, texts []string, model string,
+) (providers.EmbeddingResponse, error) {
+	if strings.HasPrefix(model, cohereModelPrefix) {
+		return p.embedCohere(ctx, texts, model)
+	}
+	return p.embedTitan(ctx, texts, model)
+}
+
+// embedTitan fans out one request per text and reassembles in order. Titan's
+// body holds a single string, so batching cannot be pushed to the endpoint.
+func (p *EmbeddingProvider) embedTitan(
+	ctx context.Context, texts []string, model string,
+) (providers.EmbeddingResponse, error) {
+	start := time.Now()
+	embeddings := make([][]float32, len(texts))
+	total := 0
+
+	for i, text := range texts {
+		body, err := providers.MarshalRequest(titanRequest{InputText: text})
+		if err != nil {
+			return providers.EmbeddingResponse{}, err
+		}
+		respBytes, err := p.DoEmbeddingRequest(ctx, providers.HTTPRequestConfig{
+			URL:  p.invokeURL(model),
+			Body: body,
+		})
+		if err != nil {
+			return providers.EmbeddingResponse{}, err
+		}
+		var resp titanResponse
+		if err := providers.UnmarshalResponse(respBytes, &resp); err != nil {
+			return providers.EmbeddingResponse{}, err
+		}
+		embeddings[i] = resp.Embedding
+		total += resp.InputTextTokenCount
+	}
+
+	providers.LogEmbeddingRequestWithTokens("Bedrock Titan", model, len(texts), total, start)
+	return providers.EmbeddingResponse{
+		Embeddings: embeddings,
+		Model:      model,
+		Usage:      &providers.EmbeddingUsage{TotalTokens: total},
+	}, nil
+}
+
+// embedCohere sends all texts in one call; Cohere returns them in input order.
+func (p *EmbeddingProvider) embedCohere(
+	ctx context.Context, texts []string, model string,
+) (providers.EmbeddingResponse, error) {
+	start := time.Now()
+	inputType := p.inputType
+	if inputType == "" {
+		inputType = DefaultInputType
+	}
+
+	body, err := providers.MarshalRequest(cohereRequest{Texts: texts, InputType: inputType})
+	if err != nil {
+		return providers.EmbeddingResponse{}, err
+	}
+	respBytes, err := p.DoEmbeddingRequest(ctx, providers.HTTPRequestConfig{
+		URL:  p.invokeURL(model),
+		Body: body,
+	})
+	if err != nil {
+		return providers.EmbeddingResponse{}, err
+	}
+	var resp cohereResponse
+	if err := providers.UnmarshalResponse(respBytes, &resp); err != nil {
+		return providers.EmbeddingResponse{}, err
+	}
+
+	providers.LogEmbeddingRequest("Bedrock Cohere", model, len(texts), start)
+	return providers.EmbeddingResponse{Embeddings: resp.Embeddings, Model: model}, nil
+}
+
+// Verify interface compliance.
+var _ providers.EmbeddingProvider = (*EmbeddingProvider)(nil)

--- a/runtime/providers/bedrock/embedding_integration_test.go
+++ b/runtime/providers/bedrock/embedding_integration_test.go
@@ -1,0 +1,141 @@
+//go:build integration
+
+// Live AWS Bedrock embedding tests. Exercises the full path the unit tests
+// stub out: SigV4 signing of the request body through the platform
+// RoundTripper, the /model/{modelId}/invoke URL with its ':' version suffix
+// percent-encoded, and the real Titan/Cohere response shapes.
+//
+// Run locally:
+//
+//	export AWS_PROFILE=<profile-with-bedrock-access>
+//	export AWS_REGION=us-west-2
+//	go test -tags=integration ./runtime/providers/bedrock/... -v
+//
+// Tests skip when AWS credentials are unavailable. Live calls additionally
+// require Bedrock model access for the chosen model in the chosen region;
+// Cohere coverage is opt-in via BEDROCK_COHERE_MODEL because model access is
+// granted per-model and most accounts enable Titan only.
+package bedrock_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func integrationRegion() string {
+	if r := os.Getenv("AWS_REGION"); r != "" {
+		return r
+	}
+	return "us-west-2"
+}
+
+func skipIfNoAWS(t *testing.T) {
+	t.Helper()
+	if _, err := credentials.NewAWSCredential(context.Background(), integrationRegion()); err != nil {
+		t.Skipf("AWS credentials not available: %v", err)
+	}
+}
+
+// liveProvider builds the provider exactly as a caller would — through the
+// factory and the platform transport — so the test covers the real wiring
+// rather than a hand-assembled struct.
+func liveProvider(t *testing.T, model string) providers.EmbeddingProvider {
+	t.Helper()
+	skipIfNoAWS(t)
+
+	cred, err := credentials.NewAWSCredential(context.Background(), integrationRegion())
+	require.NoError(t, err)
+
+	p, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		ID:       "embed",
+		Type:     "bedrock",
+		Model:    model,
+		Platform: "bedrock",
+		PlatformConfig: &credentials.PlatformConfig{
+			Type: "bedrock", Region: integrationRegion(),
+		},
+		Credential: cred,
+	})
+	require.NoError(t, err)
+	return p
+}
+
+func TestLiveTitanEmbedsSingleText(t *testing.T) {
+	p := liveProvider(t, "amazon.titan-embed-text-v2:0")
+
+	got, err := p.Embed(context.Background(), providers.EmbeddingRequest{
+		Texts: []string{"PromptKit runs on Bedrock."},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, got.Embeddings, 1)
+	assert.Len(t, got.Embeddings[0], p.EmbeddingDimensions(),
+		"live vector width must match the advertised dimensions")
+	assert.NotZero(t, got.Usage.TotalTokens)
+}
+
+// The fan-out path is the one most likely to break against the real endpoint:
+// each call is signed independently, and the body must be re-signed per text.
+func TestLiveTitanFansOutMultipleTexts(t *testing.T) {
+	p := liveProvider(t, "amazon.titan-embed-text-v2:0")
+
+	got, err := p.Embed(context.Background(), providers.EmbeddingRequest{
+		Texts: []string{"first document", "second document", "third document"},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, got.Embeddings, 3)
+	for i, v := range got.Embeddings {
+		assert.NotEmpty(t, v, "embedding %d is empty", i)
+	}
+	assert.NotEqual(t, got.Embeddings[0], got.Embeddings[1],
+		"distinct inputs must produce distinct vectors — equal ones would mean "+
+			"the same text was sent every time")
+}
+
+func TestLiveTitanV1(t *testing.T) {
+	p := liveProvider(t, "amazon.titan-embed-text-v1")
+
+	got, err := p.Embed(context.Background(), providers.EmbeddingRequest{
+		Texts: []string{"version one"},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, got.Embeddings, 1)
+	assert.Len(t, got.Embeddings[0], p.EmbeddingDimensions())
+}
+
+func TestLiveCohereBatches(t *testing.T) {
+	model := os.Getenv("BEDROCK_COHERE_MODEL")
+	if model == "" {
+		t.Skip("set BEDROCK_COHERE_MODEL (e.g. cohere.embed-english-v3) to run Cohere coverage")
+	}
+	p := liveProvider(t, model)
+
+	got, err := p.Embed(context.Background(), providers.EmbeddingRequest{
+		Texts: []string{"alpha", "beta"},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, got.Embeddings, 2)
+	assert.NotEqual(t, got.Embeddings[0], got.Embeddings[1])
+}
+
+// A model the account cannot reach must surface as a provider error rather
+// than a panic or a silently empty result.
+func TestLiveUnauthorizedModelSurfacesError(t *testing.T) {
+	p := liveProvider(t, "amazon.titan-embed-text-v2:0")
+
+	_, err := p.Embed(context.Background(), providers.EmbeddingRequest{
+		Texts: []string{"probe"},
+		Model: "amazon.titan-embed-does-not-exist-v9:0",
+	})
+
+	require.Error(t, err)
+}

--- a/runtime/providers/bedrock/embedding_register.go
+++ b/runtime/providers/bedrock/embedding_register.go
@@ -1,0 +1,53 @@
+package bedrock
+
+import (
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+//nolint:gochecknoinits // Factory registration requires init
+func init() {
+	providers.RegisterEmbeddingProviderFactory("bedrock",
+		func(spec providers.EmbeddingProviderSpec) (providers.EmbeddingProvider, error) {
+			// Bedrock has no API-key mode: without a platform block there is no
+			// SigV4 signer and every request would go unsigned. Fail here rather
+			// than once per request.
+			if spec.Platform == "" {
+				return nil, fmt.Errorf(
+					"bedrock embedding provider requires a platform block " +
+						"(platform.type: bedrock, platform.region: <region>)")
+			}
+			tr, err := providers.ResolveEmbeddingTransport(spec)
+			if err != nil {
+				return nil, err
+			}
+			return NewEmbeddingProvider(optionsFromSpec(spec, tr)...)
+		},
+	)
+}
+
+// optionsFromSpec translates a resolved spec and transport into constructor
+// options.
+func optionsFromSpec(spec providers.EmbeddingProviderSpec, tr providers.EmbeddingTransport) []EmbeddingOption {
+	opts := []EmbeddingOption{}
+	if spec.Model != "" {
+		opts = append(opts, WithModel(spec.Model))
+	}
+	if tr.BaseURL != "" {
+		opts = append(opts, WithBaseURL(tr.BaseURL))
+	}
+	if tr.Client != nil {
+		opts = append(opts, WithHTTPClient(tr.Client))
+	}
+	if tr.PlatformAuth {
+		opts = append(opts, WithPlatformAuth())
+	}
+	if dims, ok := providers.IntFromConfig(spec.AdditionalConfig, "dimensions"); ok {
+		opts = append(opts, WithDimensions(dims))
+	}
+	if v, ok := spec.AdditionalConfig["input_type"].(string); ok && v != "" {
+		opts = append(opts, WithInputType(v))
+	}
+	return opts
+}

--- a/runtime/providers/bedrock/embedding_register_test.go
+++ b/runtime/providers/bedrock/embedding_register_test.go
@@ -1,0 +1,83 @@
+package bedrock_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// Side-effect import registers the factory under test.
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/bedrock"
+)
+
+func TestFactoryIsRegistered(t *testing.T) {
+	assert.Contains(t, providers.RegisteredEmbeddingProviderTypes(), "bedrock")
+}
+
+// The end-to-end path #1774 reported as broken: type "bedrock" with a Bedrock
+// platform block must now construct instead of returning "unsupported
+// embedding provider type".
+func TestFactoryBuildsProviderFromSpec(t *testing.T) {
+	p, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		ID:             "embed",
+		Type:           "bedrock",
+		Model:          "amazon.titan-embed-text-v2:0",
+		Platform:       "bedrock",
+		PlatformConfig: &credentials.PlatformConfig{Type: "bedrock", Region: "us-west-2"},
+		Credential:     credentials.NewAPIKeyCredential("stub"),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, "bedrock-embedding", p.ID())
+}
+
+func TestFactoryPassesInputTypeThrough(t *testing.T) {
+	p, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type:             "bedrock",
+		Model:            "cohere.embed-english-v3",
+		Platform:         "bedrock",
+		PlatformConfig:   &credentials.PlatformConfig{Type: "bedrock", Region: "us-west-2"},
+		Credential:       credentials.NewAPIKeyCredential("stub"),
+		AdditionalConfig: map[string]any{"input_type": "search_query"},
+	})
+
+	require.NoError(t, err)
+	// Cohere batches, so the batch size proves the model family was honored
+	// rather than defaulted to Titan's single-text limit.
+	assert.Greater(t, p.MaxBatchSize(), 1)
+}
+
+func TestFactoryPassesDimensionsThrough(t *testing.T) {
+	p, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type:             "bedrock",
+		Model:            "amazon.titan-embed-text-v2:0",
+		Platform:         "bedrock",
+		PlatformConfig:   &credentials.PlatformConfig{Type: "bedrock", Region: "us-west-2"},
+		Credential:       credentials.NewAPIKeyCredential("stub"),
+		AdditionalConfig: map[string]any{"dimensions": 256},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 256, p.EmbeddingDimensions())
+}
+
+// Without a platform block there is no SigV4 signer, so every request would go
+// unsigned and be rejected. Failing at construction beats failing per request.
+func TestFactoryRequiresPlatformConfig(t *testing.T) {
+	_, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type:  "bedrock",
+		Model: "amazon.titan-embed-text-v2:0",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "platform")
+}
+
+func TestBedrockIsListedAmongEmbeddingTypes(t *testing.T) {
+	got := providers.RegisteredEmbeddingProviderTypes()
+	assert.True(t, slices.IsSorted(got), "%v not sorted", got)
+}

--- a/runtime/providers/bedrock/embedding_test.go
+++ b/runtime/providers/bedrock/embedding_test.go
@@ -1,0 +1,268 @@
+package bedrock_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/bedrock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// capture records what the fake Bedrock endpoint received, so tests can assert
+// on the wire format rather than on a mock's call count.
+type capture struct {
+	paths  []string
+	bodies []map[string]any
+}
+
+func fakeBedrock(t *testing.T, respond func(i int) string) (*httptest.Server, *capture) {
+	t.Helper()
+	c := &capture{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		c.paths = append(c.paths, r.URL.Path)
+		c.bodies = append(c.bodies, body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(respond(len(c.bodies) - 1)))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, c
+}
+
+func titanProvider(t *testing.T, url string) *bedrock.EmbeddingProvider {
+	t.Helper()
+	p, err := bedrock.NewEmbeddingProvider(
+		bedrock.WithModel("amazon.titan-embed-text-v2:0"),
+		bedrock.WithBaseURL(url),
+		bedrock.WithPlatformAuth(),
+	)
+	require.NoError(t, err)
+	return p
+}
+
+func cohereProvider(t *testing.T, url string) *bedrock.EmbeddingProvider {
+	t.Helper()
+	p, err := bedrock.NewEmbeddingProvider(
+		bedrock.WithModel("cohere.embed-english-v3"),
+		bedrock.WithBaseURL(url),
+		bedrock.WithPlatformAuth(),
+	)
+	require.NoError(t, err)
+	return p
+}
+
+// Titan takes a single string under "inputText" — not OpenAI's {"model","input"}
+// and not Cohere's {"texts"}. Sending the wrong shape is the failure this whole
+// provider exists to avoid, so it is asserted on the decoded request body.
+func TestTitan_RequestUsesInputTextShape(t *testing.T) {
+	srv, c := fakeBedrock(t, func(int) string { return `{"embedding":[0.5,0.25],"inputTextTokenCount":3}` })
+
+	_, err := titanProvider(t, srv.URL).Embed(context.Background(),
+		providers.EmbeddingRequest{Texts: []string{"hello"}})
+
+	require.NoError(t, err)
+	require.Len(t, c.bodies, 1)
+	assert.Equal(t, "hello", c.bodies[0]["inputText"])
+	assert.NotContains(t, c.bodies[0], "input", "must not send the OpenAI field")
+	assert.NotContains(t, c.bodies[0], "texts", "must not send the Cohere field")
+}
+
+func TestTitan_ParsesEmbeddingAndTokenCount(t *testing.T) {
+	srv, _ := fakeBedrock(t, func(int) string { return `{"embedding":[0.5,0.25],"inputTextTokenCount":3}` })
+
+	got, err := titanProvider(t, srv.URL).Embed(context.Background(),
+		providers.EmbeddingRequest{Texts: []string{"hello"}})
+
+	require.NoError(t, err)
+	assert.Equal(t, [][]float32{{0.5, 0.25}}, got.Embeddings)
+	require.NotNil(t, got.Usage)
+	assert.Equal(t, 3, got.Usage.TotalTokens)
+}
+
+// Titan embeds one text per call, so a multi-text request must fan out and
+// reassemble in order. A provider that sent only the first text, or that
+// collected results out of order, fails here.
+func TestTitan_FansOutOneCallPerTextPreservingOrder(t *testing.T) {
+	vectors := []string{
+		`{"embedding":[1],"inputTextTokenCount":1}`,
+		`{"embedding":[2],"inputTextTokenCount":2}`,
+		`{"embedding":[3],"inputTextTokenCount":4}`,
+	}
+	srv, c := fakeBedrock(t, func(i int) string { return vectors[i] })
+
+	got, err := titanProvider(t, srv.URL).Embed(context.Background(),
+		providers.EmbeddingRequest{Texts: []string{"a", "b", "c"}})
+
+	require.NoError(t, err)
+	assert.Equal(t, [][]float32{{1}, {2}, {3}}, got.Embeddings)
+	require.Len(t, c.bodies, 3, "one call per text")
+	assert.Equal(t, []any{"a", "b", "c"},
+		[]any{c.bodies[0]["inputText"], c.bodies[1]["inputText"], c.bodies[2]["inputText"]})
+	assert.Equal(t, 7, got.Usage.TotalTokens, "token counts must sum across calls")
+}
+
+// The Bedrock invoke path carries the model id, including its ":" version
+// suffix. A provider that posted to a bare host, or dropped the model, fails.
+func TestTitan_PostsToModelInvokePath(t *testing.T) {
+	srv, c := fakeBedrock(t, func(int) string { return `{"embedding":[1],"inputTextTokenCount":1}` })
+
+	_, err := titanProvider(t, srv.URL).Embed(context.Background(),
+		providers.EmbeddingRequest{Texts: []string{"hello"}})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/model/amazon.titan-embed-text-v2:0/invoke", c.paths[0])
+}
+
+// A per-request model override must retarget the invoke path, since the model
+// lives in the URL rather than the body.
+func TestTitan_RequestModelOverrideRetargetsPath(t *testing.T) {
+	srv, c := fakeBedrock(t, func(int) string { return `{"embedding":[1],"inputTextTokenCount":1}` })
+
+	_, err := titanProvider(t, srv.URL).Embed(context.Background(),
+		providers.EmbeddingRequest{Texts: []string{"hello"}, Model: "amazon.titan-embed-text-v1"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/model/amazon.titan-embed-text-v1/invoke", c.paths[0])
+}
+
+// Cohere is natively batched and requires input_type; it must not be driven
+// through the Titan path.
+func TestCohere_RequestUsesTextsShapeWithInputType(t *testing.T) {
+	srv, c := fakeBedrock(t, func(int) string { return `{"embeddings":[[1,2],[3,4]]}` })
+
+	_, err := cohereProvider(t, srv.URL).Embed(context.Background(),
+		providers.EmbeddingRequest{Texts: []string{"a", "b"}})
+
+	require.NoError(t, err)
+	require.Len(t, c.bodies, 1, "cohere batches — one call for both texts")
+	assert.Equal(t, []any{"a", "b"}, c.bodies[0]["texts"])
+	assert.NotEmpty(t, c.bodies[0]["input_type"], "cohere rejects a request without input_type")
+	assert.NotContains(t, c.bodies[0], "inputText", "must not send the Titan field")
+}
+
+func TestCohere_ParsesEmbeddingsInOrder(t *testing.T) {
+	srv, _ := fakeBedrock(t, func(int) string { return `{"embeddings":[[1,2],[3,4]]}` })
+
+	got, err := cohereProvider(t, srv.URL).Embed(context.Background(),
+		providers.EmbeddingRequest{Texts: []string{"a", "b"}})
+
+	require.NoError(t, err)
+	assert.Equal(t, [][]float32{{1, 2}, {3, 4}}, got.Embeddings)
+}
+
+func TestCohere_InputTypeIsConfigurable(t *testing.T) {
+	srv, c := fakeBedrock(t, func(int) string { return `{"embeddings":[[1]]}` })
+	p, err := bedrock.NewEmbeddingProvider(
+		bedrock.WithModel("cohere.embed-english-v3"),
+		bedrock.WithBaseURL(srv.URL),
+		bedrock.WithPlatformAuth(),
+		bedrock.WithInputType("search_query"),
+	)
+	require.NoError(t, err)
+
+	_, err = p.Embed(context.Background(), providers.EmbeddingRequest{Texts: []string{"a"}})
+
+	require.NoError(t, err)
+	assert.Equal(t, "search_query", c.bodies[0]["input_type"])
+}
+
+// Batch sizes differ by family; a single shared constant would be wrong for one
+// of them and would drive callers into malformed requests.
+func TestMaxBatchSizeDiffersByModelFamily(t *testing.T) {
+	assert.Equal(t, 1, titanProvider(t, "http://unused").MaxBatchSize(),
+		"titan embeds one text per call")
+	assert.Greater(t, cohereProvider(t, "http://unused").MaxBatchSize(), 1,
+		"cohere batches natively")
+}
+
+func TestUnknownModelFamilyIsRejectedAtConstruction(t *testing.T) {
+	_, err := bedrock.NewEmbeddingProvider(
+		bedrock.WithModel("meta.llama3-70b-instruct-v1:0"),
+		bedrock.WithPlatformAuth(),
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "meta.llama3-70b-instruct-v1:0",
+		"error must name the model so a misconfiguration is diagnosable")
+}
+
+func TestEmptyRequestMakesNoCall(t *testing.T) {
+	srv, c := fakeBedrock(t, func(int) string { return `{"embedding":[1]}` })
+
+	got, err := titanProvider(t, srv.URL).Embed(context.Background(),
+		providers.EmbeddingRequest{Texts: nil})
+
+	require.NoError(t, err)
+	assert.Empty(t, got.Embeddings)
+	assert.Empty(t, c.bodies, "no HTTP call for an empty request")
+}
+
+func TestHTTPErrorIsSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"not authorized"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := titanProvider(t, srv.URL).Embed(context.Background(),
+		providers.EmbeddingRequest{Texts: []string{"hello"}})
+
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "not authorized")
+}
+
+// A partial failure must not be reported as success with a short vector set.
+func TestTitan_FanOutStopsOnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	got, err := titanProvider(t, srv.URL).Embed(context.Background(),
+		providers.EmbeddingRequest{Texts: []string{"a", "b"}})
+
+	require.Error(t, err)
+	assert.Empty(t, got.Embeddings, "a failed fan-out must not return partial results")
+}
+
+// Titan v1 emits 1536, so its default must not be the v2 default.
+func TestDimensionsFollowModelVersion(t *testing.T) {
+	v1, err := bedrock.NewEmbeddingProvider(
+		bedrock.WithModel("amazon.titan-embed-text-v1"), bedrock.WithPlatformAuth())
+	require.NoError(t, err)
+	v2, err := bedrock.NewEmbeddingProvider(
+		bedrock.WithModel("amazon.titan-embed-text-v2:0"), bedrock.WithPlatformAuth())
+	require.NoError(t, err)
+
+	assert.NotEqual(t, v1.EmbeddingDimensions(), v2.EmbeddingDimensions())
+}
+
+// An explicit override must survive even when it equals another family's
+// default — otherwise "did the caller set this?" is confused with "is this the
+// default value?", and the override is silently discarded.
+func TestExplicitDimensionsOverrideFamilyDefault(t *testing.T) {
+	p, err := bedrock.NewEmbeddingProvider(
+		bedrock.WithModel("amazon.titan-embed-text-v1"),
+		bedrock.WithDimensions(1024),
+		bedrock.WithPlatformAuth(),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1024, p.EmbeddingDimensions())
+}
+
+func TestDimensionsDefaultPerFamily(t *testing.T) {
+	assert.Positive(t, titanProvider(t, "http://unused").EmbeddingDimensions())
+	assert.Positive(t, cohereProvider(t, "http://unused").EmbeddingDimensions())
+}
+
+// Interface compliance is asserted at compile time in embedding.go
+// (var _ providers.EmbeddingProvider = (*EmbeddingProvider)(nil)); a runtime
+// test of the same thing can never fail, so it is not repeated here.

--- a/runtime/providers/embedding_transport.go
+++ b/runtime/providers/embedding_transport.go
@@ -15,6 +15,9 @@ const (
 	platformBedrock     = "bedrock"
 	platformVertex      = "vertex"
 	embeddingTypeOpenAI = "openai"
+	// embeddingTypeBedrock speaks Bedrock's per-family InvokeModel bodies
+	// (Titan/Cohere) — see runtime/providers/bedrock.
+	embeddingTypeBedrock = "bedrock"
 )
 
 // EmbeddingTransport is the resolved HTTP wiring for a vendor embedding
@@ -80,13 +83,46 @@ func buildPlatformEmbeddingClient(
 			apiVersion: azureEmbeddingAPIVersion(pc),
 		}
 		return &http.Client{Transport: rt}, credentials.AzureOpenAIEndpoint(pc.Endpoint, model), nil
-	case platformBedrock, platformVertex:
+	case platformBedrock:
+		return buildBedrockEmbeddingClient(cred, providerType, pc)
+	case platformVertex:
 		return nil, "", fmt.Errorf(
 			"embedding platform %q is not yet supported: it requires a platform-native embedding "+
-				"provider type (Titan/Vertex body shapes), which is not implemented", platform)
+				"provider type (Vertex body shapes), which is not implemented", platform)
 	default:
 		return nil, "", fmt.Errorf("unsupported embedding platform: %q", platform)
 	}
+}
+
+// buildBedrockEmbeddingClient wires SigV4 auth and resolves the Bedrock
+// runtime host. Unlike Azure it returns the bare host, not a per-model URL:
+// Bedrock carries the model in the request path, so the provider appends
+// /model/{modelId}/invoke and a per-request model override still works.
+func buildBedrockEmbeddingClient(
+	cred credentials.Credential, providerType string, pc *PlatformConfig,
+) (*http.Client, string, error) {
+	if providerType != embeddingTypeBedrock {
+		return nil, "", fmt.Errorf(
+			"embedding platform %q requires the platform-native provider type %q (Titan/Cohere "+
+				"body shapes), got %q", platformBedrock, embeddingTypeBedrock, providerType)
+	}
+
+	baseURL := ""
+	if pc != nil {
+		baseURL = pc.Endpoint
+		if baseURL == "" && pc.Region != "" {
+			baseURL = credentials.BedrockEndpoint(pc.Region)
+		}
+	}
+	if baseURL == "" {
+		return nil, "", fmt.Errorf(
+			"embedding platform %q requires platform.region (or an explicit platform.endpoint)",
+			platformBedrock)
+	}
+
+	return &http.Client{
+		Transport: &platformEmbeddingRoundTripper{base: http.DefaultTransport, cred: cred},
+	}, baseURL, nil
 }
 
 // azureEmbeddingAPIVersion mirrors the chat path: prefer an explicit

--- a/runtime/providers/embedding_transport_test.go
+++ b/runtime/providers/embedding_transport_test.go
@@ -172,16 +172,103 @@ func TestResolveEmbeddingTransport_AzureRequiresOpenAIWire(t *testing.T) {
 	}
 }
 
-func TestResolveEmbeddingTransport_BedrockVertexGated(t *testing.T) {
-	for _, p := range []string{"bedrock", "vertex"} {
-		_, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
-			Type:           "openai",
-			Platform:       p,
-			PlatformConfig: &PlatformConfig{Type: p},
-			Credential:     &fakeCred{},
-		})
-		if err == nil || !strings.Contains(err.Error(), "not yet supported") {
-			t.Fatalf("platform %s: err = %v, want 'not yet supported'", p, err)
-		}
+func TestResolveEmbeddingTransport_VertexStillGated(t *testing.T) {
+	_, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
+		Type:           "openai",
+		Platform:       "vertex",
+		PlatformConfig: &PlatformConfig{Type: "vertex"},
+		Credential:     &fakeCred{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not yet supported") {
+		t.Fatalf("err = %v, want 'not yet supported'", err)
+	}
+}
+
+// Bedrock speaks its own per-model wire format, so an OpenAI-format provider
+// cannot be hosted on it. The error must point at the fix rather than repeat
+// the old blanket "not yet supported".
+func TestResolveEmbeddingTransport_BedrockRejectsOpenAIType(t *testing.T) {
+	_, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
+		Type:           "openai",
+		Platform:       "bedrock",
+		PlatformConfig: &PlatformConfig{Type: "bedrock", Region: "us-west-2"},
+		Credential:     &fakeCred{},
+	})
+	if err == nil {
+		t.Fatal("err = nil, want a type guard error")
+	}
+	if !strings.Contains(err.Error(), "bedrock") {
+		t.Fatalf("err = %v, want the error to name the required provider type", err)
+	}
+}
+
+func TestResolveEmbeddingTransport_BedrockResolvesRuntimeHost(t *testing.T) {
+	tr, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
+		Type:           "bedrock",
+		Model:          "amazon.titan-embed-text-v2:0",
+		Platform:       "bedrock",
+		PlatformConfig: &PlatformConfig{Type: "bedrock", Region: "eu-central-1"},
+		Credential:     &fakeCred{},
+	})
+	if err != nil {
+		t.Fatalf("ResolveEmbeddingTransport: %v", err)
+	}
+	if want := "https://bedrock-runtime.eu-central-1.amazonaws.com"; tr.BaseURL != want {
+		t.Errorf("BaseURL = %q, want %q", tr.BaseURL, want)
+	}
+	// The host, not a per-model URL: the provider appends /model/{id}/invoke so
+	// a per-request model override retargets correctly.
+	if strings.Contains(tr.BaseURL, "invoke") {
+		t.Errorf("BaseURL = %q, want the bare runtime host", tr.BaseURL)
+	}
+	if !tr.PlatformAuth || tr.Client == nil {
+		t.Errorf("PlatformAuth = %v, Client = %v, want platform-auth wiring", tr.PlatformAuth, tr.Client)
+	}
+	if tr.APIKey != "" {
+		t.Errorf("APIKey = %q, want empty — Bedrock has no API-key mode", tr.APIKey)
+	}
+}
+
+// Without a region there is no host to build, and defaulting one silently
+// would send traffic to the wrong account's region.
+func TestResolveEmbeddingTransport_BedrockRequiresRegion(t *testing.T) {
+	_, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
+		Type:           "bedrock",
+		Platform:       "bedrock",
+		PlatformConfig: &PlatformConfig{Type: "bedrock"},
+		Credential:     &fakeCred{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "region") {
+		t.Fatalf("err = %v, want a region requirement error", err)
+	}
+}
+
+// The credential must be applied to embedding requests, or they go unsigned
+// and Bedrock rejects them.
+func TestResolveEmbeddingTransport_BedrockAppliesCredential(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cred := &fakeCred{}
+	tr, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
+		Type:           "bedrock",
+		Platform:       "bedrock",
+		PlatformConfig: &PlatformConfig{Type: "bedrock", Region: "us-west-2"},
+		Credential:     cred,
+	})
+	if err != nil {
+		t.Fatalf("ResolveEmbeddingTransport: %v", err)
+	}
+
+	resp, err := tr.Client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if !cred.applied {
+		t.Error("credential was not applied to the request")
 	}
 }

--- a/sdk/provider_introspection_test.go
+++ b/sdk/provider_introspection_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	pkgconfig "github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,6 +52,38 @@ func TestRegisteredProviderTypes_CompletionRolesShareOneRegistry(t *testing.T) {
 	got := RegisteredProviderTypes()
 	assert.Equal(t, got[pkgconfig.RoleLLM], got[pkgconfig.RoleImage])
 	assert.Equal(t, got[pkgconfig.RoleLLM], got[pkgconfig.RoleVideo])
+}
+
+// The Bedrock embedding provider (#1300) is only reachable if the SDK links it
+// in. Without the blank import it exists but no SDK caller can construct it,
+// which is the exact shape of the gap #1774 reported.
+func TestRegisteredProviderTypes_IncludesBedrockEmbedding(t *testing.T) {
+	assert.Contains(t, RegisteredProviderTypes()[pkgconfig.RoleEmbedding], "bedrock")
+}
+
+// The binding #1774 reported as broken must now validate — and the platform
+// block must be what makes the difference. Bedrock has no API-key mode, so a
+// spec without one has no SigV4 signer and every request would go unsigned;
+// accepting it would be worse than the original error.
+func TestValidateOptions_AcceptsBedrockEmbeddingOnlyWithPlatform(t *testing.T) {
+	withPlatform := func(p *pkgconfig.PlatformConfig) []Option {
+		return []Option{
+			WithContextWindow(10),
+			WithStateStore(statestore.NewMemoryStore()),
+			WithEmbeddingProvider(ProviderSpec{
+				ID: "embed", Type: "bedrock",
+				Model: "amazon.titan-embed-text-v2:0", Platform: p,
+			}),
+		}
+	}
+
+	assert.NoError(t,
+		ValidateOptions(withPlatform(&pkgconfig.PlatformConfig{Type: "bedrock", Region: "us-west-2"})...),
+		"a Bedrock embedding binding must validate")
+
+	err := ValidateOptions(withPlatform(nil)...)
+	require.Error(t, err, "without a platform block there is no SigV4 signer")
+	assert.Contains(t, err.Error(), "platform")
 }
 
 func TestRegisteredProviderTypes_SortedPerRole(t *testing.T) {

--- a/sdk/runtime_config.go
+++ b/sdk/runtime_config.go
@@ -24,6 +24,7 @@ import (
 	// can resolve declarative entries.
 	// Chat-provider factories register through other SDK paths.
 	_ "github.com/AltairaLabs/PromptKit/runtime/classify/backends/all"
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/bedrock"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/gemini"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/imagen"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/ollama"


### PR DESCRIPTION
## What

Bedrock embeddings were gated in `buildPlatformEmbeddingClient`: any spec with platform `bedrock` returned "not yet supported" before a client was even built. A Bedrock-hosted deployment therefore had no embedding path at all, which is what made RAG impossible on AgentCore (#1774).

Adds `runtime/providers/bedrock` implementing `providers.EmbeddingProvider` over the two Bedrock embedding families, selected from the model id.

| Family | Body | Batching | Dimensions |
|---|---|---|---|
| `amazon.titan-embed-*` | `{"inputText": "…"}` | one text per call — provider fans out | v1 1536, v2 1024 |
| `cohere.embed-*` | `{"texts": […], "input_type": …}` | native, 96 | 1024 |

Titan's InvokeModel body carries a single string, so a multi-text request fans out and reassembles in order, summing token counts across calls. That fan-out is the part most likely to break subtly — a provider that sent only the first text, or reassembled out of order, would still "work" — so it is pinned by asserting the decoded request bodies and their order, not a call count.

The model lives in the request path, so the transport resolves the bare runtime host (`https://bedrock-runtime.<region>.amazonaws.com`) and the provider appends `/model/{modelId}/invoke` per request. That differs deliberately from the Azure branch, which returns a per-model URL: doing it this way means a per-request `Model` override retargets correctly instead of silently hitting the model configured at construction.

## Nothing new was needed for SigV4

Worth recording, since the issue flagged it as the risk: `credentials.signRequest` already reads, hashes and restores the request body, and already percent-encodes path segments — which is exactly what `amazon.titan-embed-text-v2:0` needs, since the `:` must be encoded. The existing `platformEmbeddingRoundTripper` applies it unchanged. The credential half of this issue was already done and proven by the chat path's live test.

## Failing early rather than per request

Construction rejects an unrecognized model family (naming the model) and a missing platform block. The second matters: Bedrock has no API-key mode, so a spec without a platform block has no SigV4 signer and every request would go out unsigned. Accepting it would be worse than the old error — the failure would move from construction to a 403 on every request.

Vertex stays gated, with its message narrowed to Vertex alone.

## Reachable from the SDK

Registered and blank-imported in `sdk/runtime_config.go`, so this is actually usable rather than merely present: `RegisteredProviderTypes()["embedding"]` now lists `bedrock`, and the exact binding from #1774's repro passes `ValidateOptions`.

## Testing

TDD throughout — every assertion watched failing first. Unit tests drive a fake Bedrock endpoint and assert on decoded request bodies, so sending the OpenAI or the wrong family's shape fails rather than passing on a lenient mock. Covered: both wire formats, fan-out order and token summing, invoke path including the `:` suffix, per-request model override, input_type default and override, per-family batch sizes and dimensions, explicit-dimension override surviving the family default, empty request making no call, HTTP error propagation, and a failed fan-out returning no partial results.

Live coverage is a `//go:build integration` suite that builds the provider through the real factory and transport, so it exercises the wiring rather than a hand-assembled struct. It skips without AWS credentials; Cohere is opt-in via `BEDROCK_COHERE_MODEL` because Bedrock model access is granted per model and most accounts enable Titan only.

```
export AWS_PROFILE=<profile-with-bedrock-access>
export AWS_REGION=us-west-2
go test -tags=integration ./runtime/providers/bedrock/... -v
```

**This has not been run against real Bedrock yet** — it needs an account with Titan model access granted. Everything above is httptest-level.

Full runtime and sdk suites pass; `golangci-lint --new-from-rev=main` clean; weak-assertion guard clean; both reference-drift gates up to date; new files at 90.9% / 95.2% coverage.

Closes #1300
