### PR TITLE
fix(guardrails): emit the validation lifecycle for func-backed guardrails too

### DIFF
--- a/runtime/hooks/guardrails/adapter.go
+++ b/runtime/hooks/guardrails/adapter.go
@@ -2,7 +2,6 @@ package guardrails
 
 import (
 	"context"
-	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
@@ -236,13 +235,15 @@ func (a *GuardrailHookAdapter) evaluateMessage(
 ) hooks.Decision {
 	params, thresholds := a.evalParams()
 
-	a.emitStarted()
-	start := time.Now()
+	lc := lifecycle{
+		emitter: a.emitter, name: a.evalType, valType: a.evalType, direction: a.direction,
+	}
+	start := lc.start()
 
 	result, err := a.handler.Eval(ctx, evalCtx, params)
 	if err != nil {
-		// No passed/failed emitted here: the decision is a denial, so the
-		// pipeline stage emits the failure that closes the span.
+		// No passed emitted here: the decision is a denial, so the pipeline
+		// stage emits the failure that closes the span.
 		return hooks.Deny("guardrail error: " + err.Error())
 	}
 
@@ -253,35 +254,12 @@ func (a *GuardrailHookAdapter) evaluateMessage(
 		return a.enforced(result)
 	}
 
-	a.emitPassed(time.Since(start), result)
+	var score *float64
+	if result != nil {
+		score = result.Score
+	}
+	lc.pass(start, score)
 	return hooks.Allow
-}
-
-// emitStarted opens the validation span for this guardrail.
-func (a *GuardrailHookAdapter) emitStarted() {
-	if a.emitter == nil {
-		return
-	}
-	a.emitter.ValidationStarted(a.evalType, a.evalType)
-}
-
-// emitPassed closes it for an evaluation that did not trigger. Without this the
-// metrics have no denominator: firings are countable but evaluations are not,
-// so a guardrail's firing rate cannot be computed.
-func (a *GuardrailHookAdapter) emitPassed(duration time.Duration, result *evals.EvalResult) {
-	if a.emitter == nil {
-		return
-	}
-	data := &events.ValidationEventData{
-		ValidatorName: a.evalType,
-		ValidatorType: a.evalType,
-		Direction:     a.direction,
-		Duration:      duration,
-	}
-	if result != nil && result.Score != nil {
-		data.Score = *result.Score
-	}
-	a.emitter.GuardrailResult(data)
 }
 
 // OnChunk evaluates streaming chunks via StreamableEvalHandler.EvalPartial.

--- a/runtime/hooks/guardrails/func_observability_test.go
+++ b/runtime/hooks/guardrails/func_observability_test.go
@@ -1,0 +1,124 @@
+package guardrails
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// observedFuncGuardrail builds a func guardrail wired to a bus, mirroring what
+// the provider stage does through hooks.EmitterAware.
+func observedFuncGuardrail(t *testing.T, spec Spec) (hooks.ProviderHook, *eventSink) {
+	t.Helper()
+	bus := events.NewEventBus()
+	t.Cleanup(func() { bus.Close() })
+	sink := &eventSink{}
+	for _, et := range []events.EventType{
+		events.EventValidationStarted, events.EventValidationPassed, events.EventValidationFailed,
+	} {
+		bus.Subscribe(et, func(e *events.Event) { sink.record(e) })
+	}
+
+	hook, err := spec.build(evals.NewEvalTypeRegistry())
+	require.NoError(t, err)
+
+	aware, ok := hook.(hooks.EmitterAware)
+	require.True(t, ok, "a func guardrail must accept the conversation's emitter like any other")
+	aware.SetEmitter(events.NewEmitter(bus, "exec-1", "sess-1", "conv-1"))
+	return hook, sink
+}
+
+func userReq(text string) *hooks.ProviderRequest {
+	return &hooks.ProviderRequest{
+		Messages: []types.Message{{Role: "user", Content: text}},
+	}
+}
+
+// A passing func guardrail must open and close its span, exactly as the
+// eval-backed one does. Without started the OTel listener never creates the
+// span and the end is discarded into pendingEnds.
+func TestFuncGuardrail_EmitsStartedAndPassedOnOutput(t *testing.T) {
+	hook, sink := observedFuncGuardrail(t, OutputFunc("clean-output",
+		func(_ context.Context, _ *hooks.OutputRequest) hooks.Decision { return hooks.Allow }))
+
+	d := hook.AfterCall(context.Background(), nil,
+		&hooks.ProviderResponse{Message: types.Message{Content: "all good"}})
+	require.True(t, d.Allow)
+
+	sink.awaitCount(t, 2)
+	assert.ElementsMatch(t,
+		[]events.EventType{events.EventValidationStarted, events.EventValidationPassed},
+		sink.typesSeen())
+
+	started := sink.first(events.EventValidationStarted)
+	require.NotNil(t, started)
+	data, ok := started.Data.(*events.ValidationEventData)
+	require.True(t, ok)
+	assert.Equal(t, "clean-output", data.ValidatorName, "the caller's name identifies the guardrail")
+}
+
+func TestFuncGuardrail_EmitsStartedAndPassedOnInput(t *testing.T) {
+	hook, sink := observedFuncGuardrail(t, InputFunc("clean-input",
+		func(_ context.Context, _ *hooks.InputRequest) hooks.Decision { return hooks.Allow }))
+
+	d := hook.BeforeCall(context.Background(), userReq("hello"))
+	require.True(t, d.Allow)
+
+	sink.awaitCount(t, 2)
+	assert.ElementsMatch(t,
+		[]events.EventType{events.EventValidationStarted, events.EventValidationPassed},
+		sink.typesSeen())
+}
+
+// The stage emits the failure, as it does for eval-backed guardrails. A second
+// one here would double-count every firing.
+func TestFuncGuardrail_EmitsStartedButNotFailedOnFiring(t *testing.T) {
+	hook, sink := observedFuncGuardrail(t, OutputFunc("blocker",
+		func(_ context.Context, _ *hooks.OutputRequest) hooks.Decision {
+			return hooks.Enforced("nope", nil)
+		}))
+
+	d := hook.AfterCall(context.Background(), nil,
+		&hooks.ProviderResponse{Message: types.Message{Content: "bad"}})
+	require.False(t, d.Allow)
+
+	sink.awaitCount(t, 1)
+	sink.awaitQuiet()
+	assert.ElementsMatch(t, []events.EventType{events.EventValidationStarted}, sink.typesSeen())
+}
+
+// A guardrail whose function never runs — the input gate skipped it — must not
+// open a span it will never close.
+func TestFuncGuardrail_SkippedTurnEmitsNothing(t *testing.T) {
+	hook, sink := observedFuncGuardrail(t, InputFunc("input-only",
+		func(_ context.Context, _ *hooks.InputRequest) hooks.Decision { return hooks.Allow }))
+
+	// Last message is a tool result, not user input: BeforeCall skips.
+	d := hook.BeforeCall(context.Background(), &hooks.ProviderRequest{
+		Messages: []types.Message{{Role: "assistant", Content: "tool result"}},
+	})
+	require.True(t, d.Allow)
+
+	sink.awaitQuiet()
+	assert.Empty(t, sink.typesSeen(), "a guardrail that did not run must not open a span")
+}
+
+func TestFuncGuardrail_NilEmitterIsSafe(t *testing.T) {
+	hook, err := OutputFunc("no-emitter",
+		func(_ context.Context, _ *hooks.OutputRequest) hooks.Decision { return hooks.Allow },
+	).build(evals.NewEvalTypeRegistry())
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		d := hook.AfterCall(context.Background(), nil,
+			&hooks.ProviderResponse{Message: types.Message{Content: "hi"}})
+		assert.True(t, d.Allow)
+	})
+}

--- a/runtime/hooks/guardrails/lifecycle.go
+++ b/runtime/hooks/guardrails/lifecycle.go
@@ -1,0 +1,58 @@
+package guardrails
+
+import (
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+)
+
+// funcValidatorType is the reported validator type for guardrails declared from
+// a plain function. They have no eval type, but the OTel listener maps this to
+// promptkit.eval.type, so reporting "func" is more useful than reporting the
+// caller's chosen name twice.
+const funcValidatorType = "func"
+
+// lifecycle emits the validation events for one guardrail evaluation.
+//
+// Both guardrail kinds — eval-backed and func-backed — need the same pair, and
+// they need it emitted the same way: started opens the OTel span (the only
+// place promptkit.guardrail=true is set), passed closes it and supplies the
+// denominator the firing metrics lack. Writing that twice is how the input and
+// output directions drifted before, so it lives here once.
+//
+// Firings are deliberately absent: ProviderStage.recordGuardrailFiring emits
+// validation.failed for every guardrail, and a second emission would
+// double-count every one.
+type lifecycle struct {
+	emitter   *events.Emitter
+	name      string
+	valType   string
+	direction string
+}
+
+// start emits validation.started and returns the instant to measure from.
+// Safe with no emitter, in which case nothing is published.
+func (l lifecycle) start() time.Time {
+	if l.emitter != nil {
+		l.emitter.ValidationStarted(l.name, l.valType)
+	}
+	return time.Now()
+}
+
+// pass emits validation.passed for an evaluation that did not trigger. score is
+// nil for guardrails that produce no score, such as func-backed ones.
+func (l lifecycle) pass(since time.Time, score *float64) {
+	if l.emitter == nil {
+		return
+	}
+	data := &events.ValidationEventData{
+		ValidatorName: l.name,
+		ValidatorType: l.valType,
+		Direction:     l.direction,
+		Duration:      time.Since(since),
+	}
+	if score != nil {
+		data.Score = *score
+	}
+	l.emitter.GuardrailResult(data)
+}

--- a/runtime/hooks/guardrails/spec.go
+++ b/runtime/hooks/guardrails/spec.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/hooks"
 	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 )
@@ -111,12 +112,31 @@ type funcGuardrail struct {
 	name   string
 	input  func(context.Context, *hooks.InputRequest) hooks.Decision
 	output func(context.Context, *hooks.OutputRequest) hooks.Decision
+
+	// emitter reports the validation lifecycle. Supplied by the provider stage
+	// via SetEmitter; nil until then, and nil forever for direct construction.
+	emitter *events.Emitter
 }
 
-var _ hooks.ProviderHook = (*funcGuardrail)(nil)
+var (
+	_ hooks.ProviderHook = (*funcGuardrail)(nil)
+	_ hooks.EmitterAware = (*funcGuardrail)(nil)
+)
 
 // Name returns the guardrail's declared name.
 func (g *funcGuardrail) Name() string { return g.name }
+
+// SetEmitter implements hooks.EmitterAware.
+func (g *funcGuardrail) SetEmitter(e *events.Emitter) { g.emitter = e }
+
+// lifecycleFor builds the emitter pair for one direction. A func guardrail has
+// no eval type, so it reports "func" — the listener maps that to
+// promptkit.eval.type, where the caller's name would be redundant.
+func (g *funcGuardrail) lifecycleFor(direction string) lifecycle {
+	return lifecycle{
+		emitter: g.emitter, name: g.name, valType: funcValidatorType, direction: direction,
+	}
+}
 
 // BeforeCall runs the input func, if any, when the last message is from the
 // user. Tool-loop rounds — where the last message is a tool result — are
@@ -138,7 +158,13 @@ func (g *funcGuardrail) BeforeCall(
 		Messages:  req.Messages,
 		Round:     req.Round,
 	}
+	lc := g.lifecycleFor(DirectionInput)
+	start := lc.start()
+
 	d := g.input(ctx, in)
+	if d.Allow {
+		lc.pass(start, nil)
+	}
 	if !d.Allow {
 		req.Replacement = in.Replacement
 		if req.Replacement == "" {
@@ -155,9 +181,17 @@ func (g *funcGuardrail) AfterCall(
 	if g.output == nil || resp == nil {
 		return hooks.Allow
 	}
-	return g.output(ctx, &hooks.OutputRequest{
+
+	lc := g.lifecycleFor(DirectionOutput)
+	start := lc.start()
+
+	d := g.output(ctx, &hooks.OutputRequest{
 		Content: resp.Message.GetContent(),
 		Message: &resp.Message,
 		Round:   resp.Round,
 	})
+	if d.Allow {
+		lc.pass(start, nil)
+	}
+	return d
 }

--- a/sdk/guardrail_observability_test.go
+++ b/sdk/guardrail_observability_test.go
@@ -9,10 +9,28 @@ import (
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks"
+	"github.com/AltairaLabs/PromptKit/runtime/hooks/guardrails"
 	"github.com/AltairaLabs/PromptKit/runtime/providers/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// A pack with no validators of its own — the guardrail comes from WithGuardrail.
+const plainObsPackJSON = `{
+  "$schema": "https://promptpack.org/schema/2025.1/promptpack.schema.json",
+  "schema_version": "2025.1",
+  "id": "guardrail-obs-plain",
+  "version": "1.0.0",
+  "template_engine": {"version": "v1", "syntax": "handlebars", "features": []},
+  "prompts": {
+    "default": {
+      "id": "default", "name": "Default", "description": "helpful",
+      "version": "1.0.0",
+      "system_template": "You are helpful."
+    }
+  }
+}`
 
 // A pack whose prompt declares a length guardrail generous enough to pass.
 const guardrailObsPackJSON = `{
@@ -76,4 +94,56 @@ func TestPackGuardrail_EmitsValidationEventsThroughTheConversation(t *testing.T)
 	defer mu.Unlock()
 	assert.Equal(t, seen[events.EventValidationStarted], seen[events.EventValidationPassed],
 		"every started must be closed by a passed, or spans leak into pendingEnds")
+}
+
+// The func-backed path reaches the same wiring: WithGuardrail builds a
+// funcGuardrail, which is not a GuardrailHookAdapter, so it becomes observable
+// only because Registry.SetEmitter walks every provider hook rather than
+// looking for one concrete type.
+func TestFuncGuardrail_EmitsValidationEventsThroughTheConversation(t *testing.T) {
+	packPath := filepath.Join(t.TempDir(), "func.pack.json")
+	require.NoError(t, os.WriteFile(packPath, []byte(plainObsPackJSON), 0o600))
+
+	bus := events.NewEventBus()
+	t.Cleanup(func() { bus.Close() })
+
+	var mu sync.Mutex
+	seen := map[events.EventType]int{}
+	for _, et := range []events.EventType{events.EventValidationStarted, events.EventValidationPassed} {
+		bus.Subscribe(et, func(e *events.Event) {
+			mu.Lock()
+			defer mu.Unlock()
+			seen[e.Type]++
+		})
+	}
+
+	var ran bool
+	conv, err := Open(packPath, "default",
+		WithSkipSchemaValidation(),
+		WithProvider(mock.NewProvider("mock", "mock-model", false)),
+		WithEventBus(bus),
+		WithGuardrail(guardrails.OutputFunc("length-watch",
+			func(_ context.Context, _ *hooks.OutputRequest) hooks.Decision {
+				mu.Lock()
+				ran = true
+				mu.Unlock()
+				return hooks.Allow
+			})),
+	)
+	require.NoError(t, err)
+	defer conv.Close()
+
+	_, err = conv.Send(context.Background(), "hello")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return seen[events.EventValidationStarted] > 0 && seen[events.EventValidationPassed] > 0
+	}, 2*time.Second, 10*time.Millisecond,
+		"a func guardrail must emit started and passed, or its span is never created")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.True(t, ran, "the guardrail must actually have run — otherwise the events prove nothing")
 }


### PR DESCRIPTION
Finishes the guardrail observability story #1789 started. Closes #1790.

## What was left

#1789 gave eval-backed guardrails `validation.started` / `validation.passed` — the events that create the OTel span and set `promptkit.guardrail=true`. `funcGuardrail` (`spec.go:111`) is not a `GuardrailHookAdapter`, so guardrails declared with `InputFunc` / `OutputFunc` stayed exactly as #1771 described them:

- a firing emitted `validation.failed` from the stage, but `endSpan` found no inflight span and discarded it into `pendingEnds`;
- a pass emitted nothing, so it contributed no denominator.

Metrics working while traces don't is worse than uniformly missing — a dashboard shows firings the traces deny.

## The fix cost almost nothing, by design

`funcGuardrail` implements `hooks.EmitterAware` and that is the whole wiring change. `Registry.SetEmitter` already walks *every* provider hook rather than looking for one concrete type, so the emitter arrives with no changes to the stage, the SDK or Arena. That generality was the point of shaping it that way in #1789.

## Shared lifecycle helper

The emit pair moves into `lifecycle` (`start` / `pass`), used by both guardrail kinds.

Both need the same two events emitted the same way, and hand-writing that twice is precisely how the two directions drifted before — #1789 removed a duplicated `AfterCall` eval path whose existence meant the first version of that emission covered only the input direction. Same class as the two tool loops in #1747 and the two OpenAI serializers in #1735. Two copies of one behaviour is the defect, so there is now one.

## Details worth noting

- **`validator_type` is `"func"`**, not the caller's name repeated. The listener maps that field to `promptkit.eval.type`; the name is already carried by `ValidatorName`.
- **A guardrail that never runs emits nothing.** `BeforeCall`'s `lastUserTurn` gate skips tool-loop rounds, and opening a span that will never be closed is the same `pendingEnds` leak wearing a different hat. Covered by `TestFuncGuardrail_SkippedTurnEmitsNothing`.

## Testing

Input and output directions, started-without-failed on a firing (so the stage is not double-counted), the skipped-turn case, nil emitter, and an end-to-end SDK test that drives a real `WithGuardrail(guardrails.OutputFunc(...))` through `Open`/`Send` — asserting the guardrail actually ran, so the events cannot pass by measuring nothing.

**Mutation-verified twice:** neutering `SetEmitter` fails the end-to-end test; dropping the `pass` emission fails the adapter test.

Guardrails package coverage 98.5%, `lifecycle.go` and `spec.go` at 100%. Runtime and SDK suites green.
