### PR TITLE
feat(providers): add Vertex AI embedding provider and ungate platform vertex

### DIFF
--- a/docs/src/content/docs/runtime/reference/providers.md
+++ b/docs/src/content/docs/runtime/reference/providers.md
@@ -63,6 +63,7 @@ This file contains exported test helpers that can be used by provider implementa
 - [func ReadErrorBody\(body io.Reader\) \[\]byte](<#ReadErrorBody>)
 - [func ReadResponseBody\(body io.Reader\) \(\[\]byte, error\)](<#ReadResponseBody>)
 - [func RegisterEmbeddingProviderFactory\(providerType string, factory EmbeddingProviderFactory\)](<#RegisterEmbeddingProviderFactory>)
+- [func RegisterPlatformEmbeddingProvider\(typeName string, spec PlatformEmbeddingSpec\)](<#RegisterPlatformEmbeddingProvider>)
 - [func RegisterProviderFactory\(providerType string, factory ProviderFactory\)](<#RegisterProviderFactory>)
 - [func RegisteredEmbeddingProviderTypes\(\) \[\]string](<#RegisteredEmbeddingProviderTypes>)
 - [func RegisteredProviderTypes\(\) \[\]string](<#RegisteredProviderTypes>)
@@ -86,6 +87,7 @@ This file contains exported test helpers that can be used by provider implementa
   - [func \(b BargeInSignal\) SignalBargeIn\(\)](<#BargeInSignal.SignalBargeIn>)
 - [type BaseEmbeddingProvider](<#BaseEmbeddingProvider>)
   - [func NewBaseEmbeddingProvider\(providerID, defaultModel, defaultBaseURL string, defaultDimensions, defaultBatchSize int, defaultTimeout time.Duration\) \*BaseEmbeddingProvider](<#NewBaseEmbeddingProvider>)
+  - [func \(b \*BaseEmbeddingProvider\) ApplyWiring\(w EmbeddingWiring\) \(dimsExplicit bool\)](<#BaseEmbeddingProvider.ApplyWiring>)
   - [func \(b \*BaseEmbeddingProvider\) DoEmbeddingRequest\(ctx context.Context, cfg HTTPRequestConfig\) \(\[\]byte, error\)](<#BaseEmbeddingProvider.DoEmbeddingRequest>)
   - [func \(b \*BaseEmbeddingProvider\) EmbedWithEmptyCheck\(ctx context.Context, req EmbeddingRequest, embedFn EmbedFunc\) \(EmbeddingResponse, error\)](<#BaseEmbeddingProvider.EmbedWithEmptyCheck>)
   - [func \(b \*BaseEmbeddingProvider\) EmbeddingDimensions\(\) int](<#BaseEmbeddingProvider.EmbeddingDimensions>)
@@ -154,6 +156,8 @@ This file contains exported test helpers that can be used by provider implementa
 - [type EmbeddingTransport](<#EmbeddingTransport>)
   - [func ResolveEmbeddingTransport\(spec EmbeddingProviderSpec\) \(EmbeddingTransport, error\)](<#ResolveEmbeddingTransport>)
 - [type EmbeddingUsage](<#EmbeddingUsage>)
+- [type EmbeddingWiring](<#EmbeddingWiring>)
+  - [func EmbeddingWiringFrom\(spec EmbeddingProviderSpec, tr EmbeddingTransport\) EmbeddingWiring](<#EmbeddingWiringFrom>)
 - [type ExecutionResult](<#ExecutionResult>)
 - [type FrameDetector](<#FrameDetector>)
 - [type HTTPRequestConfig](<#HTTPRequestConfig>)
@@ -184,6 +188,7 @@ This file contains exported test helpers that can be used by provider implementa
   - [func \(NDJSONFrameDetector\) Name\(\) string](<#NDJSONFrameDetector.Name>)
   - [func \(NDJSONFrameDetector\) PeekFirstFrame\(r io.Reader\) \(\[\]byte, error\)](<#NDJSONFrameDetector.PeekFirstFrame>)
 - [type PlatformConfig](<#PlatformConfig>)
+- [type PlatformEmbeddingSpec](<#PlatformEmbeddingSpec>)
 - [type PredictionRequest](<#PredictionRequest>)
   - [func \(r \*PredictionRequest\) NormalizeMessages\(\)](<#PredictionRequest.NormalizeMessages>)
 - [type PredictionResponse](<#PredictionResponse>)
@@ -732,6 +737,19 @@ func RegisterEmbeddingProviderFactory(providerType string, factory EmbeddingProv
 
 RegisterEmbeddingProviderFactory registers a factory for the given provider type. Typically called from per\-provider package init\(\). Re\-registration overwrites silently — matching RegisterProviderFactory for chat providers.
 
+<a name="RegisterPlatformEmbeddingProvider"></a>
+## func RegisterPlatformEmbeddingProvider
+
+```go
+func RegisterPlatformEmbeddingProvider(typeName string, spec PlatformEmbeddingSpec)
+```
+
+RegisterPlatformEmbeddingProvider registers an embedding factory that enforces the platform block, resolves the transport, and delegates to Build.
+
+Platform\-native providers have no API\-key mode: without a platform block there is no signer or token source, so every request would go unauthenticated. Failing at construction beats failing once per request.
+
+Shared because the enforce\-resolve\-construct sequence is identical for every such provider; only the hint and the constructor differ.
+
 <a name="RegisterProviderFactory"></a>
 ## func RegisterProviderFactory
 
@@ -974,6 +992,15 @@ func NewBaseEmbeddingProvider(providerID, defaultModel, defaultBaseURL string, d
 ```
 
 NewBaseEmbeddingProvider creates a base embedding provider with defaults.
+
+<a name="BaseEmbeddingProvider.ApplyWiring"></a>
+### func \(\*BaseEmbeddingProvider\) ApplyWiring
+
+```go
+func (b *BaseEmbeddingProvider) ApplyWiring(w EmbeddingWiring) (dimsExplicit bool)
+```
+
+ApplyWiring applies the transport\-derived settings, leaving each field alone when the wiring does not carry one. It reports whether Dimensions was set, so the caller knows not to overwrite it with a model\-family default — a comparison against the default value cannot tell "unset" from "set to the same number".
 
 <a name="BaseEmbeddingProvider.DoEmbeddingRequest"></a>
 ### func \(\*BaseEmbeddingProvider\) DoEmbeddingRequest
@@ -1710,6 +1737,32 @@ type EmbeddingUsage struct {
 }
 ```
 
+<a name="EmbeddingWiring"></a>
+## type EmbeddingWiring
+
+EmbeddingWiring is the transport\-derived configuration every platform\-native embedding provider applies the same way. Family\-specific settings — Cohere's input\_type, Vertex's task\_type — stay with their own provider.
+
+```go
+type EmbeddingWiring struct {
+    Model        string
+    BaseURL      string
+    Client       *http.Client
+    PlatformAuth bool
+    // Dimensions is 0 when the spec did not request one, which is what tells
+    // the provider to keep its family default.
+    Dimensions int
+}
+```
+
+<a name="EmbeddingWiringFrom"></a>
+### func EmbeddingWiringFrom
+
+```go
+func EmbeddingWiringFrom(spec EmbeddingProviderSpec, tr EmbeddingTransport) EmbeddingWiring
+```
+
+EmbeddingWiringFrom extracts the shared wiring from a spec and its resolved transport.
+
 <a name="ExecutionResult"></a>
 ## type ExecutionResult
 
@@ -2128,6 +2181,21 @@ PlatformConfig is an alias for credentials.PlatformConfig.
 
 ```go
 type PlatformConfig = credentials.PlatformConfig
+```
+
+<a name="PlatformEmbeddingSpec"></a>
+## type PlatformEmbeddingSpec
+
+PlatformEmbeddingSpec describes a platform\-native embedding provider — one whose request bodies are the cloud's own rather than OpenAI\-shaped, so it is selected by provider type and cannot be hosted on the OpenAI path.
+
+```go
+type PlatformEmbeddingSpec struct {
+    // PlatformHint completes the "requires a platform block (…)" error, naming
+    // the fields that platform actually needs.
+    PlatformHint string
+    // Build constructs the provider once the transport has been resolved.
+    Build func(EmbeddingProviderSpec, EmbeddingTransport) (EmbeddingProvider, error)
+}
 ```
 
 <a name="PredictionRequest"></a>

--- a/runtime/credentials/gcp.go
+++ b/runtime/credentials/gcp.go
@@ -12,10 +12,37 @@ import (
 // gcpTokenRefreshBuffer is the time before token expiration to trigger a refresh.
 const gcpTokenRefreshBuffer = 5 * time.Minute
 
-// VertexEndpoint returns the Vertex AI endpoint URL for a project and region.
+// Vertex model publishers. The publisher is part of the URL, so a model from
+// one cannot be reached through the other's endpoint.
+const (
+	vertexPublisherAnthropic = "anthropic"
+	vertexPublisherGoogle    = "google"
+)
+
+// VertexEndpoint returns the Vertex AI endpoint URL for Anthropic models in a
+// project and region. For Google-published models (embeddings) use
+// VertexEmbeddingEndpoint.
 func VertexEndpoint(project, region string) string {
-	return fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models",
-		region, project, region)
+	return vertexPublisherEndpoint(project, region, vertexPublisherAnthropic)
+}
+
+// VertexEmbeddingEndpoint returns the Vertex AI models base URL for Google's
+// text-embedding models. Callers append "/{model}:predict".
+//
+// Kept separate from VertexEndpoint rather than parameterised at the call site
+// because the publisher is easy to get wrong and wrong late: an anthropic-shaped
+// URL for an embedding model is structurally valid and only fails when the
+// request is made (#1301).
+func VertexEmbeddingEndpoint(project, region string) string {
+	return vertexPublisherEndpoint(project, region, vertexPublisherGoogle)
+}
+
+// vertexPublisherEndpoint builds the models base URL for one publisher. Single
+// format string so the two exported helpers cannot drift.
+func vertexPublisherEndpoint(project, region, publisher string) string {
+	return fmt.Sprintf(
+		"https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/%s/models",
+		region, project, region, publisher)
 }
 
 // Apply adds the OAuth2 token to the request.

--- a/runtime/credentials/gcp_integration_test.go
+++ b/runtime/credentials/gcp_integration_test.go
@@ -232,3 +232,16 @@ func TestGCPCredential_ConcurrentAccess(t *testing.T) {
 	// Despite concurrent access, token source should only be called once
 	assert.Equal(t, 1, mock.getCalls())
 }
+
+// Embeddings are published by "google", not "anthropic". Reusing the chat
+// endpoint here produces a URL that 404s at request time rather than failing
+// at construction, which is why they are separate helpers (#1301).
+func TestVertexEmbeddingEndpoint(t *testing.T) {
+	got := VertexEmbeddingEndpoint("my-project", "us-central1")
+
+	assert.Equal(t,
+		"https://us-central1-aiplatform.googleapis.com/v1/projects/my-project/locations/us-central1/publishers/google/models",
+		got)
+	assert.NotContains(t, got, "anthropic",
+		"the embedding endpoint must not inherit the chat publisher")
+}

--- a/runtime/providers/bedrock/embedding.go
+++ b/runtime/providers/bedrock/embedding.go
@@ -107,6 +107,11 @@ func WithPlatformAuth() EmbeddingOption {
 	return func(p *EmbeddingProvider) { p.PlatformAuth = true }
 }
 
+// WithWiring applies the transport-derived settings the factory resolved.
+func WithWiring(w providers.EmbeddingWiring) EmbeddingOption {
+	return func(p *EmbeddingProvider) { p.dimsExplicit = p.ApplyWiring(w) }
+}
+
 // NewEmbeddingProvider creates a Bedrock embedding provider. It fails when the
 // model is not a recognized embedding family, rather than guessing a wire
 // format that the endpoint would reject at request time.

--- a/runtime/providers/bedrock/embedding.go
+++ b/runtime/providers/bedrock/embedding.go
@@ -17,7 +17,6 @@ package bedrock
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -68,31 +67,6 @@ type EmbeddingProvider struct {
 
 // EmbeddingOption configures the EmbeddingProvider.
 type EmbeddingOption func(*EmbeddingProvider)
-
-// WithModel sets the Bedrock model id (e.g. amazon.titan-embed-text-v2:0).
-func WithModel(model string) EmbeddingOption {
-	return func(p *EmbeddingProvider) { p.ProviderModel = model }
-}
-
-// WithBaseURL overrides the Bedrock runtime host. The provider appends
-// /model/{modelId}/invoke per request.
-func WithBaseURL(url string) EmbeddingOption {
-	return func(p *EmbeddingProvider) { p.BaseURL = url }
-}
-
-// WithHTTPClient sets the HTTP client. For real use this must be the
-// SigV4-applying client from providers.ResolveEmbeddingTransport.
-func WithHTTPClient(client *http.Client) EmbeddingOption {
-	return func(p *EmbeddingProvider) { p.HTTPClient = client }
-}
-
-// WithDimensions overrides the reported embedding dimensionality.
-func WithDimensions(dims int) EmbeddingOption {
-	return func(p *EmbeddingProvider) {
-		p.Dimensions = dims
-		p.dimsExplicit = true
-	}
-}
 
 // WithInputType sets Cohere's input_type ("search_document" or
 // "search_query"). Ignored by Titan, which has no equivalent.

--- a/runtime/providers/bedrock/embedding_register.go
+++ b/runtime/providers/bedrock/embedding_register.go
@@ -1,53 +1,21 @@
 package bedrock
 
 import (
-	"fmt"
-
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 )
 
 //nolint:gochecknoinits // Factory registration requires init
 func init() {
-	providers.RegisterEmbeddingProviderFactory("bedrock",
-		func(spec providers.EmbeddingProviderSpec) (providers.EmbeddingProvider, error) {
-			// Bedrock has no API-key mode: without a platform block there is no
-			// SigV4 signer and every request would go unsigned. Fail here rather
-			// than once per request.
-			if spec.Platform == "" {
-				return nil, fmt.Errorf(
-					"bedrock embedding provider requires a platform block " +
-						"(platform.type: bedrock, platform.region: <region>)")
+	providers.RegisterPlatformEmbeddingProvider("bedrock", providers.PlatformEmbeddingSpec{
+		PlatformHint: "platform.type: bedrock, platform.region: <region>",
+		Build: func(
+			spec providers.EmbeddingProviderSpec, tr providers.EmbeddingTransport,
+		) (providers.EmbeddingProvider, error) {
+			opts := []EmbeddingOption{WithWiring(providers.EmbeddingWiringFrom(spec, tr))}
+			if v, ok := spec.AdditionalConfig["input_type"].(string); ok && v != "" {
+				opts = append(opts, WithInputType(v))
 			}
-			tr, err := providers.ResolveEmbeddingTransport(spec)
-			if err != nil {
-				return nil, err
-			}
-			return NewEmbeddingProvider(optionsFromSpec(spec, tr)...)
+			return NewEmbeddingProvider(opts...)
 		},
-	)
-}
-
-// optionsFromSpec translates a resolved spec and transport into constructor
-// options.
-func optionsFromSpec(spec providers.EmbeddingProviderSpec, tr providers.EmbeddingTransport) []EmbeddingOption {
-	opts := []EmbeddingOption{}
-	if spec.Model != "" {
-		opts = append(opts, WithModel(spec.Model))
-	}
-	if tr.BaseURL != "" {
-		opts = append(opts, WithBaseURL(tr.BaseURL))
-	}
-	if tr.Client != nil {
-		opts = append(opts, WithHTTPClient(tr.Client))
-	}
-	if tr.PlatformAuth {
-		opts = append(opts, WithPlatformAuth())
-	}
-	if dims, ok := providers.IntFromConfig(spec.AdditionalConfig, "dimensions"); ok {
-		opts = append(opts, WithDimensions(dims))
-	}
-	if v, ok := spec.AdditionalConfig["input_type"].(string); ok && v != "" {
-		opts = append(opts, WithInputType(v))
-	}
-	return opts
+	})
 }

--- a/runtime/providers/bedrock/embedding_test.go
+++ b/runtime/providers/bedrock/embedding_test.go
@@ -39,9 +39,9 @@ func fakeBedrock(t *testing.T, respond func(i int) string) (*httptest.Server, *c
 func titanProvider(t *testing.T, url string) *bedrock.EmbeddingProvider {
 	t.Helper()
 	p, err := bedrock.NewEmbeddingProvider(
-		bedrock.WithModel("amazon.titan-embed-text-v2:0"),
-		bedrock.WithBaseURL(url),
-		bedrock.WithPlatformAuth(),
+		bedrock.WithWiring(providers.EmbeddingWiring{
+			Model: "amazon.titan-embed-text-v2:0", BaseURL: url, PlatformAuth: true,
+		}),
 	)
 	require.NoError(t, err)
 	return p
@@ -50,9 +50,9 @@ func titanProvider(t *testing.T, url string) *bedrock.EmbeddingProvider {
 func cohereProvider(t *testing.T, url string) *bedrock.EmbeddingProvider {
 	t.Helper()
 	p, err := bedrock.NewEmbeddingProvider(
-		bedrock.WithModel("cohere.embed-english-v3"),
-		bedrock.WithBaseURL(url),
-		bedrock.WithPlatformAuth(),
+		bedrock.WithWiring(providers.EmbeddingWiring{
+			Model: "cohere.embed-english-v3", BaseURL: url, PlatformAuth: true,
+		}),
 	)
 	require.NoError(t, err)
 	return p
@@ -160,9 +160,9 @@ func TestCohere_ParsesEmbeddingsInOrder(t *testing.T) {
 func TestCohere_InputTypeIsConfigurable(t *testing.T) {
 	srv, c := fakeBedrock(t, func(int) string { return `{"embeddings":[[1]]}` })
 	p, err := bedrock.NewEmbeddingProvider(
-		bedrock.WithModel("cohere.embed-english-v3"),
-		bedrock.WithBaseURL(srv.URL),
-		bedrock.WithPlatformAuth(),
+		bedrock.WithWiring(providers.EmbeddingWiring{
+			Model: "cohere.embed-english-v3", BaseURL: srv.URL, PlatformAuth: true,
+		}),
 		bedrock.WithInputType("search_query"),
 	)
 	require.NoError(t, err)
@@ -184,8 +184,7 @@ func TestMaxBatchSizeDiffersByModelFamily(t *testing.T) {
 
 func TestUnknownModelFamilyIsRejectedAtConstruction(t *testing.T) {
 	_, err := bedrock.NewEmbeddingProvider(
-		bedrock.WithModel("meta.llama3-70b-instruct-v1:0"),
-		bedrock.WithPlatformAuth(),
+		bedrock.WithWiring(providers.EmbeddingWiring{Model: "meta.llama3-70b-instruct-v1:0", PlatformAuth: true}),
 	)
 
 	require.Error(t, err)
@@ -235,10 +234,10 @@ func TestTitan_FanOutStopsOnError(t *testing.T) {
 // Titan v1 emits 1536, so its default must not be the v2 default.
 func TestDimensionsFollowModelVersion(t *testing.T) {
 	v1, err := bedrock.NewEmbeddingProvider(
-		bedrock.WithModel("amazon.titan-embed-text-v1"), bedrock.WithPlatformAuth())
+		bedrock.WithWiring(providers.EmbeddingWiring{Model: "amazon.titan-embed-text-v1", PlatformAuth: true}))
 	require.NoError(t, err)
 	v2, err := bedrock.NewEmbeddingProvider(
-		bedrock.WithModel("amazon.titan-embed-text-v2:0"), bedrock.WithPlatformAuth())
+		bedrock.WithWiring(providers.EmbeddingWiring{Model: "amazon.titan-embed-text-v2:0", PlatformAuth: true}))
 	require.NoError(t, err)
 
 	assert.NotEqual(t, v1.EmbeddingDimensions(), v2.EmbeddingDimensions())
@@ -249,8 +248,7 @@ func TestDimensionsFollowModelVersion(t *testing.T) {
 // default value?", and the override is silently discarded.
 func TestExplicitDimensionsOverrideFamilyDefault(t *testing.T) {
 	p, err := bedrock.NewEmbeddingProvider(
-		bedrock.WithModel("amazon.titan-embed-text-v1"),
-		bedrock.WithDimensions(1024),
+		bedrock.WithWiring(providers.EmbeddingWiring{Model: "amazon.titan-embed-text-v1", Dimensions: 1024}),
 		bedrock.WithPlatformAuth(),
 	)
 	require.NoError(t, err)

--- a/runtime/providers/embedding_platform.go
+++ b/runtime/providers/embedding_platform.go
@@ -1,0 +1,96 @@
+package providers
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// PlatformEmbeddingSpec describes a platform-native embedding provider — one
+// whose request bodies are the cloud's own rather than OpenAI-shaped, so it is
+// selected by provider type and cannot be hosted on the OpenAI path.
+type PlatformEmbeddingSpec struct {
+	// PlatformHint completes the "requires a platform block (…)" error, naming
+	// the fields that platform actually needs.
+	PlatformHint string
+	// Build constructs the provider once the transport has been resolved.
+	Build func(EmbeddingProviderSpec, EmbeddingTransport) (EmbeddingProvider, error)
+}
+
+// RegisterPlatformEmbeddingProvider registers an embedding factory that enforces
+// the platform block, resolves the transport, and delegates to Build.
+//
+// Platform-native providers have no API-key mode: without a platform block
+// there is no signer or token source, so every request would go
+// unauthenticated. Failing at construction beats failing once per request.
+//
+// Shared because the enforce-resolve-construct sequence is identical for every
+// such provider; only the hint and the constructor differ.
+func RegisterPlatformEmbeddingProvider(typeName string, spec PlatformEmbeddingSpec) {
+	RegisterEmbeddingProviderFactory(typeName,
+		func(s EmbeddingProviderSpec) (EmbeddingProvider, error) {
+			if s.Platform == "" {
+				return nil, fmt.Errorf(
+					"%s embedding provider requires a platform block (%s)",
+					typeName, spec.PlatformHint)
+			}
+			tr, err := ResolveEmbeddingTransport(s)
+			if err != nil {
+				return nil, err
+			}
+			return spec.Build(s, tr)
+		},
+	)
+}
+
+// EmbeddingWiring is the transport-derived configuration every platform-native
+// embedding provider applies the same way. Family-specific settings — Cohere's
+// input_type, Vertex's task_type — stay with their own provider.
+type EmbeddingWiring struct {
+	Model        string
+	BaseURL      string
+	Client       *http.Client
+	PlatformAuth bool
+	// Dimensions is 0 when the spec did not request one, which is what tells
+	// the provider to keep its family default.
+	Dimensions int
+}
+
+// EmbeddingWiringFrom extracts the shared wiring from a spec and its resolved
+// transport.
+func EmbeddingWiringFrom(spec EmbeddingProviderSpec, tr EmbeddingTransport) EmbeddingWiring {
+	w := EmbeddingWiring{
+		Model:        spec.Model,
+		BaseURL:      tr.BaseURL,
+		Client:       tr.Client,
+		PlatformAuth: tr.PlatformAuth,
+	}
+	if dims, ok := IntFromConfig(spec.AdditionalConfig, "dimensions"); ok {
+		w.Dimensions = dims
+	}
+	return w
+}
+
+// ApplyWiring applies the transport-derived settings, leaving each field alone
+// when the wiring does not carry one. It reports whether Dimensions was set, so
+// the caller knows not to overwrite it with a model-family default — a
+// comparison against the default value cannot tell "unset" from "set to the
+// same number".
+func (b *BaseEmbeddingProvider) ApplyWiring(w EmbeddingWiring) (dimsExplicit bool) {
+	if w.Model != "" {
+		b.ProviderModel = w.Model
+	}
+	if w.BaseURL != "" {
+		b.BaseURL = w.BaseURL
+	}
+	if w.Client != nil {
+		b.HTTPClient = w.Client
+	}
+	if w.PlatformAuth {
+		b.PlatformAuth = true
+	}
+	if w.Dimensions > 0 {
+		b.Dimensions = w.Dimensions
+		return true
+	}
+	return false
+}

--- a/runtime/providers/embedding_platform_test.go
+++ b/runtime/providers/embedding_platform_test.go
@@ -1,0 +1,138 @@
+package providers
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// stubEmbeddingProvider is a minimal EmbeddingProvider for factory tests.
+type stubEmbeddingProvider struct{ *BaseEmbeddingProvider }
+
+func (s *stubEmbeddingProvider) Embed(_ context.Context, _ EmbeddingRequest) (EmbeddingResponse, error) {
+	return EmbeddingResponse{}, nil
+}
+
+func newStubEmbedding() *stubEmbeddingProvider {
+	return &stubEmbeddingProvider{
+		BaseEmbeddingProvider: NewBaseEmbeddingProvider("stub", "m", "", 8, 4, 0),
+	}
+}
+
+func TestEmbeddingWiringFrom_CarriesTransportAndDimensions(t *testing.T) {
+	client := &http.Client{}
+	w := EmbeddingWiringFrom(
+		EmbeddingProviderSpec{
+			Model:            "m1",
+			AdditionalConfig: map[string]any{"dimensions": 256},
+		},
+		EmbeddingTransport{BaseURL: "https://host", Client: client, PlatformAuth: true},
+	)
+
+	if w.Model != "m1" || w.BaseURL != "https://host" || w.Client != client || !w.PlatformAuth {
+		t.Fatalf("wiring = %+v, want the spec model and the transport's fields", w)
+	}
+	if w.Dimensions != 256 {
+		t.Fatalf("Dimensions = %d, want 256", w.Dimensions)
+	}
+}
+
+// Dimensions must stay 0 when unset: that zero is what tells a provider to keep
+// its model-family default rather than reporting a size nobody asked for.
+func TestEmbeddingWiringFrom_LeavesDimensionsZeroWhenAbsent(t *testing.T) {
+	w := EmbeddingWiringFrom(EmbeddingProviderSpec{Model: "m"}, EmbeddingTransport{})
+	if w.Dimensions != 0 {
+		t.Fatalf("Dimensions = %d, want 0 for an unset spec", w.Dimensions)
+	}
+}
+
+func TestApplyWiring_AppliesEveryFieldAndReportsExplicitDimensions(t *testing.T) {
+	p := newStubEmbedding()
+	client := &http.Client{}
+
+	explicit := p.ApplyWiring(EmbeddingWiring{
+		Model: "m2", BaseURL: "https://h", Client: client, PlatformAuth: true, Dimensions: 512,
+	})
+
+	if !explicit {
+		t.Fatal("dimsExplicit = false, want true when Dimensions is set")
+	}
+	if p.Model() != "m2" || p.BaseURL != "https://h" || p.HTTPClient != client || !p.PlatformAuth {
+		t.Fatalf("provider = %+v, want every wiring field applied", p.BaseEmbeddingProvider)
+	}
+	if p.EmbeddingDimensions() != 512 {
+		t.Fatalf("Dimensions = %d, want 512", p.EmbeddingDimensions())
+	}
+}
+
+// An empty wiring must not blank out constructor defaults — the factory applies
+// wiring after construction, so overwriting with zero values would erase them.
+func TestApplyWiring_EmptyWiringLeavesDefaults(t *testing.T) {
+	p := newStubEmbedding()
+	p.BaseURL = "https://default"
+
+	explicit := p.ApplyWiring(EmbeddingWiring{})
+
+	if explicit {
+		t.Fatal("dimsExplicit = true, want false for an empty wiring")
+	}
+	if p.Model() != "m" || p.BaseURL != "https://default" || p.EmbeddingDimensions() != 8 {
+		t.Fatalf("provider = %+v, want defaults preserved", p.BaseEmbeddingProvider)
+	}
+	if p.PlatformAuth {
+		t.Fatal("PlatformAuth = true, want it left alone")
+	}
+}
+
+// The platform block is what supplies the signer or token source, so a spec
+// without one must fail at construction rather than once per request.
+func TestRegisterPlatformEmbeddingProvider_RequiresPlatform(t *testing.T) {
+	RegisterPlatformEmbeddingProvider("stub-platform-required", PlatformEmbeddingSpec{
+		PlatformHint: "platform.type: stub, platform.region: <region>",
+		Build: func(EmbeddingProviderSpec, EmbeddingTransport) (EmbeddingProvider, error) {
+			t.Fatal("Build must not run without a platform block")
+			return nil, nil
+		},
+	})
+
+	_, err := CreateEmbeddingProviderFromSpec(EmbeddingProviderSpec{Type: "stub-platform-required"})
+	if err == nil {
+		t.Fatal("expected an error for a spec with no platform block")
+	}
+	// The hint has to name the fields, or the error tells the caller nothing
+	// they can act on.
+	if !strings.Contains(err.Error(), "platform.region") {
+		t.Fatalf("err = %v, want the hint naming the required fields", err)
+	}
+}
+
+// A transport failure must surface rather than be swallowed into a provider
+// built with no credentials.
+func TestRegisterPlatformEmbeddingProvider_PropagatesTransportError(t *testing.T) {
+	RegisterPlatformEmbeddingProvider("stub-bad-transport", PlatformEmbeddingSpec{
+		PlatformHint: "platform.type: stub",
+		Build: func(EmbeddingProviderSpec, EmbeddingTransport) (EmbeddingProvider, error) {
+			t.Fatal("Build must not run when the transport fails to resolve")
+			return nil, nil
+		},
+	})
+
+	_, err := CreateEmbeddingProviderFromSpec(EmbeddingProviderSpec{
+		Type:     "stub-bad-transport",
+		Platform: "nonexistent-platform",
+	})
+	if err == nil {
+		t.Fatal("expected the transport resolution error to surface")
+	}
+}
+
+// The success path — Build receiving a resolved transport — cannot be tested
+// with a stub type here: every platform's transport guards that the provider
+// type is its own native one (azure→openai, bedrock→bedrock, vertex→vertex), so
+// a made-up type can never resolve a transport, and registering the stub under
+// a real type would clobber that provider's factory for the rest of the package.
+//
+// It is covered where it is real instead, end to end through the registry:
+// TestFactoryBuildsProviderFromSpec in runtime/providers/bedrock and
+// runtime/providers/vertex, each asserting the constructed provider's ID.

--- a/runtime/providers/embedding_transport.go
+++ b/runtime/providers/embedding_transport.go
@@ -18,6 +18,9 @@ const (
 	// embeddingTypeBedrock speaks Bedrock's per-family InvokeModel bodies
 	// (Titan/Cohere) — see runtime/providers/bedrock.
 	embeddingTypeBedrock = "bedrock"
+	// embeddingTypeVertex speaks Vertex AI's :predict instances/predictions
+	// bodies, which are likewise not OpenAI-shaped.
+	embeddingTypeVertex = "vertex"
 )
 
 // EmbeddingTransport is the resolved HTTP wiring for a vendor embedding
@@ -86,9 +89,7 @@ func buildPlatformEmbeddingClient(
 	case platformBedrock:
 		return buildBedrockEmbeddingClient(cred, providerType, pc)
 	case platformVertex:
-		return nil, "", fmt.Errorf(
-			"embedding platform %q is not yet supported: it requires a platform-native embedding "+
-				"provider type (Vertex body shapes), which is not implemented", platform)
+		return buildVertexEmbeddingClient(cred, providerType, pc)
 	default:
 		return nil, "", fmt.Errorf("unsupported embedding platform: %q", platform)
 	}
@@ -123,6 +124,48 @@ func buildBedrockEmbeddingClient(
 	return &http.Client{
 		Transport: &platformEmbeddingRoundTripper{base: http.DefaultTransport, cred: cred},
 	}, baseURL, nil
+}
+
+// buildVertexEmbeddingClient wires GCP bearer-token auth and resolves the
+// Vertex models base URL. Like Bedrock — and unlike Azure — it returns the
+// models collection rather than a per-model URL: Vertex carries the model in
+// the path as /{model}:predict, so the provider appends it and a per-request
+// model override still works.
+func buildVertexEmbeddingClient(
+	cred credentials.Credential, providerType string, pc *PlatformConfig,
+) (*http.Client, string, error) {
+	if providerType != embeddingTypeVertex {
+		return nil, "", fmt.Errorf(
+			"embedding platform %q requires the platform-native provider type %q (:predict "+
+				"body shapes), got %q", platformVertex, embeddingTypeVertex, providerType)
+	}
+
+	// An explicit endpoint wins, for private or otherwise non-standard
+	// endpoints. Otherwise both project and region are required: each appears
+	// twice in the URL and neither has a sane default.
+	if pc != nil && pc.Endpoint != "" {
+		return vertexClient(cred), pc.Endpoint, nil
+	}
+	if pc == nil || pc.Project == "" {
+		return nil, "", fmt.Errorf(
+			"embedding platform %q requires platform.project (or an explicit platform.endpoint)",
+			platformVertex)
+	}
+	if pc.Region == "" {
+		return nil, "", fmt.Errorf(
+			"embedding platform %q requires platform.region (or an explicit platform.endpoint)",
+			platformVertex)
+	}
+
+	return vertexClient(cred), credentials.VertexEmbeddingEndpoint(pc.Project, pc.Region), nil
+}
+
+// vertexClient builds the token-applying HTTP client. Vertex needs no
+// api-version query param, so the round tripper carries only the credential.
+func vertexClient(cred credentials.Credential) *http.Client {
+	return &http.Client{
+		Transport: &platformEmbeddingRoundTripper{base: http.DefaultTransport, cred: cred},
+	}
 }
 
 // azureEmbeddingAPIVersion mirrors the chat path: prefer an explicit

--- a/runtime/providers/embedding_transport_test.go
+++ b/runtime/providers/embedding_transport_test.go
@@ -172,15 +172,88 @@ func TestResolveEmbeddingTransport_AzureRequiresOpenAIWire(t *testing.T) {
 	}
 }
 
-func TestResolveEmbeddingTransport_VertexStillGated(t *testing.T) {
+// Vertex is no longer gated (#1301); it now requires its own provider type,
+// like Bedrock, because :predict bodies are not OpenAI-shaped. This replaces
+// the old "still gated" test.
+func TestResolveEmbeddingTransport_VertexRejectsOpenAIType(t *testing.T) {
 	_, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
 		Type:           "openai",
 		Platform:       "vertex",
-		PlatformConfig: &PlatformConfig{Type: "vertex"},
+		PlatformConfig: &PlatformConfig{Type: "vertex", Project: "p", Region: "us-central1"},
 		Credential:     &fakeCred{},
 	})
-	if err == nil || !strings.Contains(err.Error(), "not yet supported") {
-		t.Fatalf("err = %v, want 'not yet supported'", err)
+	if err == nil || !strings.Contains(err.Error(), `platform-native provider type "vertex"`) {
+		t.Fatalf("err = %v, want a pointer at the vertex provider type", err)
+	}
+}
+
+// The resolved base URL must be the google-publisher models collection: the
+// anthropic-shaped chat endpoint is structurally valid and only fails when a
+// request is made, so getting this wrong is invisible until runtime.
+func TestResolveEmbeddingTransport_VertexResolvesGooglePublisherEndpoint(t *testing.T) {
+	tr, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
+		Type:           "vertex",
+		Platform:       "vertex",
+		PlatformConfig: &PlatformConfig{Type: "vertex", Project: "my-proj", Region: "us-central1"},
+		Credential:     &fakeCred{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "https://us-central1-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-central1/publishers/google/models"
+	if tr.BaseURL != want {
+		t.Fatalf("BaseURL = %q, want %q", tr.BaseURL, want)
+	}
+	if !tr.PlatformAuth {
+		t.Fatal("PlatformAuth = false, want true — Vertex has no API-key mode")
+	}
+	if tr.Client == nil {
+		t.Fatal("Client = nil, want a credential-applying client")
+	}
+}
+
+// Vertex URLs embed the project and region, so neither can be defaulted.
+func TestResolveEmbeddingTransport_VertexRequiresProjectAndRegion(t *testing.T) {
+	tests := []struct {
+		name string
+		pc   *PlatformConfig
+		want string
+	}{
+		{"no project", &PlatformConfig{Type: "vertex", Region: "us-central1"}, "platform.project"},
+		{"no region", &PlatformConfig{Type: "vertex", Project: "p"}, "platform.region"},
+		{"no config", nil, "platform.project"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
+				Type:           "vertex",
+				Platform:       "vertex",
+				PlatformConfig: tc.pc,
+				Credential:     &fakeCred{},
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want mention of %s", err, tc.want)
+			}
+		})
+	}
+}
+
+// An explicit endpoint wins, for private/regional endpoints and for tests.
+func TestResolveEmbeddingTransport_VertexHonorsExplicitEndpoint(t *testing.T) {
+	tr, err := ResolveEmbeddingTransport(EmbeddingProviderSpec{
+		Type:     "vertex",
+		Platform: "vertex",
+		PlatformConfig: &PlatformConfig{
+			Type: "vertex", Project: "p", Region: "us-central1",
+			Endpoint: "https://custom.example/v1/models",
+		},
+		Credential: &fakeCred{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tr.BaseURL != "https://custom.example/v1/models" {
+		t.Fatalf("BaseURL = %q, want the explicit endpoint", tr.BaseURL)
 	}
 }
 

--- a/runtime/providers/vertex/embedding.go
+++ b/runtime/providers/vertex/embedding.go
@@ -112,6 +112,11 @@ func WithPlatformAuth() EmbeddingOption {
 	return func(p *EmbeddingProvider) { p.PlatformAuth = true }
 }
 
+// WithWiring applies the transport-derived settings the factory resolved.
+func WithWiring(w providers.EmbeddingWiring) EmbeddingOption {
+	return func(p *EmbeddingProvider) { p.dimsExplicit = p.ApplyWiring(w) }
+}
+
 // NewEmbeddingProvider creates a Vertex embedding provider. It fails when the
 // model is not a recognized embedding family rather than sending a body the
 // endpoint would reject at request time.

--- a/runtime/providers/vertex/embedding.go
+++ b/runtime/providers/vertex/embedding.go
@@ -1,0 +1,248 @@
+// Package vertex provides embedding generation via Google Vertex AI's
+// text-embedding models.
+//
+// Vertex is not OpenAI-wire-compatible: embeddings are produced by POSTing to
+// .../publishers/google/models/{model}:predict with
+//
+//	{"instances":[{"content":"…","task_type":"…"}],"parameters":{…}}
+//
+// and reading back
+//
+//	{"predictions":[{"embeddings":{"values":[…],"statistics":{"token_count":N}}}]}
+//
+// so it needs its own provider type rather than a transport-level rewrite of an
+// OpenAI body (#1301).
+//
+// Authentication is a GCP OAuth2 bearer token applied by the HTTP client's
+// transport (see providers.ResolveEmbeddingTransport with platform "vertex"),
+// so this package never handles credentials directly.
+package vertex
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// Model family prefixes used to select defaults.
+const (
+	textEmbeddingPrefix   = "text-embedding"
+	geckoEmbeddingPrefix  = "textembedding-gecko"
+	geminiEmbeddingPrefix = "gemini-embedding"
+)
+
+// DefaultModel is Google's current general-purpose text embedding model.
+const DefaultModel = "text-embedding-005"
+
+// Family defaults. These are the documented defaults at time of writing and
+// are overridable per provider: WithDimensions sets outputDimensionality, and
+// the batch size is what the caller's batching loop is told to respect. They
+// are not enforced by this package — the endpoint is the authority, and a
+// wrong guess here surfaces as an API error rather than silent truncation.
+const (
+	textEmbeddingDimensions   = 768
+	geminiEmbeddingDimensions = 3072
+	textEmbeddingMaxBatch     = 250
+	geminiEmbeddingMaxBatch   = 1
+)
+
+// DefaultTaskType is Vertex's task type for embedding documents to be indexed.
+// Use "RETRIEVAL_QUERY" when embedding a search query; the two produce
+// different vectors on purpose.
+const DefaultTaskType = "RETRIEVAL_DOCUMENT"
+
+const vertexTimeout = 60 * time.Second
+
+// EmbeddingProvider implements embedding generation via Vertex AI.
+type EmbeddingProvider struct {
+	*providers.BaseEmbeddingProvider
+	taskType string
+	// dimsExplicit records that the caller set Dimensions, so the family
+	// default must not overwrite it and outputDimensionality is only sent when
+	// actually requested — tracking intent rather than comparing to a default,
+	// which cannot tell "unset" from "set to the same number".
+	dimsExplicit bool
+}
+
+// EmbeddingOption configures the EmbeddingProvider.
+type EmbeddingOption func(*EmbeddingProvider)
+
+// WithModel sets the Vertex model id (e.g. text-embedding-005).
+func WithModel(model string) EmbeddingOption {
+	return func(p *EmbeddingProvider) { p.ProviderModel = model }
+}
+
+// WithBaseURL overrides the models base URL. The provider appends
+// /{model}:predict per request, so this is the models collection — not a single
+// model — which is what lets a per-request model override work.
+func WithBaseURL(url string) EmbeddingOption {
+	return func(p *EmbeddingProvider) { p.BaseURL = url }
+}
+
+// WithHTTPClient sets the HTTP client. For real use this must be the
+// token-applying client from providers.ResolveEmbeddingTransport.
+func WithHTTPClient(client *http.Client) EmbeddingOption {
+	return func(p *EmbeddingProvider) { p.HTTPClient = client }
+}
+
+// WithDimensions requests a specific output dimensionality. Sent as
+// parameters.outputDimensionality; Vertex truncates server-side, so this is a
+// request parameter and not a client-side slice.
+func WithDimensions(dims int) EmbeddingOption {
+	return func(p *EmbeddingProvider) {
+		p.Dimensions = dims
+		p.dimsExplicit = true
+	}
+}
+
+// WithTaskType sets the Vertex task type ("RETRIEVAL_DOCUMENT",
+// "RETRIEVAL_QUERY", "SEMANTIC_SIMILARITY", …).
+func WithTaskType(taskType string) EmbeddingOption {
+	return func(p *EmbeddingProvider) { p.taskType = taskType }
+}
+
+// WithPlatformAuth marks the provider as authenticated by its HTTP client's
+// transport. Vertex has no API-key mode, so this is always the case in real
+// use; the flag exists for symmetry with the other embedding providers.
+func WithPlatformAuth() EmbeddingOption {
+	return func(p *EmbeddingProvider) { p.PlatformAuth = true }
+}
+
+// NewEmbeddingProvider creates a Vertex embedding provider. It fails when the
+// model is not a recognized embedding family rather than sending a body the
+// endpoint would reject at request time.
+func NewEmbeddingProvider(opts ...EmbeddingOption) (*EmbeddingProvider, error) {
+	p := &EmbeddingProvider{
+		BaseEmbeddingProvider: providers.NewBaseEmbeddingProvider(
+			"vertex-embedding", DefaultModel, "",
+			textEmbeddingDimensions, textEmbeddingMaxBatch, vertexTimeout,
+		),
+		taskType: DefaultTaskType,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	dims, batch, err := familyDefaults(p.ProviderModel)
+	if err != nil {
+		return nil, err
+	}
+	p.BatchSize = batch
+	if !p.dimsExplicit {
+		p.Dimensions = dims
+	}
+	return p, nil
+}
+
+// familyDefaults returns the dimension and batch defaults for a model id, and
+// an error when the model is not a known Vertex embedding family.
+func familyDefaults(model string) (dims, batch int, err error) {
+	switch {
+	case strings.HasPrefix(model, geminiEmbeddingPrefix):
+		return geminiEmbeddingDimensions, geminiEmbeddingMaxBatch, nil
+	case strings.HasPrefix(model, textEmbeddingPrefix),
+		strings.HasPrefix(model, geckoEmbeddingPrefix):
+		return textEmbeddingDimensions, textEmbeddingMaxBatch, nil
+	default:
+		return 0, 0, fmt.Errorf(
+			"unsupported vertex embedding model %q: expected a %s*, %s* or %s* model",
+			model, textEmbeddingPrefix, geckoEmbeddingPrefix, geminiEmbeddingPrefix)
+	}
+}
+
+// predictURL builds the :predict URL for a model. The model is part of the
+// path, so a per-request override changes the URL rather than the body.
+func (p *EmbeddingProvider) predictURL(model string) string {
+	return strings.TrimSuffix(p.BaseURL, "/") + "/" + model + ":predict"
+}
+
+// predictInstance is one text to embed. task_type is omitted when unset so a
+// model that does not accept it is not sent one.
+type predictInstance struct {
+	Content  string `json:"content"`
+	TaskType string `json:"task_type,omitempty"`
+}
+
+// predictParameters carries request-level knobs. Omitted entirely when empty.
+type predictParameters struct {
+	OutputDimensionality int `json:"outputDimensionality,omitempty"`
+}
+
+type predictRequest struct {
+	Instances  []predictInstance  `json:"instances"`
+	Parameters *predictParameters `json:"parameters,omitempty"`
+}
+
+type predictResponse struct {
+	Predictions []struct {
+		Embeddings struct {
+			Values     []float32 `json:"values"`
+			Statistics struct {
+				TokenCount int `json:"token_count"`
+			} `json:"statistics"`
+		} `json:"embeddings"`
+	} `json:"predictions"`
+}
+
+// Embed generates embeddings for the given texts.
+func (p *EmbeddingProvider) Embed(
+	ctx context.Context, req providers.EmbeddingRequest,
+) (providers.EmbeddingResponse, error) {
+	return p.EmbedWithEmptyCheck(ctx, req, p.embedTexts)
+}
+
+func (p *EmbeddingProvider) embedTexts(
+	ctx context.Context, texts []string, model string,
+) (providers.EmbeddingResponse, error) {
+	start := time.Now()
+
+	instances := make([]predictInstance, len(texts))
+	for i, text := range texts {
+		instances[i] = predictInstance{Content: text, TaskType: p.taskType}
+	}
+	request := predictRequest{Instances: instances}
+	if p.dimsExplicit && p.Dimensions > 0 {
+		request.Parameters = &predictParameters{OutputDimensionality: p.Dimensions}
+	}
+
+	body, err := providers.MarshalRequest(request)
+	if err != nil {
+		return providers.EmbeddingResponse{}, err
+	}
+	respBytes, err := p.DoEmbeddingRequest(ctx, providers.HTTPRequestConfig{
+		URL:  p.predictURL(model),
+		Body: body,
+	})
+	if err != nil {
+		return providers.EmbeddingResponse{}, err
+	}
+
+	var resp predictResponse
+	if err := providers.UnmarshalResponse(respBytes, &resp); err != nil {
+		return providers.EmbeddingResponse{}, err
+	}
+	// A short predictions array would otherwise be returned as fewer vectors
+	// than texts, silently misaligning whatever index consumes them.
+	if len(resp.Predictions) != len(texts) {
+		return providers.EmbeddingResponse{}, fmt.Errorf(
+			"vertex returned %d embeddings for %d texts", len(resp.Predictions), len(texts))
+	}
+
+	embeddings := make([][]float32, len(resp.Predictions))
+	total := 0
+	for i := range resp.Predictions {
+		embeddings[i] = resp.Predictions[i].Embeddings.Values
+		total += resp.Predictions[i].Embeddings.Statistics.TokenCount
+	}
+
+	providers.LogEmbeddingRequestWithTokens("Vertex", model, len(texts), total, start)
+	return providers.EmbeddingResponse{
+		Embeddings: embeddings,
+		Model:      model,
+		Usage:      &providers.EmbeddingUsage{TotalTokens: total},
+	}, nil
+}

--- a/runtime/providers/vertex/embedding.go
+++ b/runtime/providers/vertex/embedding.go
@@ -21,7 +21,6 @@ package vertex
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -39,7 +38,8 @@ const (
 const DefaultModel = "text-embedding-005"
 
 // Family defaults. These are the documented defaults at time of writing and
-// are overridable per provider: WithDimensions sets outputDimensionality, and
+// are overridable per provider: the wiring's Dimensions sets
+// outputDimensionality, and
 // the batch size is what the caller's batching loop is told to respect. They
 // are not enforced by this package — the endpoint is the authority, and a
 // wrong guess here surfaces as an API error rather than silent truncation.
@@ -70,34 +70,6 @@ type EmbeddingProvider struct {
 
 // EmbeddingOption configures the EmbeddingProvider.
 type EmbeddingOption func(*EmbeddingProvider)
-
-// WithModel sets the Vertex model id (e.g. text-embedding-005).
-func WithModel(model string) EmbeddingOption {
-	return func(p *EmbeddingProvider) { p.ProviderModel = model }
-}
-
-// WithBaseURL overrides the models base URL. The provider appends
-// /{model}:predict per request, so this is the models collection — not a single
-// model — which is what lets a per-request model override work.
-func WithBaseURL(url string) EmbeddingOption {
-	return func(p *EmbeddingProvider) { p.BaseURL = url }
-}
-
-// WithHTTPClient sets the HTTP client. For real use this must be the
-// token-applying client from providers.ResolveEmbeddingTransport.
-func WithHTTPClient(client *http.Client) EmbeddingOption {
-	return func(p *EmbeddingProvider) { p.HTTPClient = client }
-}
-
-// WithDimensions requests a specific output dimensionality. Sent as
-// parameters.outputDimensionality; Vertex truncates server-side, so this is a
-// request parameter and not a client-side slice.
-func WithDimensions(dims int) EmbeddingOption {
-	return func(p *EmbeddingProvider) {
-		p.Dimensions = dims
-		p.dimsExplicit = true
-	}
-}
 
 // WithTaskType sets the Vertex task type ("RETRIEVAL_DOCUMENT",
 // "RETRIEVAL_QUERY", "SEMANTIC_SIMILARITY", …).

--- a/runtime/providers/vertex/embedding_integration_test.go
+++ b/runtime/providers/vertex/embedding_integration_test.go
@@ -1,0 +1,135 @@
+//go:build integration
+
+// Live Google Vertex AI embedding tests. Exercises the full path the unit tests
+// stub out: an OAuth2 bearer token applied by the platform RoundTripper, the
+// publishers/google/models/{model}:predict URL, and the real predictions
+// response shape.
+//
+// Run locally:
+//
+//	gcloud auth application-default login
+//	export GCP_PROJECT=<project-with-vertex-ai-enabled>
+//	export GCP_REGION=us-central1
+//	go test -tags=integration ./runtime/providers/vertex/... -v
+//
+// Tests skip when GCP credentials or GCP_PROJECT are unavailable. Live calls
+// additionally require the Vertex AI API to be enabled on the project.
+package vertex_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/vertex"
+)
+
+func integrationRegion() string {
+	if r := os.Getenv("GCP_REGION"); r != "" {
+		return r
+	}
+	return "us-central1"
+}
+
+func integrationProject(t *testing.T) string {
+	t.Helper()
+	project := os.Getenv("GCP_PROJECT")
+	if project == "" {
+		t.Skip("GCP_PROJECT not set")
+	}
+	return project
+}
+
+// liveProvider builds the provider exactly as a caller would — through the
+// factory and the platform transport — so the test covers the real wiring
+// rather than a hand-assembled struct.
+func liveProvider(t *testing.T, model string) providers.EmbeddingProvider {
+	t.Helper()
+	project := integrationProject(t)
+
+	cred, err := credentials.NewGCPCredential(context.Background(), project, integrationRegion())
+	if err != nil {
+		t.Skipf("GCP credentials not available: %v", err)
+	}
+
+	p, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		ID:       "vertex-live",
+		Type:     "vertex",
+		Model:    model,
+		Platform: "vertex",
+		PlatformConfig: &credentials.PlatformConfig{
+			Type: "vertex", Project: project, Region: integrationRegion(),
+		},
+		Credential: cred,
+	})
+	require.NoError(t, err)
+	return p
+}
+
+func TestLive_EmbedSingleText(t *testing.T) {
+	p := liveProvider(t, "text-embedding-005")
+
+	resp, err := p.Embed(context.Background(), providers.EmbeddingRequest{
+		Texts: []string{"the quick brown fox"},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, resp.Embeddings, 1)
+	assert.NotEmpty(t, resp.Embeddings[0], "a live embedding must not come back empty")
+	assert.Len(t, resp.Embeddings[0], p.EmbeddingDimensions(),
+		"the reported dimensionality must match what the service actually returns")
+	require.NotNil(t, resp.Usage)
+	assert.Positive(t, resp.Usage.TotalTokens)
+}
+
+// Batching is the claim most likely to be wrong against the live service: the
+// unit tests only prove the request shape, not that Vertex accepts several
+// instances in one call and returns them in order.
+func TestLive_EmbedBatchPreservesOrder(t *testing.T) {
+	p := liveProvider(t, "text-embedding-005")
+
+	texts := []string{"alpha", "beta", "gamma"}
+	resp, err := p.Embed(context.Background(), providers.EmbeddingRequest{Texts: texts})
+	require.NoError(t, err)
+
+	require.Len(t, resp.Embeddings, len(texts))
+	for i := range texts {
+		assert.NotEmpty(t, resp.Embeddings[i], "embedding %d empty", i)
+	}
+	assert.NotEqual(t, resp.Embeddings[0], resp.Embeddings[1],
+		"distinct inputs must produce distinct vectors — equal ones would mean the "+
+			"instances were collapsed or the response was misread")
+}
+
+// outputDimensionality is applied server-side, so this is the only way to know
+// the parameter is accepted rather than ignored.
+func TestLive_OutputDimensionalityIsHonored(t *testing.T) {
+	project := integrationProject(t)
+	cred, err := credentials.NewGCPCredential(context.Background(), project, integrationRegion())
+	if err != nil {
+		t.Skipf("GCP credentials not available: %v", err)
+	}
+
+	p, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type:     "vertex",
+		Model:    "text-embedding-005",
+		Platform: "vertex",
+		PlatformConfig: &credentials.PlatformConfig{
+			Type: "vertex", Project: project, Region: integrationRegion(),
+		},
+		Credential:       cred,
+		AdditionalConfig: map[string]any{"dimensions": 256},
+	})
+	require.NoError(t, err)
+
+	resp, err := p.Embed(context.Background(), providers.EmbeddingRequest{Texts: []string{"x"}})
+	require.NoError(t, err)
+	require.Len(t, resp.Embeddings, 1)
+	assert.Len(t, resp.Embeddings[0], 256,
+		"Vertex must return the requested dimensionality, not the family default")
+}

--- a/runtime/providers/vertex/embedding_register.go
+++ b/runtime/providers/vertex/embedding_register.go
@@ -1,53 +1,21 @@
 package vertex
 
 import (
-	"fmt"
-
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 )
 
 //nolint:gochecknoinits // Factory registration requires init
 func init() {
-	providers.RegisterEmbeddingProviderFactory("vertex",
-		func(spec providers.EmbeddingProviderSpec) (providers.EmbeddingProvider, error) {
-			// Vertex has no API-key mode: without a platform block there is no
-			// token source and every request would go unauthenticated. Fail
-			// here rather than once per request.
-			if spec.Platform == "" {
-				return nil, fmt.Errorf(
-					"vertex embedding provider requires a platform block " +
-						"(platform.type: vertex, platform.project: <project>, platform.region: <region>)")
+	providers.RegisterPlatformEmbeddingProvider("vertex", providers.PlatformEmbeddingSpec{
+		PlatformHint: "platform.type: vertex, platform.project: <project>, platform.region: <region>",
+		Build: func(
+			spec providers.EmbeddingProviderSpec, tr providers.EmbeddingTransport,
+		) (providers.EmbeddingProvider, error) {
+			opts := []EmbeddingOption{WithWiring(providers.EmbeddingWiringFrom(spec, tr))}
+			if v, ok := spec.AdditionalConfig["task_type"].(string); ok && v != "" {
+				opts = append(opts, WithTaskType(v))
 			}
-			tr, err := providers.ResolveEmbeddingTransport(spec)
-			if err != nil {
-				return nil, err
-			}
-			return NewEmbeddingProvider(optionsFromSpec(spec, tr)...)
+			return NewEmbeddingProvider(opts...)
 		},
-	)
-}
-
-// optionsFromSpec translates a resolved spec and transport into constructor
-// options.
-func optionsFromSpec(spec providers.EmbeddingProviderSpec, tr providers.EmbeddingTransport) []EmbeddingOption {
-	opts := []EmbeddingOption{}
-	if spec.Model != "" {
-		opts = append(opts, WithModel(spec.Model))
-	}
-	if tr.BaseURL != "" {
-		opts = append(opts, WithBaseURL(tr.BaseURL))
-	}
-	if tr.Client != nil {
-		opts = append(opts, WithHTTPClient(tr.Client))
-	}
-	if tr.PlatformAuth {
-		opts = append(opts, WithPlatformAuth())
-	}
-	if dims, ok := providers.IntFromConfig(spec.AdditionalConfig, "dimensions"); ok {
-		opts = append(opts, WithDimensions(dims))
-	}
-	if v, ok := spec.AdditionalConfig["task_type"].(string); ok && v != "" {
-		opts = append(opts, WithTaskType(v))
-	}
-	return opts
+	})
 }

--- a/runtime/providers/vertex/embedding_register.go
+++ b/runtime/providers/vertex/embedding_register.go
@@ -1,0 +1,53 @@
+package vertex
+
+import (
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+//nolint:gochecknoinits // Factory registration requires init
+func init() {
+	providers.RegisterEmbeddingProviderFactory("vertex",
+		func(spec providers.EmbeddingProviderSpec) (providers.EmbeddingProvider, error) {
+			// Vertex has no API-key mode: without a platform block there is no
+			// token source and every request would go unauthenticated. Fail
+			// here rather than once per request.
+			if spec.Platform == "" {
+				return nil, fmt.Errorf(
+					"vertex embedding provider requires a platform block " +
+						"(platform.type: vertex, platform.project: <project>, platform.region: <region>)")
+			}
+			tr, err := providers.ResolveEmbeddingTransport(spec)
+			if err != nil {
+				return nil, err
+			}
+			return NewEmbeddingProvider(optionsFromSpec(spec, tr)...)
+		},
+	)
+}
+
+// optionsFromSpec translates a resolved spec and transport into constructor
+// options.
+func optionsFromSpec(spec providers.EmbeddingProviderSpec, tr providers.EmbeddingTransport) []EmbeddingOption {
+	opts := []EmbeddingOption{}
+	if spec.Model != "" {
+		opts = append(opts, WithModel(spec.Model))
+	}
+	if tr.BaseURL != "" {
+		opts = append(opts, WithBaseURL(tr.BaseURL))
+	}
+	if tr.Client != nil {
+		opts = append(opts, WithHTTPClient(tr.Client))
+	}
+	if tr.PlatformAuth {
+		opts = append(opts, WithPlatformAuth())
+	}
+	if dims, ok := providers.IntFromConfig(spec.AdditionalConfig, "dimensions"); ok {
+		opts = append(opts, WithDimensions(dims))
+	}
+	if v, ok := spec.AdditionalConfig["task_type"].(string); ok && v != "" {
+		opts = append(opts, WithTaskType(v))
+	}
+	return opts
+}

--- a/runtime/providers/vertex/embedding_register_test.go
+++ b/runtime/providers/vertex/embedding_register_test.go
@@ -1,0 +1,83 @@
+package vertex_test
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/credentials"
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// Side-effect import registers the factory under test.
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/vertex"
+)
+
+func vertexSpec(model string, extra map[string]any) providers.EmbeddingProviderSpec {
+	return providers.EmbeddingProviderSpec{
+		ID:       "embed",
+		Type:     "vertex",
+		Model:    model,
+		Platform: "vertex",
+		PlatformConfig: &credentials.PlatformConfig{
+			Type: "vertex", Project: "my-proj", Region: "us-central1",
+		},
+		Credential:       credentials.NewAPIKeyCredential("stub"),
+		AdditionalConfig: extra,
+	}
+}
+
+func TestFactoryIsRegistered(t *testing.T) {
+	assert.Contains(t, providers.RegisteredEmbeddingProviderTypes(), "vertex")
+}
+
+// The path #1301 reported as gated: type "vertex" with a Vertex platform block
+// must now construct instead of erroring with "not yet supported".
+func TestFactoryBuildsProviderFromSpec(t *testing.T) {
+	p, err := providers.CreateEmbeddingProviderFromSpec(vertexSpec("text-embedding-005", nil))
+
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, "vertex-embedding", p.ID())
+}
+
+func TestFactoryPassesDimensionsThrough(t *testing.T) {
+	p, err := providers.CreateEmbeddingProviderFromSpec(
+		vertexSpec("text-embedding-005", map[string]any{"dimensions": 256}))
+
+	require.NoError(t, err)
+	assert.Equal(t, 256, p.EmbeddingDimensions())
+}
+
+func TestFactoryPassesTaskTypeThrough(t *testing.T) {
+	// gemini-embedding batches one at a time, so the batch size proves the
+	// model family reached the constructor rather than being defaulted.
+	p, err := providers.CreateEmbeddingProviderFromSpec(
+		vertexSpec("gemini-embedding-001", map[string]any{"task_type": "RETRIEVAL_QUERY"}))
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, p.MaxBatchSize())
+}
+
+// Without a platform block there is no token source, so every request would go
+// unauthenticated. Failing at construction beats failing per request.
+func TestFactoryRequiresPlatformConfig(t *testing.T) {
+	_, err := providers.CreateEmbeddingProviderFromSpec(providers.EmbeddingProviderSpec{
+		Type:  "vertex",
+		Model: "text-embedding-005",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "platform")
+}
+
+// project and region both appear twice in the Vertex URL and cannot be
+// defaulted, so a spec missing either must fail at construction.
+func TestFactoryRequiresProject(t *testing.T) {
+	spec := vertexSpec("text-embedding-005", nil)
+	spec.PlatformConfig = &credentials.PlatformConfig{Type: "vertex", Region: "us-central1"}
+
+	_, err := providers.CreateEmbeddingProviderFromSpec(spec)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "platform.project")
+}

--- a/runtime/providers/vertex/embedding_test.go
+++ b/runtime/providers/vertex/embedding_test.go
@@ -55,9 +55,9 @@ func TestEmbeddingProvider_SendsVertexPredictBody(t *testing.T) {
 	srv, got := predictServer(t, []float32{0.1, 0.2, 0.3}, 7)
 
 	p, err := NewEmbeddingProvider(
-		WithModel("text-embedding-005"),
-		WithBaseURL(srv.URL),
-		WithHTTPClient(srv.Client()),
+		WithWiring(providers.EmbeddingWiring{
+			Model: "text-embedding-005", BaseURL: srv.URL, Client: srv.Client(),
+		}),
 	)
 	require.NoError(t, err)
 
@@ -92,9 +92,9 @@ func TestEmbeddingProvider_SendsTaskType(t *testing.T) {
 	srv, got := predictServer(t, []float32{1}, 1)
 
 	p, err := NewEmbeddingProvider(
-		WithModel("text-embedding-005"),
-		WithBaseURL(srv.URL),
-		WithHTTPClient(srv.Client()),
+		WithWiring(providers.EmbeddingWiring{
+			Model: "text-embedding-005", BaseURL: srv.URL, Client: srv.Client(),
+		}),
 		WithTaskType("RETRIEVAL_QUERY"),
 	)
 	require.NoError(t, err)
@@ -112,10 +112,9 @@ func TestEmbeddingProvider_SendsOutputDimensionality(t *testing.T) {
 	srv, got := predictServer(t, []float32{1}, 1)
 
 	p, err := NewEmbeddingProvider(
-		WithModel("text-embedding-005"),
-		WithBaseURL(srv.URL),
-		WithHTTPClient(srv.Client()),
-		WithDimensions(256),
+		WithWiring(providers.EmbeddingWiring{
+			Model: "text-embedding-005", BaseURL: srv.URL, Client: srv.Client(), Dimensions: 256,
+		}),
 	)
 	require.NoError(t, err)
 
@@ -143,7 +142,7 @@ func TestNewEmbeddingProvider_FamilyDefaults(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.model, func(t *testing.T) {
-			p, err := NewEmbeddingProvider(WithModel(tc.model))
+			p, err := NewEmbeddingProvider(WithWiring(providers.EmbeddingWiring{Model: tc.model}))
 			require.NoError(t, err)
 			assert.Equal(t, tc.dims, p.EmbeddingDimensions())
 			assert.Equal(t, tc.batch, p.MaxBatchSize())
@@ -154,7 +153,7 @@ func TestNewEmbeddingProvider_FamilyDefaults(t *testing.T) {
 // An unknown model is rejected at construction rather than producing a request
 // the endpoint rejects later.
 func TestNewEmbeddingProvider_RejectsUnknownModel(t *testing.T) {
-	_, err := NewEmbeddingProvider(WithModel("gpt-4o"))
+	_, err := NewEmbeddingProvider(WithWiring(providers.EmbeddingWiring{Model: "gpt-4o"}))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported vertex embedding model")
 }
@@ -169,7 +168,9 @@ func TestEmbeddingProvider_RejectsPredictionCountMismatch(t *testing.T) {
 	defer srv.Close()
 
 	p, err := NewEmbeddingProvider(
-		WithModel("text-embedding-005"), WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+		WithWiring(providers.EmbeddingWiring{
+			Model: "text-embedding-005", BaseURL: srv.URL, Client: srv.Client(),
+		}))
 	require.NoError(t, err)
 
 	_, err = p.Embed(context.Background(), providers.EmbeddingRequest{Texts: []string{"a", "b"}})
@@ -183,7 +184,9 @@ func TestEmbeddingProvider_PerRequestModelOverride(t *testing.T) {
 	srv, got := predictServer(t, []float32{1}, 1)
 
 	p, err := NewEmbeddingProvider(
-		WithModel("text-embedding-005"), WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+		WithWiring(providers.EmbeddingWiring{
+			Model: "text-embedding-005", BaseURL: srv.URL, Client: srv.Client(),
+		}))
 	require.NoError(t, err)
 
 	_, err = p.Embed(context.Background(), providers.EmbeddingRequest{

--- a/runtime/providers/vertex/embedding_test.go
+++ b/runtime/providers/vertex/embedding_test.go
@@ -1,0 +1,196 @@
+package vertex
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+// capturedRequest records what the provider sent, so the assertions are about
+// the Vertex wire format rather than about a mock.
+type capturedRequest struct {
+	path string
+	body map[string]any
+}
+
+// predictServer serves Vertex :predict responses with one embedding per
+// instance, and records every request.
+func predictServer(t *testing.T, values []float32, tokens int) (*httptest.Server, *[]capturedRequest) {
+	t.Helper()
+	var got []capturedRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(raw, &body))
+		got = append(got, capturedRequest{path: r.URL.Path, body: body})
+
+		instances, _ := body["instances"].([]any)
+		preds := make([]map[string]any, 0, len(instances))
+		for range instances {
+			preds = append(preds, map[string]any{
+				"embeddings": map[string]any{
+					"values":     values,
+					"statistics": map[string]any{"token_count": tokens},
+				},
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"predictions": preds}))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &got
+}
+
+func TestEmbeddingProvider_SendsVertexPredictBody(t *testing.T) {
+	srv, got := predictServer(t, []float32{0.1, 0.2, 0.3}, 7)
+
+	p, err := NewEmbeddingProvider(
+		WithModel("text-embedding-005"),
+		WithBaseURL(srv.URL),
+		WithHTTPClient(srv.Client()),
+	)
+	require.NoError(t, err)
+
+	resp, err := p.Embed(context.Background(), providers.EmbeddingRequest{
+		Texts: []string{"hello", "world"},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, *got, 1, "text-embedding models batch natively — one call for both texts")
+	req := (*got)[0]
+
+	assert.True(t, strings.HasSuffix(req.path, "/text-embedding-005:predict"),
+		"the model belongs in the path with the :predict verb, got %q", req.path)
+
+	instances, ok := req.body["instances"].([]any)
+	require.True(t, ok, "Vertex expects an instances array, got %v", req.body)
+	require.Len(t, instances, 2)
+	first, ok := instances[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "hello", first["content"], "each instance carries its text under content")
+
+	require.Len(t, resp.Embeddings, 2)
+	assert.Equal(t, []float32{0.1, 0.2, 0.3}, resp.Embeddings[0],
+		"values must be read from predictions[].embeddings.values")
+	require.NotNil(t, resp.Usage)
+	assert.Equal(t, 14, resp.Usage.TotalTokens, "token_count sums across predictions")
+}
+
+// task_type steers Vertex between indexing and query embeddings, and the two
+// are not interchangeable for retrieval quality.
+func TestEmbeddingProvider_SendsTaskType(t *testing.T) {
+	srv, got := predictServer(t, []float32{1}, 1)
+
+	p, err := NewEmbeddingProvider(
+		WithModel("text-embedding-005"),
+		WithBaseURL(srv.URL),
+		WithHTTPClient(srv.Client()),
+		WithTaskType("RETRIEVAL_QUERY"),
+	)
+	require.NoError(t, err)
+
+	_, err = p.Embed(context.Background(), providers.EmbeddingRequest{Texts: []string{"q"}})
+	require.NoError(t, err)
+
+	instances := (*got)[0].body["instances"].([]any)
+	first := instances[0].(map[string]any)
+	assert.Equal(t, "RETRIEVAL_QUERY", first["task_type"])
+}
+
+// outputDimensionality is a request parameter, not a client-side truncation.
+func TestEmbeddingProvider_SendsOutputDimensionality(t *testing.T) {
+	srv, got := predictServer(t, []float32{1}, 1)
+
+	p, err := NewEmbeddingProvider(
+		WithModel("text-embedding-005"),
+		WithBaseURL(srv.URL),
+		WithHTTPClient(srv.Client()),
+		WithDimensions(256),
+	)
+	require.NoError(t, err)
+
+	_, err = p.Embed(context.Background(), providers.EmbeddingRequest{Texts: []string{"x"}})
+	require.NoError(t, err)
+
+	params, ok := (*got)[0].body["parameters"].(map[string]any)
+	require.True(t, ok, "dimensions must travel in parameters, got %v", (*got)[0].body)
+	assert.EqualValues(t, 256, params["outputDimensionality"])
+	assert.Equal(t, 256, p.EmbeddingDimensions(), "the provider reports what it asked for")
+}
+
+// Without an explicit override the reported dimensionality follows the model
+// family, so a caller reading GetDimensions before the first call is not lied to.
+func TestNewEmbeddingProvider_FamilyDefaults(t *testing.T) {
+	tests := []struct {
+		model string
+		dims  int
+		batch int
+	}{
+		{"text-embedding-005", textEmbeddingDimensions, textEmbeddingMaxBatch},
+		{"text-embedding-004", textEmbeddingDimensions, textEmbeddingMaxBatch},
+		{"textembedding-gecko@003", textEmbeddingDimensions, textEmbeddingMaxBatch},
+		{"gemini-embedding-001", geminiEmbeddingDimensions, geminiEmbeddingMaxBatch},
+	}
+	for _, tc := range tests {
+		t.Run(tc.model, func(t *testing.T) {
+			p, err := NewEmbeddingProvider(WithModel(tc.model))
+			require.NoError(t, err)
+			assert.Equal(t, tc.dims, p.EmbeddingDimensions())
+			assert.Equal(t, tc.batch, p.MaxBatchSize())
+		})
+	}
+}
+
+// An unknown model is rejected at construction rather than producing a request
+// the endpoint rejects later.
+func TestNewEmbeddingProvider_RejectsUnknownModel(t *testing.T) {
+	_, err := NewEmbeddingProvider(WithModel("gpt-4o"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported vertex embedding model")
+}
+
+// A response with fewer predictions than instances is a protocol violation, and
+// silently returning short results would corrupt a vector index.
+func TestEmbeddingProvider_RejectsPredictionCountMismatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"predictions":[{"embeddings":{"values":[1,2]}}]}`))
+	}))
+	defer srv.Close()
+
+	p, err := NewEmbeddingProvider(
+		WithModel("text-embedding-005"), WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	require.NoError(t, err)
+
+	_, err = p.Embed(context.Background(), providers.EmbeddingRequest{Texts: []string{"a", "b"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "returned 1 embeddings for 2 texts")
+}
+
+// A per-request model override must reach the URL: the base URL is the models
+// collection, not a single model, which is what makes the override possible.
+func TestEmbeddingProvider_PerRequestModelOverride(t *testing.T) {
+	srv, got := predictServer(t, []float32{1}, 1)
+
+	p, err := NewEmbeddingProvider(
+		WithModel("text-embedding-005"), WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	require.NoError(t, err)
+
+	_, err = p.Embed(context.Background(), providers.EmbeddingRequest{
+		Texts: []string{"x"}, Model: "text-embedding-004",
+	})
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasSuffix((*got)[0].path, "/text-embedding-004:predict"),
+		"got %q", (*got)[0].path)
+}

--- a/sdk/provider_introspection_test.go
+++ b/sdk/provider_introspection_test.go
@@ -61,6 +61,12 @@ func TestRegisteredProviderTypes_IncludesBedrockEmbedding(t *testing.T) {
 	assert.Contains(t, RegisteredProviderTypes()[pkgconfig.RoleEmbedding], "bedrock")
 }
 
+// Same for Vertex (#1301): the provider is unreachable from the SDK without the
+// blank import, so the registration is only real if this passes.
+func TestRegisteredProviderTypes_IncludesVertexEmbedding(t *testing.T) {
+	assert.Contains(t, RegisteredProviderTypes()[pkgconfig.RoleEmbedding], "vertex")
+}
+
 // The binding #1774 reported as broken must now validate — and the platform
 // block must be what makes the difference. Bedrock has no API-key mode, so a
 // spec without one has no SigV4 signer and every request would go unsigned;

--- a/sdk/runtime_config.go
+++ b/sdk/runtime_config.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/imagen"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/ollama"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/openai"
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/vertex"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/voyageai"
 	"github.com/AltairaLabs/PromptKit/runtime/selection"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"


### PR DESCRIPTION
Implements the Vertex AI embedding provider and removes the `platform: vertex` gate. Closes #1301.

## Why this was gated rather than plumbed

`buildPlatformEmbeddingClient` returned "not yet supported" for Vertex. The blockers were never auth — `GCPCredential.Apply` already produces a bearer token the existing RoundTripper applies:

1. **Wrong publisher.** `credentials.VertexEndpoint` hardcodes `publishers/anthropic`. Embeddings live under `publishers/google`.
2. **Wrong wire format.** `:predict` takes `{"instances":[{"content":…}]}` and returns `{"predictions":[{"embeddings":{"values":[…]}}]}`. No OpenAI-shaped provider emits that, so this needed its own provider type — the same reason Bedrock got one in #1780.

## What's here

- **`runtime/providers/vertex`** — `EmbeddingProvider` over the `:predict` shapes, with `task_type` (RETRIEVAL_DOCUMENT / RETRIEVAL_QUERY) and `outputDimensionality` as request parameters rather than client-side handling.
- **`credentials.VertexEmbeddingEndpoint`** — deliberately a separate function, not a publisher argument on the existing one. An anthropic-shaped URL for an embedding model is structurally valid and only fails when a request is made, so the mistake is invisible at construction. Both helpers now build from one format string so they cannot drift.
- **Transport** — Vertex resolves the models *collection*, like Bedrock and unlike Azure, so the provider appends `/{model}:predict` and a per-request model override still works. `project` and `region` are both required (each appears twice in the URL); an explicit `platform.endpoint` overrides.
- **Registration + the blank import** in `sdk/runtime_config.go`.

That last point is the one worth checking in review. Without the import the provider exists and no SDK caller can construct it — precisely the gap #1774 reported for Bedrock — so there is a test asserting `vertex` appears in the SDK's embedding types, not merely in the runtime registry.

## Test replaced, not deleted

`TestResolveEmbeddingTransport_VertexStillGated` asserted the behaviour this PR removes. It becomes four tests over the new behaviour: the wrong-type guard, the google-publisher endpoint, the project/region requirements, and the explicit-endpoint override.

## Not verified against live Vertex

Stated plainly, as with the Bedrock provider it mirrors: **this has never run against the real service.** Unit tests prove the request shape and the response parse against an httptest server, which cannot tell you whether Vertex accepts the request.

The `-tags=integration` suite covers exactly what they can't, and needs `gcloud auth application-default login` plus `GCP_PROJECT`:

- a batch call returning vectors in input order — the claim most likely to be wrong, since batching is asserted by construction here;
- `outputDimensionality` honoured server-side;
- reported dimensionality matching what the service returns.

Family defaults (768 dims / 250 batch for `text-embedding-*`, 3072 / 1 for `gemini-embedding-*`) come from documentation, not observation. They are overridable, the endpoint remains the authority, and a response with fewer predictions than instances is rejected rather than returned misaligned — silently short results would corrupt whatever index consumed them.
