### PR TITLE
fix(vllm): serialize tool calls and tool_call_id back into requests

### DIFF
--- a/runtime/providers/vllm/vllm.go
+++ b/runtime/providers/vllm/vllm.go
@@ -110,6 +110,12 @@ type vllmMessage struct {
 	Role      string         `json:"role"`
 	Content   any            `json:"content"` // Can be string or []any for multimodal
 	ToolCalls []vllmToolCall `json:"tool_calls,omitempty"`
+	// ToolCallID links a role:"tool" message back to the assistant tool call
+	// it answers. OpenAI-compatible servers reject or ignore an unlinked tool
+	// message, which breaks multi-turn tool use.
+	ToolCallID string `json:"tool_call_id,omitempty"`
+	// Name carries the tool name on tool-result messages.
+	Name string `json:"name,omitempty"`
 }
 
 type vllmChatResponse struct {
@@ -180,13 +186,46 @@ func (p *Provider) prepareMessages(req *providers.PredictionRequest) ([]vllmMess
 
 	// Convert each message
 	for i := range req.Messages {
-		messages = append(messages, vllmMessage{
-			Role:    req.Messages[i].Role,
-			Content: req.Messages[i].GetContent(),
-		})
+		messages = append(messages, newVLLMMessage(req.Messages[i], req.Messages[i].GetContent()))
 	}
 
 	return messages, nil
+}
+
+// newVLLMMessage builds a wire message from a runtime message and its
+// already-resolved content, carrying the tool fields across.
+//
+// Tool fields are applied unconditionally rather than by a tool-aware variant
+// selected at a routing seam: they are omitempty, so a tool-free message
+// serializes byte-identically, and there is no wrong serializer left to route
+// to. Picking the tool-blind builder at such a seam is what broke the OpenAI
+// provider in #1735.
+func newVLLMMessage(msg types.Message, content any) vllmMessage {
+	out := vllmMessage{Role: msg.Role, Content: content}
+
+	if len(msg.ToolCalls) > 0 {
+		out.ToolCalls = make([]vllmToolCall, 0, len(msg.ToolCalls))
+		for _, call := range msg.ToolCalls {
+			out.ToolCalls = append(out.ToolCalls, vllmToolCall{
+				ID:   call.ID,
+				Type: toolTypeFunction,
+				Function: vllmFunctionCall{
+					Name: call.Name,
+					// vLLM takes arguments as a JSON string, not an object.
+					Arguments: string(call.Args),
+				},
+			})
+		}
+	}
+
+	// A tool result is unusable to the model without the id of the call it
+	// answers; OpenAI-compatible servers reject or ignore an unlinked one.
+	if msg.Role == "tool" && msg.ToolResult != nil {
+		out.ToolCallID = msg.ToolResult.ID
+		out.Name = msg.ToolResult.Name
+	}
+
+	return out
 }
 
 // applyRequestDefaults applies provider defaults to zero-valued request parameters

--- a/runtime/providers/vllm/vllm_multimodal.go
+++ b/runtime/providers/vllm/vllm_multimodal.go
@@ -48,16 +48,10 @@ func (p *Provider) prepareMultimodalMessages(req providers.PredictionRequest) ([
 			if err != nil {
 				return nil, fmt.Errorf("failed to build multimodal content for message %d: %w", i, err)
 			}
-			messages = append(messages, vllmMessage{
-				Role:    msg.Role,
-				Content: content,
-			})
+			messages = append(messages, newVLLMMessage(msg, content))
 		} else {
 			// Regular text-only message
-			messages = append(messages, vllmMessage{
-				Role:    msg.Role,
-				Content: msg.GetContent(),
-			})
+			messages = append(messages, newVLLMMessage(msg, msg.GetContent()))
 		}
 	}
 

--- a/runtime/providers/vllm/vllm_tool_serialization_test.go
+++ b/runtime/providers/vllm/vllm_tool_serialization_test.go
@@ -1,0 +1,240 @@
+package vllm
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// toolRoundTripHistory is the message history a second round of tool use
+// carries: the assistant turn that made the call, followed by its result.
+func toolRoundTripHistory() []types.Message {
+	return []types.Message{
+		{Role: "user", Content: "what is 6 times 7?"},
+		{
+			Role:    "assistant",
+			Content: "",
+			ToolCalls: []types.MessageToolCall{{
+				ID:   "call_abc123",
+				Name: "multiply",
+				Args: json.RawMessage(`{"a":6,"b":7}`),
+			}},
+		},
+		types.NewToolResultMessage(types.NewTextToolResult("call_abc123", "multiply", "42")),
+	}
+}
+
+// findByRole returns the first serialized message with the given role.
+func findByRole(t *testing.T, msgs []vllmMessage, role string) vllmMessage {
+	t.Helper()
+	for _, m := range msgs {
+		if m.Role == role {
+			return m
+		}
+	}
+	t.Fatalf("no %q message in %+v", role, msgs)
+	return vllmMessage{}
+}
+
+// The assistant's tool calls must survive serialization. Without this the model
+// is told it never made the call it just made, and round 2 of any tool
+// conversation is incoherent.
+func TestPrepareMessages_SerializesAssistantToolCalls(t *testing.T) {
+	p := &Provider{}
+
+	msgs, err := p.prepareMessages(&providers.PredictionRequest{Messages: toolRoundTripHistory()})
+
+	require.NoError(t, err)
+	assistant := findByRole(t, msgs, "assistant")
+	require.Len(t, assistant.ToolCalls, 1)
+	assert.Equal(t, "call_abc123", assistant.ToolCalls[0].ID)
+	assert.Equal(t, "function", assistant.ToolCalls[0].Type)
+	assert.Equal(t, "multiply", assistant.ToolCalls[0].Function.Name)
+	// vLLM takes arguments as a JSON *string*, not an object.
+	assert.JSONEq(t, `{"a":6,"b":7}`, assistant.ToolCalls[0].Function.Arguments)
+}
+
+// The tool result must carry tool_call_id or it cannot be attached to the call
+// that produced it — an OpenAI-compatible server will 400 or ignore it.
+func TestPrepareMessages_LinksToolResultToItsCall(t *testing.T) {
+	p := &Provider{}
+
+	msgs, err := p.prepareMessages(&providers.PredictionRequest{Messages: toolRoundTripHistory()})
+
+	require.NoError(t, err)
+	tool := findByRole(t, msgs, "tool")
+	assert.Equal(t, "call_abc123", tool.ToolCallID)
+	assert.Equal(t, "42", tool.Content)
+}
+
+// The invariant that matters end to end: every tool result references a call
+// the assistant actually made in the same request.
+func TestPrepareMessages_ToolRoundTripIsLinked(t *testing.T) {
+	p := &Provider{}
+
+	msgs, err := p.prepareMessages(&providers.PredictionRequest{Messages: toolRoundTripHistory()})
+
+	require.NoError(t, err)
+	called := map[string]bool{}
+	for _, m := range msgs {
+		for _, tc := range m.ToolCalls {
+			called[tc.ID] = true
+		}
+	}
+	for _, m := range msgs {
+		if m.Role == "tool" {
+			assert.True(t, called[m.ToolCallID],
+				"tool result %q references no tool call in the request", m.ToolCallID)
+		}
+	}
+	assert.NotEmpty(t, called, "no tool calls were serialized at all")
+}
+
+// The multimodal serializer is the other path into the same request body. A fix
+// applied to only one of the two leaves multimodal tool use broken.
+func TestPrepareMultimodalMessages_SerializesToolFields(t *testing.T) {
+	p := &Provider{}
+
+	msgs, err := p.prepareMultimodalMessages(providers.PredictionRequest{Messages: toolRoundTripHistory()})
+
+	require.NoError(t, err)
+	assistant := findByRole(t, msgs, "assistant")
+	require.Len(t, assistant.ToolCalls, 1)
+	assert.Equal(t, "call_abc123", assistant.ToolCalls[0].ID)
+	assert.Equal(t, "call_abc123", findByRole(t, msgs, "tool").ToolCallID)
+}
+
+// Tool-free requests must serialize exactly as before: the new fields are
+// omitempty, so no tool_calls or tool_call_id key may appear on the wire.
+func TestPrepareMessages_NoToolKeysForToolFreeMessages(t *testing.T) {
+	p := &Provider{}
+
+	msgs, err := p.prepareMessages(&providers.PredictionRequest{
+		System:   "be brief",
+		Messages: []types.Message{{Role: "user", Content: "hello"}},
+	})
+
+	require.NoError(t, err)
+	body, err := json.Marshal(msgs)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "tool_calls")
+	assert.NotContains(t, string(body), "tool_call_id")
+}
+
+// A failed tool must still be linked to its call. The pipeline builds failure
+// results the way handleToolResult does (stages_provider.go): the error text
+// goes into the content and Error is set alongside as structured metadata, so
+// the content path already carries it — but the link is what was missing.
+func TestPrepareMessages_FailedToolResultIsStillLinked(t *testing.T) {
+	p := &Provider{}
+	result := types.NewTextToolResult("call_err", "divide", "Tool execution failed: division by zero")
+	result.Error = "division by zero"
+
+	msgs, err := p.prepareMessages(&providers.PredictionRequest{
+		Messages: []types.Message{types.NewToolResultMessage(result)},
+	})
+
+	require.NoError(t, err)
+	tool := findByRole(t, msgs, "tool")
+	assert.Equal(t, "call_err", tool.ToolCallID)
+	assert.Contains(t, tool.Content, "division by zero")
+}
+
+// PredictWithTools is one of the two entry points the runtime uses; the fields
+// must survive all the way to the request body, not just the serializer.
+func TestPredictWithTools_SendsToolFieldsOnTheWire(t *testing.T) {
+	var got map[string]any
+	srv := newCapturingServer(t, &got)
+	p := newTestProvider(srv.URL)
+
+	_, _, err := p.PredictWithTools(t.Context(),
+		providers.PredictionRequest{Messages: toolRoundTripHistory()}, nil, "")
+	require.NoError(t, err)
+
+	assistant, tool := findWireMessages(t, got)
+	assert.NotEmpty(t, assistant["tool_calls"], "assistant tool_calls missing from request body")
+	assert.Equal(t, "call_abc123", tool["tool_call_id"])
+}
+
+func TestPredictStreamWithTools_SendsToolFieldsOnTheWire(t *testing.T) {
+	var got map[string]any
+	srv := newCapturingSSEServer(t, &got)
+	p := newTestProvider(srv.URL)
+
+	ch, err := p.PredictStreamWithTools(t.Context(),
+		providers.PredictionRequest{Messages: toolRoundTripHistory()}, nil, "")
+	require.NoError(t, err)
+	for range ch { //nolint:revive // drain the stream so the request completes
+	}
+
+	assistant, tool := findWireMessages(t, got)
+	assert.NotEmpty(t, assistant["tool_calls"], "assistant tool_calls missing from streamed request body")
+	assert.Equal(t, "call_abc123", tool["tool_call_id"])
+}
+
+func newTestProvider(url string) *Provider {
+	return NewProvider("vllm-test", "test-model", url, providers.ProviderDefaults{}, false, nil)
+}
+
+// newCapturingServer records the decoded request body and returns a minimal
+// non-tool completion.
+func newCapturingServer(t *testing.T, into *map[string]any) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(into))
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(vllmChatResponse{
+			ID: "chatcmpl-1", Model: "vllm-test",
+			Choices: []vllmChatChoice{{
+				Message:      vllmMessage{Role: "assistant", Content: "ok"},
+				FinishReason: "stop",
+			}},
+		}))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newCapturingSSEServer records the decoded request body and returns a minimal
+// terminated stream.
+func newCapturingSSEServer(t *testing.T, into *map[string]any) *httptest.Server {
+	t.Helper()
+	const sse = "data: {\"id\":\"c1\",\"model\":\"vllm-test\",\"choices\":" +
+		"[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\n" +
+		"data: [DONE]\n\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(into))
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sse))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// findWireMessages pulls the assistant and tool messages out of a captured
+// request body.
+func findWireMessages(t *testing.T, body map[string]any) (assistant, tool map[string]any) {
+	t.Helper()
+	raw, ok := body["messages"].([]any)
+	require.True(t, ok, "request body has no messages array: %v", body)
+	for _, m := range raw {
+		msg, ok := m.(map[string]any)
+		require.True(t, ok)
+		switch msg["role"] {
+		case "assistant":
+			assistant = msg
+		case "tool":
+			tool = msg
+		}
+	}
+	require.NotNil(t, assistant, "no assistant message on the wire")
+	require.NotNil(t, tool, "no tool message on the wire")
+	return assistant, tool
+}

--- a/runtime/providers/vllm/vllm_tools.go
+++ b/runtime/providers/vllm/vllm_tools.go
@@ -50,6 +50,9 @@ type vllmFunctionCall struct {
 	Arguments string `json:"arguments"` // vLLM returns this as a JSON string
 }
 
+// toolTypeFunction is the only tool type the OpenAI-compatible API defines.
+const toolTypeFunction = "function"
+
 // BuildTooling converts tool descriptors to vLLM format
 func (p *Provider) BuildTooling(descriptors []*providers.ToolDescriptor) (any, error) {
 	if len(descriptors) == 0 {


### PR DESCRIPTION
## The bug

vLLM read tool calls out of a response but never wrote them back into the next request. Multi-turn tool use was therefore broken after round 1, silently:

```
round 2 request body, before:
  {"role":"assistant","content":""}      ← tool_calls gone
  {"role":"tool","content":"42"}         ← no tool_call_id
```

The model is told it never made the call it just made, and the result has nothing to attach to. An OpenAI-compatible server either 400s the unlinked tool message or ignores it — either way, no diagnostic points here.

Both claims in #1746 verified in the code before touching anything:

- `vllmMessage.ToolCalls` existed (`vllm.go:112`) but neither serializer populated it.
- `vllmMessage` had no `tool_call_id` field at all, so a tool result could not reference its call whatever the serializer did.

## The fix, and why not a tool-aware serializer

The issue suggested adding a tool-aware serializer and routing `PredictWithTools` / `PredictStreamWithTools` to it. I did it the other way round: the existing builders now carry tool fields unconditionally through a shared `newVLLMMessage` helper.

The fields are `omitempty`, so a tool-free message serializes byte-identically — there is a test asserting no `tool_calls` or `tool_call_id` key appears for a plain request. The gain is that **no tool-blind variant is left to select by mistake**. Picking the wrong builder at exactly that seam is what broke the OpenAI provider in #1735; adding a second vLLM serializer would have rebuilt the same trap.

It also means `prepareMultimodalMessages` is fixed for free. It had the identical hole, and a tool-path-only fix would have left multimodal tool use broken — a second bug of the same shape, found the same way, some months later.

## One correction to the issue

#1746's acceptance criteria implied a tool result's `Error` needs serializing. Tracing how errors actually reach a result (`stages_provider.go:2212`) shows they don't need it: `handleToolResult` builds a failure as `NewTextToolResult(id, name, "Tool execution failed: <error>")` and sets `.Error` alongside as structured metadata. The error text already travels the normal content path, exactly as it does for OpenAI. I'd written a test asserting otherwise, which would have driven divergent special-case code; it now asserts what the pipeline really produces — that a *failed* tool result is still linked to its call.

## Sweep

The issue asked whether other OpenAI-compatible providers share the hole. Checked: **ollama already serializes `tool_calls`, `tool_call_id` and `name`** (`ollama_tools.go:211-217`). With OpenAI fixed in #1737 and vLLM here, that closes the set.

## Testing

TDD — every assertion watched failing first. The tests assert the invariant rather than a byte body, per #1742's shape:

- assistant `tool_calls` survive, with `arguments` as a JSON **string** (vLLM's format, not an object)
- tool result carries `tool_call_id` and its content
- round-trip linkage: every serialized tool result references a call present in the same request
- the multimodal serializer does the same — this fails if only one path is fixed
- tool-free requests emit no tool keys at all
- a failed tool result is still linked
- both entry points put the fields on the wire, verified against a capturing server for the buffered and streaming paths

That last pair matters: serializer-level tests alone would pass even if the tool paths bypassed the serializer entirely.

Full runtime suite passes; `golangci-lint --new-from-rev=main` clean; weak-assertion guard clean; changed files 92.2% / 91.7% / 83.9%.

Closes #1746
