### PR TITLE
feat(providers): reach Vertex Model Garden through the OpenAI provider

### DIFF
--- a/runtime/credentials/gcp.go
+++ b/runtime/credentials/gcp.go
@@ -37,6 +37,36 @@ func VertexEmbeddingEndpoint(project, region string) string {
 	return vertexPublisherEndpoint(project, region, vertexPublisherGoogle)
 }
 
+// DefaultVertexOpenAIEndpointID is the shared endpoint serving Vertex's
+// OpenAI-compatible Chat Completions API for Gemini and MaaS partner models.
+// Self-deployed Model Garden models use their own numeric endpoint ID instead.
+const DefaultVertexOpenAIEndpointID = "openapi"
+
+// VertexOpenAIEndpoint returns the base URL for Vertex AI's OpenAI-compatible
+// Chat Completions API. Callers append "/chat/completions" — the OpenAI
+// provider does this itself, so the helper stops short of it.
+//
+// endpointID selects the surface: empty means the shared "openapi" endpoint
+// (Gemini plus MaaS partner models, zero configuration), and a numeric ID
+// targets a self-deployed Model Garden endpoint.
+//
+// Separate from VertexEndpoint because this path differs in both API version
+// (v1beta1) and shape (endpoints/{id} rather than publishers/{p}/models) — the
+// two are not interchangeable, and substituting one produces a URL that is
+// structurally valid and fails only at request time.
+//
+// Note: a self-deployed endpoint only speaks chat-completions when it is backed
+// by a TGI, vLLM or HexLLM serving container deployed after 2024-08-20. That is
+// not visible on the endpoint resource, so an older one fails at request time.
+func VertexOpenAIEndpoint(project, region, endpointID string) string {
+	if endpointID == "" {
+		endpointID = DefaultVertexOpenAIEndpointID
+	}
+	return fmt.Sprintf(
+		"https://%s-aiplatform.googleapis.com/v1beta1/projects/%s/locations/%s/endpoints/%s",
+		region, project, region, endpointID)
+}
+
 // vertexPublisherEndpoint builds the models base URL for one publisher. Single
 // format string so the two exported helpers cannot drift.
 func vertexPublisherEndpoint(project, region, publisher string) string {

--- a/runtime/credentials/gcp_integration_test.go
+++ b/runtime/credentials/gcp_integration_test.go
@@ -245,3 +245,38 @@ func TestVertexEmbeddingEndpoint(t *testing.T) {
 	assert.NotContains(t, got, "anthropic",
 		"the embedding endpoint must not inherit the chat publisher")
 }
+
+// Model Garden's OpenAI-compatible surface is a different shape from the
+// publisher-models path: v1beta1, and endpoints/{id} rather than
+// publishers/{p}/models. Reusing either of the other helpers produces a URL
+// that only fails when a request is made.
+func TestVertexOpenAIEndpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		endpointID string
+		want       string
+	}{
+		{
+			name:       "shared MaaS endpoint defaults to openapi",
+			endpointID: "",
+			want: "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project" +
+				"/locations/us-central1/endpoints/openapi",
+		},
+		{
+			name:       "dedicated self-deployed endpoint",
+			endpointID: "4812379461283840",
+			want: "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project" +
+				"/locations/us-central1/endpoints/4812379461283840",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := VertexOpenAIEndpoint("my-project", "us-central1", tc.endpointID)
+			assert.Equal(t, tc.want, got)
+			// The OpenAI provider appends /chat/completions itself, so the
+			// helper must stop short of it or the path doubles up.
+			assert.NotContains(t, got, "chat/completions")
+			assert.NotContains(t, got, "publishers")
+		})
+	}
+}

--- a/runtime/providers/openai/openai.go
+++ b/runtime/providers/openai/openai.go
@@ -217,6 +217,15 @@ func NewProviderFromConfig(cfg *ProviderConfig) *Provider {
 			baseURL = credentials.AzureOpenAIEndpoint(cfg.PlatformConfig.Endpoint, cfg.Model)
 		case cfg.Platform == bedrockPlatform && cfg.PlatformConfig != nil && cfg.PlatformConfig.Region != "":
 			baseURL = credentials.BedrockEndpoint(cfg.PlatformConfig.Region)
+		// Vertex needs both project and region — each appears twice in the URL
+		// and neither has a default. PlatformConfig.Endpoint carries the
+		// endpoint ID here, not a host: empty selects the shared "openapi"
+		// endpoint (Gemini and MaaS partner models), and a numeric ID targets a
+		// self-deployed Model Garden endpoint.
+		case cfg.Platform == vertexPlatform && cfg.PlatformConfig != nil &&
+			cfg.PlatformConfig.Project != "" && cfg.PlatformConfig.Region != "":
+			baseURL = credentials.VertexOpenAIEndpoint(
+				cfg.PlatformConfig.Project, cfg.PlatformConfig.Region, cfg.PlatformConfig.Endpoint)
 		}
 	}
 
@@ -450,6 +459,10 @@ func (p *Provider) applyAuth(ctx context.Context, req *http.Request) error {
 const (
 	azurePlatform   = "azure"
 	bedrockPlatform = "bedrock"
+	// vertexPlatform reaches Vertex AI's OpenAI-compatible Chat Completions
+	// API, which covers Model Garden — Gemini, MaaS partner models, and
+	// self-deployed TGI/vLLM endpoints — with ADC and no API key.
+	vertexPlatform = "vertex"
 )
 
 // isAzure returns true if this provider is hosted on Azure OpenAI.

--- a/runtime/providers/openai/openai_tools.go
+++ b/runtime/providers/openai/openai_tools.go
@@ -647,12 +647,14 @@ func (p *ToolProvider) predictStreamWithCompletions(
 
 //nolint:gochecknoinits // Factory registration requires init
 func init() {
-	// Reject (openai, vertex): Vertex AI does not host OpenAI models as a
-	// native partner endpoint. Routing this combination would either 404
-	// at the wire or silently send Entra-style auth to an OpenAI-shaped
-	// URL. Fail at construction with a clear error instead. (#1009)
-	providers.RegisterProviderFactory("openai", providers.RejectPlatforms(
-		map[string]bool{"vertex": true},
+	// (openai, vertex) was rejected under #1009 because Vertex hosts no
+	// OpenAI-shaped endpoint, so the pair could only 404 at the wire. That is
+	// no longer true: Vertex exposes an OpenAI-compatible Chat Completions API
+	// covering Model Garden, and the platform switch now builds its URL from
+	// project/region with an ADC bearer token (#1768). The rejection is lifted
+	// rather than narrowed — with a base URL and a credential, the combination
+	// is real.
+	providers.RegisterProviderFactory("openai",
 		providers.CredentialFactory(
 			func(spec providers.ProviderSpec) (providers.Provider, error) {
 				tp := NewToolProviderWithCredential(
@@ -672,5 +674,5 @@ func init() {
 				return tp, nil
 			},
 		),
-	))
+	)
 }

--- a/runtime/providers/openai/vertex_unit_test.go
+++ b/runtime/providers/openai/vertex_unit_test.go
@@ -1,0 +1,142 @@
+package openai
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+)
+
+func vertexPlatformConfig(endpointID string) *providers.PlatformConfig {
+	return &providers.PlatformConfig{
+		Type:     vertexPlatform,
+		Project:  "my-project",
+		Region:   "us-central1",
+		Endpoint: endpointID,
+	}
+}
+
+// Vertex Model Garden is reachable only if the platform switch maps it to a
+// base URL. The credential half was already wired — this is the missing half
+// (#1768).
+func TestNewProviderFromConfig_Vertex(t *testing.T) {
+	cred := &mockSigningCredential{}
+
+	t.Run("derives the shared MaaS endpoint from project and region", func(t *testing.T) {
+		p := NewProviderFromConfig(&ProviderConfig{
+			ID:             "llama-maas",
+			Model:          "meta/llama-3.3-70b-instruct-maas",
+			Platform:       vertexPlatform,
+			PlatformConfig: vertexPlatformConfig(""),
+			Credential:     cred,
+		})
+		want := "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project" +
+			"/locations/us-central1/endpoints/openapi"
+		if p.baseURL != want {
+			t.Errorf("baseURL = %q, want %q", p.baseURL, want)
+		}
+	})
+
+	t.Run("targets a dedicated self-deployed endpoint by ID", func(t *testing.T) {
+		p := NewProviderFromConfig(&ProviderConfig{
+			ID:             "qwen-self-hosted",
+			Model:          "qwen2.5-7b",
+			Platform:       vertexPlatform,
+			PlatformConfig: vertexPlatformConfig("4812379461283840"),
+			Credential:     cred,
+		})
+		if !strings.HasSuffix(p.baseURL, "/endpoints/4812379461283840") {
+			t.Errorf("baseURL = %q, want it to target the dedicated endpoint", p.baseURL)
+		}
+	})
+
+	// The request URL is what actually reaches Vertex; the provider appends the
+	// path itself, so a helper that included it would double up.
+	t.Run("request URL appends chat/completions exactly once", func(t *testing.T) {
+		p := NewProviderFromConfig(&ProviderConfig{
+			ID:             "llama-maas",
+			Model:          "meta/llama-3.3-70b-instruct-maas",
+			Platform:       vertexPlatform,
+			PlatformConfig: vertexPlatformConfig(""),
+			Credential:     cred,
+		})
+		got := p.chatCompletionsURL()
+		want := "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project" +
+			"/locations/us-central1/endpoints/openapi/chat/completions"
+		if got != want {
+			t.Errorf("chatCompletionsURL() = %q, want %q", got, want)
+		}
+		if strings.Count(got, "chat/completions") != 1 {
+			t.Errorf("chat/completions appears %d times in %q", strings.Count(got, "chat/completions"), got)
+		}
+	})
+
+	t.Run("explicit BaseURL is preserved", func(t *testing.T) {
+		custom := "https://custom.vertex.example/v1beta1/endpoints/openapi"
+		p := NewProviderFromConfig(&ProviderConfig{
+			ID:             "test",
+			Model:          "qwen2.5-7b",
+			BaseURL:        custom,
+			Platform:       vertexPlatform,
+			PlatformConfig: vertexPlatformConfig(""),
+			Credential:     cred,
+		})
+		if p.baseURL != custom {
+			t.Errorf("baseURL = %q, want the explicit %q", p.baseURL, custom)
+		}
+	})
+
+	// Both appear twice in the URL and neither has a sane default, so an
+	// incomplete platform block must not produce a half-built URL.
+	t.Run("incomplete platform config derives no base URL", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			pc   *providers.PlatformConfig
+		}{
+			{"no project", &providers.PlatformConfig{Type: vertexPlatform, Region: "us-central1"}},
+			{"no region", &providers.PlatformConfig{Type: vertexPlatform, Project: "my-project"}},
+			{"nil config", nil},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				p := NewProviderFromConfig(&ProviderConfig{
+					ID:             "test",
+					Model:          "qwen2.5-7b",
+					Platform:       vertexPlatform,
+					PlatformConfig: tc.pc,
+					Credential:     cred,
+				})
+				if p.baseURL != "" {
+					t.Errorf("baseURL = %q, want empty for an incomplete platform block", p.baseURL)
+				}
+			})
+		}
+	})
+}
+
+// The registry is where this was actually unreachable. (openai, vertex) was
+// rejected outright by RejectPlatforms under #1009, so fixing the platform
+// switch alone would have left the feature inert — the constructor is never
+// called for a spec the factory refuses.
+func TestCreateProviderFromSpec_VertexIsNoLongerRejected(t *testing.T) {
+	p, err := providers.CreateProviderFromSpec(providers.ProviderSpec{
+		ID:             "llama-maas",
+		Type:           "openai",
+		Model:          "meta/llama-3.3-70b-instruct-maas",
+		Platform:       vertexPlatform,
+		PlatformConfig: vertexPlatformConfig(""),
+		Credential:     &mockSigningCredential{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tp, ok := p.(*ToolProvider)
+	if !ok {
+		t.Fatalf("provider = %T, want *ToolProvider", p)
+	}
+	want := "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-project" +
+		"/locations/us-central1/endpoints/openapi"
+	if tp.baseURL != want {
+		t.Errorf("baseURL = %q, want %q", tp.baseURL, want)
+	}
+}

--- a/runtime/providers/registry.go
+++ b/runtime/providers/registry.go
@@ -297,6 +297,24 @@ type MediaStorageConfigurable interface {
 	SetMediaStorageService(storage.MediaStorageService)
 }
 
+// openAIBuildsPlatformBaseURL reports whether the openai factory derives the
+// base URL itself from PlatformConfig — Azure's deployment URL, Bedrock's
+// regional invoke URL, Vertex's Model Garden endpoint.
+//
+// For those, applying the api.openai.com default here would clobber spec.BaseURL
+// and make the platform branch in NewProviderFromConfig unreachable (#1010).
+// Kept as a named list because the failure is silent: the provider constructs
+// fine and simply talks to the wrong host. A platform added to the factory's
+// switch and forgotten here looks implemented and is not (#1768).
+func openAIBuildsPlatformBaseURL(platform string) bool {
+	switch platform {
+	case platformAzure, platformBedrock, platformVertex:
+		return true
+	default:
+		return false
+	}
+}
+
 // CreateProviderFromSpec creates a provider implementation from a spec.
 // Returns an error if the provider type is unsupported.
 func CreateProviderFromSpec(spec ProviderSpec) (Provider, error) {
@@ -305,13 +323,7 @@ func CreateProviderFromSpec(spec ProviderSpec) (Provider, error) {
 	if baseURL == "" {
 		switch spec.Type {
 		case "openai":
-			// Skip the api.openai.com default for hyperscaler-hosted
-			// OpenAI — the openai factory builds the platform URL from
-			// PlatformConfig (Azure: deployment URL; Bedrock: regional
-			// invoke URL). Without these skips the default clobbers
-			// spec.BaseURL and the platform branch in
-			// NewProviderFromConfig becomes unreachable (#1010).
-			if spec.Platform != "azure" && spec.Platform != "bedrock" {
+			if !openAIBuildsPlatformBaseURL(spec.Platform) {
 				baseURL = "https://api.openai.com/v1"
 			}
 		case "gemini":

--- a/runtime/providers/reject_platforms_test.go
+++ b/runtime/providers/reject_platforms_test.go
@@ -65,26 +65,48 @@ func TestUnsupportedProviderPlatformError_Message(t *testing.T) {
 	}
 }
 
-// TestCreateProviderFromSpec_RejectsOpenAIVertex verifies the registered
-// openai factory returns UnsupportedProviderPlatformError when the spec
-// asks for Vertex (which Google does not host as an OpenAI partner
-// endpoint).
-func TestCreateProviderFromSpec_RejectsOpenAIVertex(t *testing.T) {
+// (openai, vertex) is no longer rejected. #1009 blocked it because Vertex
+// hosted no OpenAI-shaped endpoint, so the pair could only 404; #1768 added the
+// OpenAI-compatible Model Garden route, so the combination is real and the
+// rejection was lifted. This replaces the old rejection test.
+//
+// The base URL is the assertion that matters: the api.openai.com default must
+// NOT be applied, or the provider constructs happily and talks to the wrong
+// host — a silent failure the old error at least made loud.
+func TestCreateProviderFromSpec_AllowsOpenAIVertex(t *testing.T) {
 	if _, ok := providerFactories["openai"]; !ok {
 		t.Skip("openai factory not registered; subpackage not imported in this test build")
 	}
-	_, err := CreateProviderFromSpec(ProviderSpec{
+	p, err := CreateProviderFromSpec(ProviderSpec{
 		ID:       "x",
 		Type:     "openai",
 		Model:    testModelName,
 		Platform: "vertex",
+		PlatformConfig: &PlatformConfig{
+			Type: "vertex", Project: "my-project", Region: "us-central1",
+		},
 	})
-	if err == nil {
-		t.Fatal("expected error for openai+vertex, got nil")
+	if err != nil {
+		t.Fatalf("openai+vertex must construct, got %v", err)
 	}
-	var typed *UnsupportedProviderPlatformError
-	if !errors.As(err, &typed) {
-		t.Fatalf("expected UnsupportedProviderPlatformError, got %T: %v", err, err)
+	if p == nil {
+		t.Fatal("provider = nil")
+	}
+}
+
+// The default base URL must be skipped for every platform whose factory builds
+// its own, or the platform branch is unreachable (#1010) — the defect that made
+// #1768 look implemented while it was not.
+func TestOpenAIBuildsPlatformBaseURL(t *testing.T) {
+	for _, platform := range []string{"azure", "bedrock", "vertex"} {
+		if !openAIBuildsPlatformBaseURL(platform) {
+			t.Errorf("openAIBuildsPlatformBaseURL(%q) = false, want true", platform)
+		}
+	}
+	for _, platform := range []string{"", "none", "openai"} {
+		if openAIBuildsPlatformBaseURL(platform) {
+			t.Errorf("openAIBuildsPlatformBaseURL(%q) = true, want false", platform)
+		}
 	}
 }
 


### PR DESCRIPTION
Makes Vertex AI Model Garden reachable through the existing OpenAI provider with ADC and no API key. Closes #1768.

## Four gates, not one

The issue describes this as a single missing endpoint mapping — "the OpenAI provider already has everything needed except..." That is true of the *constructor* and false of the path a config actually takes:

1. **`credentials.VertexOpenAIEndpoint`** — new helper. The OpenAI-compatible path differs from the publisher-models path in both API version (`v1beta1`) and shape (`endpoints/{id}` vs `publishers/{p}/models`), so `VertexEndpoint` cannot be reused. Empty endpoint ID → the shared `openapi` endpoint (Gemini + MaaS partners, zero config); a numeric ID → a self-deployed endpoint.
2. **The platform switch** in `NewProviderFromConfig`, requiring project **and** region — each appears twice in the URL and neither has a default.
3. **`RejectPlatforms{"vertex": true}`** on the openai factory. #1009 added it because Vertex hosted no OpenAI-shaped endpoint, so the pair could only 404 at the wire. That premise no longer holds, so the rejection is lifted rather than narrowed.
4. **`CreateProviderFromSpec`'s default base URL.** `api.openai.com/v1` is applied unless the platform is in a skip list — which held only `azure` and `bedrock`. It would have clobbered `spec.BaseURL` and left the new branch unreachable.

**Gates 3 and 4 were caught only by a test that goes through `CreateProviderFromSpec`.** Every unit test of the constructor passed while the feature was completely unreachable in production. That is worth dwelling on: the constructor was correct, its tests were green, and a config using it would have silently talked to `api.openai.com`.

Gate 4's own comment documents this exact failure happening before, for azure and bedrock (#1010). So the open-coded condition is now `openAIBuildsPlatformBaseURL`, named and commented — "add the platform to the factory's switch and forget this list" has three recorded occurrences now, and the failure is silent each time.

## Test replaced, not deleted

`TestCreateProviderFromSpec_RejectsOpenAIVertex` asserted the behaviour this change removes. It becomes `TestCreateProviderFromSpec_AllowsOpenAIVertex`, which checks both that the pair constructs *and* that it does not receive the `api.openai.com` base URL — the silent failure the old loud error at least made obvious. Plus a direct test of the skip list.

## What this unlocks

Model Garden for both `llm` and `inference` roles: MaaS partner models (Llama, Mistral) via the shared endpoint, and self-deployed models via a dedicated endpoint ID. Prebuilt HF TGI and vLLM serving containers are OpenAI-compatible, so HuggingFace-based inference providers on a Vertex endpoint become reachable through this path.

```yaml
providers:
  - id: llama-maas
    type: openai
    model: meta/llama-3.3-70b-instruct-maas
    platform: {type: vertex, project: my-project, region: us-central1}

  - id: qwen-self-hosted
    type: openai
    model: qwen2.5-7b
    platform: {type: vertex, project: my-project, region: us-central1, endpoint: "4812379461283840"}
```

## Caveats

**Not verified against live Vertex** — unit tests cover URL construction and the registry path, not that Vertex accepts the request.

A self-deployed endpoint only speaks chat-completions when backed by a **TGI, vLLM or HexLLM** container deployed **after 2024-08-20**. That is not visible on the endpoint resource, so an older one fails at request time; documented on the helper.

The **vLLM provider still cannot reach Vertex** — it takes a bare base URL with no credential support, so it has no way to attach an ADC token. Vertex-hosted vLLM should go through this path instead. Unchanged by this PR, noted in the issue.
