### PR TITLE
refactor(docs): use the shared family-bar stylesheet

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -74,7 +74,7 @@ export default defineConfig({
         src: './public/atlas/logo-promptkit.svg',
         alt: 'PromptKit',
       },
-      customCss: ['./src/styles/custom.css'],
+      customCss: ['@altairalabs/brand/family-bar-starlight.css', './src/styles/custom.css'],
       // Atlas-themed code blocks: a distinct ink-void surface, mono code font,
       // hairline frame with a soft shadow, and a violet active-tab indicator —
       // so docs code blocks read as first-class, not the plain default.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "promptkit-docs",
       "version": "0.0.1",
       "dependencies": {
-        "@altairalabs/brand": "^0.2.0",
+        "@altairalabs/brand": "^0.4.0",
         "@astrojs/mdx": "^7.0.3",
         "@astrojs/sitemap": "^3.7.3",
         "@astrojs/starlight": "~0.41.4",
@@ -25,9 +25,9 @@
       }
     },
     "node_modules/@altairalabs/brand": {
-      "version": "0.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@altairalabs/brand/0.2.0/1823517b9aa8db000d7a7554c8c771256d89320a",
-      "integrity": "sha512-w8pLUAs3/bEk5ST+7NvWbPhT8tdpRy6KxOU0+qfPF4e7QS1rEkZr6ODtqDufOMNvkGmusjjXuvyResVCdLgOXg==",
+      "version": "0.4.0",
+      "resolved": "https://npm.pkg.github.com/download/@altairalabs/brand/0.4.0/fddfccb96e1410a3ade67fb305a80f4e0715143b",
+      "integrity": "sha512-3Bo8qim0whNiEm48PLFcw75UV89ljiZ2Cpq3Mi3+0kbjaSPF559H5QUUXz0dZPRbQboOaXIqF/tWKF4ejBxW0w==",
       "license": "UNLICENSED"
     },
     "node_modules/@antfu/install-pkg": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
     "check-doc-urls": "node check-doc-urls.js"
   },
   "dependencies": {
-    "@altairalabs/brand": "^0.2.0",
+    "@altairalabs/brand": "^0.4.0",
     "@astrojs/mdx": "^7.0.3",
     "@astrojs/sitemap": "^3.7.3",
     "@astrojs/starlight": "~0.41.4",

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -11,34 +11,6 @@
 @import './atlas/semantic.css';
 @import './atlas/starlight-map.css';
 
-/* ---- Family bar in the Starlight header ---- */
-/* Reserve a 38px masterbrand strip at the top of the fixed header: grow the
-   nav height by --fam-h so content/sidebar offsets stay correct, and push the
-   default header's nav content into the row below the strip. */
-:root {
-  --fam-h: 38px;
-  --sl-nav-height: calc(3.5rem + var(--fam-h));
-}
-@media (min-width: 50rem) {
-  :root {
-    --sl-nav-height: calc(4rem + var(--fam-h));
-  }
-}
-/* Scope to the <header> SHELL only — Starlight also gives the inner nav row
-   class="header sl-flex", and padding it breaks the nav's vertical centering. */
-header.header {
-  /* Reserve the strip PLUS the shell's natural top padding, so the nav row
-     stays vertically centered in the band below the family strip. */
-  padding-top: calc(var(--fam-h) + var(--sl-nav-pad-y));
-  /* Let the switcher dropdown escape the header bounds. */
-  overflow: visible;
-}
-/* Starlight sizes the logo from --sl-nav-height; pin it so the taller header
-   (which now includes the family strip) doesn't inflate the mark. */
-header.header .site-title img {
-  height: 2rem;
-  width: auto;
-}
 
 /* ---- Inner doc-chrome (Atlas) ---- */
 


### PR DESCRIPTION
Drops this site's copy of the Starlight header rules for the masterbrand strip, in favour of `@altairalabs/brand/family-bar-starlight.css`.

The block was **byte-identical in four repos** (omnia, promptarena, promptkit, codegen-sandbox), so the bar's height was defined in the package and *reserved* in four repositories. Changing the strip to 44px would have silently mis-offset every Starlight site — overlapping content or leaving a gap — until all four were edited.

The shared sheet is listed **first** in `customCss` so this site's own `custom.css` can still override it.

A test in the package asserts `--fam-h` matches the height `FamilyBar.astro` actually renders, so the two cannot drift.

**Verified locally:** site builds, and `--fam-h: 38px` plus the header padding rule are present in the built CSS — now sourced from the package rather than a local copy.