### PR TITLE
feat(adaptersdk): shared prior-state drift reconciliation

### DIFF
--- a/runtime/deploy/adaptersdk/drift.go
+++ b/runtime/deploy/adaptersdk/drift.go
@@ -1,0 +1,118 @@
+package adaptersdk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AltairaLabs/PromptKit/runtime/deploy"
+)
+
+// Existence is what a probe could determine about a resource.
+//
+// Unknown is the zero value on purpose: a probe that fails to answer, or a
+// caller that forgets to set one, must land on the conservative outcome rather
+// than on "absent".
+type Existence int
+
+const (
+	// ExistsUnknown means the lookup could not determine the answer. It is not
+	// evidence of absence.
+	ExistsUnknown Existence = iota
+	// ExistsYes means the resource is present. It says nothing about health:
+	// a degraded resource still exists, so it is an update, not a recreate.
+	ExistsYes
+	// ExistsNo means the resource is confirmed gone.
+	ExistsNo
+)
+
+// ResourceRef identifies a resource recorded in prior state.
+//
+// Type and Name mirror deploy.ResourceChange so a dropped resource can be
+// reported without translation. ID carries the provider's own identifier when
+// the adapter stored one — often the only handle a lookup can use.
+type ResourceRef struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+	ID   string `json:"id,omitempty"`
+}
+
+// ResourceProbe answers whether a previously-deployed resource still exists.
+//
+// Adapters implement this against their own API; everything else about drift
+// reconciliation is shared. Returning an error is equivalent to answering
+// ExistsUnknown — the error is kept for the message, not for the decision.
+type ResourceProbe interface {
+	Exists(ctx context.Context, ref ResourceRef) (Existence, error)
+}
+
+// ReconcilePriorState drops resources that no longer exist and reports them as
+// drift.
+//
+// A plan built from a stored state blob alone cannot see changes made outside
+// promptarena: delete a resource in the cloud console and the adapter plans an
+// UPDATE against something that is gone, which then fails at apply. Probing
+// prior state against the live provider is what closes that gap.
+//
+// Three rules, and the third is the one worth sharing:
+//
+//   - confirmed absent  → drop, and report drift
+//   - present, however degraded → keep; it exists, so it is an update
+//   - lookup failed or unknown  → keep
+//
+// The last is easy to get backwards and expensive when wrong. Dropping a
+// resource because the lookup errored plans a CREATE that collides with the
+// live resource at apply time — turning a transient API error into a hard
+// failure, or worse, a duplicate. Vertex makes this concrete: a malformed
+// resource name returns InvalidArgument, not NotFound, so any "not found means
+// absent" shortcut that treats every error alike deletes real state.
+//
+// A nil probe keeps everything: an adapter that cannot look up resources has
+// no basis to drop them, and silently dropping would turn every plan into a
+// full recreate.
+func ReconcilePriorState(
+	ctx context.Context, probe ResourceProbe, refs []ResourceRef,
+) (kept []ResourceRef, drift []deploy.ResourceChange) {
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	if probe == nil {
+		return refs, nil
+	}
+
+	kept = make([]ResourceRef, 0, len(refs))
+	for _, r := range refs {
+		existence, err := probe.Exists(ctx, r)
+		if err != nil {
+			// Keep: the lookup failed, which tells us nothing about the
+			// resource. See the rules above.
+			kept = append(kept, r)
+			continue
+		}
+		if existence == ExistsNo {
+			drift = append(drift, driftChange(r))
+			continue
+		}
+		kept = append(kept, r)
+	}
+	return kept, drift
+}
+
+// driftChange builds the ResourceChange reported for a resource that vanished.
+//
+// Drift is a ResourceChange rather than a free-text warning so it travels the
+// same path as every other change — counted by SummarizeChanges, rendered in
+// the plan, and machine-readable — instead of prose each adapter formats its
+// own way.
+func driftChange(r ResourceRef) deploy.ResourceChange {
+	detail := fmt.Sprintf("%s no longer exists at the provider; it was removed outside promptarena", r.Name)
+	if r.ID != "" {
+		detail = fmt.Sprintf("%s (%s) no longer exists at the provider; it was removed outside promptarena",
+			r.Name, r.ID)
+	}
+	return deploy.ResourceChange{
+		Type:   r.Type,
+		Name:   r.Name,
+		Action: deploy.ActionDrift,
+		Detail: detail,
+	}
+}

--- a/runtime/deploy/adaptersdk/drift_test.go
+++ b/runtime/deploy/adaptersdk/drift_test.go
@@ -1,0 +1,149 @@
+package adaptersdk
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/deploy"
+)
+
+// fakeProbe answers from a scripted map, and records what it was asked.
+type fakeProbe struct {
+	answers map[string]Existence
+	errs    map[string]error
+	asked   []string
+}
+
+func (p *fakeProbe) Exists(_ context.Context, ref ResourceRef) (Existence, error) {
+	p.asked = append(p.asked, ref.Name)
+	if err, ok := p.errs[ref.Name]; ok {
+		return ExistsUnknown, err
+	}
+	return p.answers[ref.Name], nil
+}
+
+func ref(name string) ResourceRef {
+	return ResourceRef{Type: "agent_runtime", Name: name, ID: "id-" + name}
+}
+
+// A resource deleted outside promptarena must be dropped from prior state, or
+// the plan plots an UPDATE against something that no longer exists and apply
+// fails.
+func TestReconcilePriorState_DropsAbsentResources(t *testing.T) {
+	probe := &fakeProbe{answers: map[string]Existence{
+		"alpha": ExistsYes,
+		"beta":  ExistsNo,
+	}}
+
+	kept, drift := ReconcilePriorState(context.Background(), probe,
+		[]ResourceRef{ref("alpha"), ref("beta")})
+
+	require.Len(t, kept, 1)
+	assert.Equal(t, "alpha", kept[0].Name)
+
+	require.Len(t, drift, 1)
+	assert.Equal(t, deploy.ActionDrift, drift[0].Action)
+	assert.Equal(t, "beta", drift[0].Name)
+	assert.Equal(t, "agent_runtime", drift[0].Type)
+	assert.Contains(t, drift[0].Detail, "no longer exists")
+}
+
+// The rule that is easy to get backwards and expensive when wrong: a failed
+// lookup is not evidence of absence. Dropping on error plans a CREATE that
+// collides with the live resource at apply time.
+func TestReconcilePriorState_KeepsResourcesWhoseLookupFailed(t *testing.T) {
+	probe := &fakeProbe{
+		answers: map[string]Existence{"alpha": ExistsYes},
+		errs:    map[string]error{"beta": errors.New("InvalidArgument: malformed name")},
+	}
+
+	kept, drift := ReconcilePriorState(context.Background(), probe,
+		[]ResourceRef{ref("alpha"), ref("beta")})
+
+	require.Len(t, kept, 2, "a resource whose lookup errored must be kept")
+	assert.Empty(t, drift, "an errored lookup is not drift — nothing was observed to be missing")
+}
+
+// ExistsUnknown without an error means the same thing: the probe could not
+// tell, so the resource stays.
+func TestReconcilePriorState_KeepsUnknown(t *testing.T) {
+	probe := &fakeProbe{answers: map[string]Existence{"alpha": ExistsUnknown}}
+
+	kept, drift := ReconcilePriorState(context.Background(), probe, []ResourceRef{ref("alpha")})
+
+	require.Len(t, kept, 1)
+	assert.Empty(t, drift)
+}
+
+// A resource that exists but is unhealthy is still an UPDATE, not a recreate,
+// so the probe reporting ExistsYes must keep it regardless of its condition.
+func TestReconcilePriorState_KeepsDegradedResources(t *testing.T) {
+	probe := &fakeProbe{answers: map[string]Existence{"degraded": ExistsYes}}
+
+	kept, drift := ReconcilePriorState(context.Background(), probe, []ResourceRef{ref("degraded")})
+
+	require.Len(t, kept, 1)
+	assert.Empty(t, drift)
+}
+
+// Without a probe the adapter has no way to check, so prior state is trusted
+// as-is. Silently dropping everything would turn every plan into a full
+// recreate.
+func TestReconcilePriorState_NilProbeKeepsEverything(t *testing.T) {
+	refs := []ResourceRef{ref("alpha"), ref("beta")}
+
+	kept, drift := ReconcilePriorState(context.Background(), nil, refs)
+
+	assert.Equal(t, refs, kept)
+	assert.Empty(t, drift)
+}
+
+func TestReconcilePriorState_EmptyRefs(t *testing.T) {
+	probe := &fakeProbe{answers: map[string]Existence{}}
+
+	kept, drift := ReconcilePriorState(context.Background(), probe, nil)
+
+	assert.Empty(t, kept)
+	assert.Empty(t, drift)
+	assert.Empty(t, probe.asked, "an empty prior state must not call the provider at all")
+}
+
+// Order is preserved so a plan built from the kept refs is deterministic.
+func TestReconcilePriorState_PreservesOrder(t *testing.T) {
+	probe := &fakeProbe{answers: map[string]Existence{
+		"a": ExistsYes, "b": ExistsNo, "c": ExistsYes, "d": ExistsYes,
+	}}
+
+	kept, _ := ReconcilePriorState(context.Background(), probe,
+		[]ResourceRef{ref("a"), ref("b"), ref("c"), ref("d")})
+
+	require.Len(t, kept, 3)
+	assert.Equal(t, []string{"a", "c", "d"}, []string{kept[0].Name, kept[1].Name, kept[2].Name})
+}
+
+// Drift is reported as a ResourceChange rather than a string so it flows into
+// the plan the same way every other change does — countable, renderable and
+// machine-readable, instead of prose each adapter formats differently.
+func TestSummarizeChanges_RendersDrift(t *testing.T) {
+	changes := []deploy.ResourceChange{
+		{Type: "agent_runtime", Name: "a", Action: deploy.ActionCreate},
+		{Type: "agent_runtime", Name: "b", Action: deploy.ActionDrift},
+		{Type: "agent_runtime", Name: "c", Action: deploy.ActionDrift},
+	}
+
+	assert.Equal(t, "1 to create, 2 drifted", SummarizeChanges(changes))
+}
+
+// A plan that is nothing but drift must not read as "No changes" — that is the
+// case an operator most needs to see.
+func TestSummarizeChanges_DriftOnlyIsNotNoChanges(t *testing.T) {
+	changes := []deploy.ResourceChange{
+		{Type: "agent_runtime", Name: "b", Action: deploy.ActionDrift},
+	}
+
+	assert.Equal(t, "1 drifted", SummarizeChanges(changes))
+}

--- a/runtime/deploy/adaptersdk/plan.go
+++ b/runtime/deploy/adaptersdk/plan.go
@@ -91,17 +91,21 @@ func SummarizeChanges(changes []deploy.ResourceChange) string {
 		counts[c.Action]++
 	}
 
-	// Fixed order for deterministic output.
+	// Fixed order for deterministic output. Drift is included because a plan
+	// made entirely of drift would otherwise summarize as "No changes" — the
+	// case an operator most needs to see (#1781).
 	order := []deploy.Action{
 		deploy.ActionCreate,
 		deploy.ActionUpdate,
 		deploy.ActionDelete,
+		deploy.ActionDrift,
 		deploy.ActionNoChange,
 	}
 	labels := map[deploy.Action]string{
 		deploy.ActionCreate:   "to create",
 		deploy.ActionUpdate:   "to update",
 		deploy.ActionDelete:   "to delete",
+		deploy.ActionDrift:    "drifted",
 		deploy.ActionNoChange: "unchanged",
 	}
 


### PR DESCRIPTION
Implements the shared drift-detection contract. Closes #1781.

## What it is

`ReconcilePriorState(ctx, probe, refs)` takes a `ResourceProbe` — the one piece that is genuinely provider-specific — and applies the three rules the three existing implementations already agree on:

| Probe says | Outcome |
|---|---|
| confirmed absent | drop, and report drift |
| present, however degraded | keep — it exists, so it is an update, not a recreate |
| lookup failed, or unknown | keep |

A nil probe keeps everything: an adapter that cannot look up resources has no basis to drop them, and dropping silently would turn every plan into a full recreate.

## The third rule is why this belongs in one place

Dropping a resource because its lookup *errored* plans a CREATE that collides with the live resource at apply time — a transient API error becomes a hard failure, or a duplicate. The vertex adapter found the concrete case: a malformed resource name returns `InvalidArgument`, **not** `NotFound`, so any "error means gone" shortcut deletes real state. A fake client returning a clean not-found would never have surfaced it.

`Existence`'s zero value is `ExistsUnknown` for the same reason — a probe that fails to answer, or a caller that forgets to set one, lands on the conservative outcome by default rather than on "absent".

## Drift is a ResourceChange, not a string

The issue sketched `drift []string`. I've returned `[]deploy.ResourceChange` with `ActionDrift` instead, because strings cannot be counted, rendered, or read by anything downstream — and agentcore appending to a plan summary while vertex used `Warnings` is precisely the divergence a shared contract should end.

**That required fixing `ActionDrift` itself.** It has existed since the deploy package was written and is referenced *nowhere* outside its own definition and an enum test. `SummarizeChanges` omitted it from both its order and label maps, so a plan made entirely of drift rendered **"No changes"** — the one case an operator most needs to see. It now counts as `N drifted`.

That is the third instance of this shape found today, after `max_tool_calls` (#1788) and `validation.started` (#1789): a declared vocabulary with no producer, where the consumer side looks complete enough that nobody notices.

## Testing

Each rule has its own test, plus order preservation, empty refs (which must not call the provider at all), and the nil probe.

**Mutation-verified on the two that matter:** treating an errored lookup as absent fails `KeepsResourcesWhoseLookupFailed`; removing drift from the summary order fails both summary tests. `drift.go` is at 100% coverage.

## Scope

The adapters live in separate repos, so this ships the contract only. Wiring agentcore, vertex and omnia onto it — and deleting their three private implementations — follows there. The omnia case is the least direct fit: it *discovers* resources by label selector rather than verifying stored ones, so it may want a discovery entry point alongside this rather than a straight swap.
