### PR TITLE
fix(sdk): keep the workflow conversation ID across resumed transitions

### DIFF
--- a/sdk/CLAUDE.md
+++ b/sdk/CLAUDE.md
@@ -40,12 +40,27 @@ c.toolRegistry.RegisterExecutor(localExec)  // Name() = "local"
 
 The runtime's ProviderStage dispatches to it identically to any other executor. **Do not create parallel execution paths** — always go through `tools.Executor`.
 
-### 2. Pipeline Built Per Send()
+### 2. Pipeline Built Once, at Open()
 
-Every `Send()` rebuilds the entire pipeline. This enables:
-- Dynamic tool registration between sends
-- Capability registration on first build (guarded by `capabilitiesRegistered`)
-- Handler snapshots at send time
+`Open()` builds the pipeline exactly once (`initInternalStateStore` →
+`buildPipelineWithParams` in `sdk.go`) and every `Send()` executes that same
+pipeline through the session. **`Send()` does not rebuild anything** —
+`executePipeline` just calls `unarySession.ExecuteWithMessage`. `OpenDuplex()`
+does the same for the streaming pipeline.
+
+Consequences, and they bite:
+
+- **Capabilities register their tools during that single build** (guarded by
+  `capabilitiesRegistered`), so a capability added later never registers.
+- **Build-time snapshots go stale.** `buildPipelineConfig` copies the handler
+  maps into `localExecutor`, so an `OnTool()` call made after `Open()` would be
+  invisible to it. That is why `localExecutor` also carries a `live`
+  `localHandlersAccessor` that reads the conversation's handler maps under its
+  mutex — the copy alone would fail post-Open registrations with "no handler
+  registered". Any new build-time snapshot needs the same treatment.
+- **A tool absent from the registry at build time stays absent.** Registering a
+  handler is not enough; register a live executor on `conv.ToolRegistry()`
+  (see `TestComposition_EmbeddedState_RunsViaSend`).
 
 ### 3. Deferred Workflow Transitions
 
@@ -83,7 +98,7 @@ Providers can be supplied three ways: programmatic instances (`WithProvider`, `W
 
 - **Don't duplicate runtime interfaces** — use `tools.Executor`, not a parallel dispatch mechanism
 - **Don't import `sdk/` from `runtime/`** — if both need it, it belongs in runtime
-- **Don't cache pipelines across Send() calls** — the per-Send rebuild is intentional
+- **Don't assume `Send()` rebuilds the pipeline** — it is built once at `Open()`, so anything that must see post-Open state needs a live accessor, not a build-time copy
 - **Don't execute workflow transitions immediately** — use the deferred pattern via `TransitionExecutor.Pending()`/`CommitPending()`
 
 ## Testing

--- a/sdk/workflow.go
+++ b/sdk/workflow.go
@@ -304,13 +304,17 @@ func ResumeWorkflow(workflowID, packPath string, opts ...Option) (*WorkflowConve
 	}
 
 	wc := &WorkflowConversation{
-		machine:                 machine,
-		workflowSpec:            spec,
-		packPath:                packPath,
-		sdkPack:                 p,
-		activeConv:              conv,
-		activeStateName:         machine.CurrentState(),
-		opts:                    opts,
+		machine:         machine,
+		workflowSpec:    spec,
+		packPath:        packPath,
+		sdkPack:         p,
+		activeConv:      conv,
+		activeStateName: machine.CurrentState(),
+		// optsWithID, not opts: openConvForCurrentState reuses this slice for
+		// every state entered after a transition, so the workflow ID has to be
+		// in it or the destination state's conversation is issued a fresh UUID
+		// and persists under a key no later Resume looks up.
+		opts:                    optsWithID,
 		stateStore:              cfg.stateStore,
 		workflowID:              workflowID,
 		contextCarryForward:     cfg.contextCarryForward,

--- a/sdk/workflow_test.go
+++ b/sdk/workflow_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/runtime/tools"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -789,6 +790,41 @@ func TestResumeWorkflow_ValidMetadataButOpenFails(t *testing.T) {
 		assert.Equal(t, "processing", wc.CurrentState())
 		_ = wc.Close()
 	}
+}
+
+// A resumed workflow runs every state under the workflow ID. ResumeWorkflow
+// threads WithConversationID into the conversation it opens for the state it
+// resumed into, so the ID must survive the first transition too — otherwise the
+// destination state's conversation gets a fresh UUID and its history is
+// persisted under a key no later Resume will ever look up.
+func TestResumeWorkflow_KeepsConversationIDAcrossTransition(t *testing.T) {
+	packPath := writeWorkflowTestPack(t, workflowPackJSON)
+	store := statestore.NewMemoryStore()
+	ctx := context.Background()
+
+	const workflowID = "wf-keep-conv-id"
+	require.NoError(t, store.Save(ctx, &statestore.ConversationState{
+		ID:       workflowID,
+		Metadata: map[string]any{workflowCurrentKey: &workflow.Context{CurrentState: "intake"}},
+	}))
+
+	wc, err := ResumeWorkflow(workflowID, packPath,
+		WithStateStore(store),
+		WithSkipSchemaValidation(),
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+	)
+	require.NoError(t, err)
+	defer wc.Close()
+
+	require.Equal(t, workflowID, wc.ActiveConversation().ID(),
+		"the resumed state's conversation runs under the workflow ID")
+
+	newState, err := wc.Transition("InfoComplete")
+	require.NoError(t, err)
+	require.Equal(t, "processing", newState)
+
+	assert.Equal(t, workflowID, wc.ActiveConversation().ID(),
+		"the destination state's conversation must keep the workflow ID, not be issued a fresh UUID")
 }
 
 func TestExtractWorkflowContext_MarshalError(t *testing.T) {


### PR DESCRIPTION
Two of the three loose ends listed under "Not included" in #1747.

## The bug

`ResumeWorkflow` builds `optsWithID` — the caller's options plus
`WithConversationID(workflowID)` — and opens the resumed state's conversation
with it. But it stores the **original** `opts` on the `WorkflowConversation`,
and `openConvForCurrentState` reuses that slice for every state entered
afterwards. So the ID lasts exactly one state:

```
conversation opened        id=wf-123        prompt=gather_info
workflow state transition  from=intake to=processing
conversation opened        id=1dd3997c-...  prompt=process
```

`Open()` generates a UUID when no ID is supplied, so the destination state is
not merely unlabeled — it is labeled *wrongly*, and confidently. From there the
turn's history, its events and its session hooks are keyed to an ID that no
later `ResumeWorkflow(workflowID, ...)` will ever load. A workflow resumed and
transitioned has its persistence silently split in two.

Storing the slice that already carries the ID is the whole fix.

`OpenWorkflow` is unaffected and deliberately left alone: a caller's own
`WithConversationID` is already in `opts` and therefore already propagates, and
a workflow opened without one is transient by design (`persistWorkflowContext`
skips it).

## Why no test caught it

Every existing `ResumeWorkflow` test stops at the state it resumed into —
several tolerate `Open()` failing outright ("May succeed or fail depending on
whether Open works without a provider"). The ID is correct at that point. It is
only the *second* conversation, the one a transition opens, that is wrong, and
nothing resumed and then transitioned.

The new test does exactly that — resume at `intake`, transition to
`processing`, assert the active conversation still reports the workflow ID.
Mutation-verified: reverting `opts: optsWithID` to `opts: opts` fails it with
the generated UUID.

## Second commit: a docs correction

`sdk/CLAUDE.md` claimed "Every `Send()` rebuilds the entire pipeline" and listed
"don't cache pipelines across Send() calls — the per-Send rebuild is
intentional" as a rule. `Open()` builds the pipeline once; `executePipeline` is
a straight call to `unarySession.ExecuteWithMessage`.

That inverts the constraint it was meant to teach. Because the build happens
once, build-time captures are snapshots — which is why `localExecutor` carries a
live `localHandlersAccessor` onto the conversation's handler maps instead of
trusting its own copy. Anyone who believed the old text would expect the copy to
refresh and would leave the accessor off the next stage they wrote.

## Still open from #1747

`engine.budget.max_tool_calls` is inert. `machine.go` checks it, but
`Context.IncrementToolCalls` has no caller outside `machine_test.go`, so
`TotalToolCalls` is always 0 and the budget never fires. Filed separately —
where the counting belongs is a real question (SDK and Arena drive their own
turn loops), so it is not a drive-by fix.

Closes #1747 follow-ups (conversation ID, docs).
