### PR TITLE
feat(evals): add spoke_in_state, an assertion that reads the conversation

### DIFF
--- a/docs/src/content/docs/reference/checks.md
+++ b/docs/src/content/docs/reference/checks.md
@@ -240,6 +240,7 @@ assertions:
 | `workflow_transitioned_to` | `state` (string) | A E |
 | `workflow_transition_order` | `sequence` (string[]) | A E |
 | `workflow_tool_access` | `rules` (array of `{state, allowed}`) | A E |
+| `spoke_in_state` | `state` (string) | A E |
 
 **Example:**
 
@@ -249,6 +250,32 @@ assertions:
     params:
       sequence: ["triage", "investigation", "resolution"]
 ```
+
+### Checking a state actually spoke
+
+Every other workflow check reads the state machine's transition history, so a
+transition that produces **no output at all** satisfies all of them — the state
+was entered, and that is all they ask. `spoke_in_state` is the one that reads
+the conversation instead: it passes only when an assistant message with
+non-empty text was produced while the workflow was in that state.
+
+Pair it with `workflow_transitioned_to` when a handoff is supposed to say
+something:
+
+```yaml
+assertions:
+  - type: workflow_transitioned_to
+    params:
+      state: handoff        # the machine advanced
+  - type: spoke_in_state
+    params:
+      state: handoff        # ...and the destination agent actually replied
+```
+
+Whitespace does not count as speech. If a run produces no per-message state
+stamps at all, the failure says so explicitly rather than reporting a silent
+state — that case means the workflow resolver is not wired, which is a
+different problem from a state that stayed quiet.
 
 ---
 

--- a/runtime/evals/handlers/handlers_test.go
+++ b/runtime/evals/handlers/handlers_test.go
@@ -1592,6 +1592,7 @@ func TestRegisterInit(t *testing.T) {
 		"workflow_complete",
 		"state_is",
 		"transitioned_to",
+		"spoke_in_state",
 		"workflow_transition_order",
 		"workflow_tool_access",
 		"skill_activated",

--- a/runtime/evals/handlers/register.go
+++ b/runtime/evals/handlers/register.go
@@ -60,6 +60,7 @@ func init() {
 	evals.RegisterDefault(&WorkflowCompleteHandler{})
 	evals.RegisterDefault(&WorkflowStateIsHandler{})
 	evals.RegisterDefault(&WorkflowTransitionedToHandler{})
+	evals.RegisterDefault(&WorkflowSpokeInStateHandler{})
 	evals.RegisterDefault(&WorkflowTransitionOrderHandler{})
 	evals.RegisterDefault(&WorkflowToolAccessHandler{})
 	evals.RegisterDefault(&SkillActivatedHandler{})

--- a/runtime/evals/handlers/workflow_spoke_in_state.go
+++ b/runtime/evals/handlers/workflow_spoke_in_state.go
@@ -1,0 +1,147 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+)
+
+// workflowStateMetaKey is the message metadata key under which the runtime
+// records the workflow state that produced each assistant message. Declared
+// here rather than imported: runtime/pipeline/stage owns the constant, and
+// evals must not depend on the pipeline.
+const workflowStateMetaKey = "current_workflow_state"
+
+// Result keys and messages for this handler.
+const (
+	keyState           = "state"
+	keyStatesThatSpoke = "states_that_spoke"
+	msgMissingState    = "missing required param 'state'"
+)
+
+// WorkflowSpokeInStateHandler checks that a workflow state actually produced
+// assistant output, rather than merely being entered.
+//
+// This closes the blind spot that let the in-turn handoff bug ship. state_is,
+// transitioned_to, workflow_complete and workflow_transition_order all read the
+// state machine's history, so a transition that generates no output at all
+// satisfies every one of them — which is exactly what was broken: the machine
+// advanced and the destination state never spoke.
+//
+// Params: state string (required).
+type WorkflowSpokeInStateHandler struct{}
+
+// Type returns the eval type identifier.
+func (h *WorkflowSpokeInStateHandler) Type() string { return "spoke_in_state" }
+
+// Eval reports whether any assistant message with non-empty text was produced
+// while the workflow was in the named state.
+func (h *WorkflowSpokeInStateHandler) Eval(
+	_ context.Context,
+	evalCtx *evals.EvalContext,
+	params map[string]any,
+) (*evals.EvalResult, error) {
+	expected, _ := params[keyState].(string)
+	if expected == "" {
+		return &evals.EvalResult{
+			Type:        h.Type(),
+			Score:       boolScore(false),
+			Explanation: msgMissingState,
+		}, nil
+	}
+
+	spoke, anyStamped := statesThatSpoke(evalCtx)
+	for _, state := range spoke {
+		if state == expected {
+			return &evals.EvalResult{
+				Type:        h.Type(),
+				Score:       boolScore(true),
+				Value:       map[string]any{keyState: expected},
+				Explanation: fmt.Sprintf("state %q produced assistant output", expected),
+				Details:     map[string]any{keyStatesThatSpoke: spoke},
+			}, nil
+		}
+	}
+
+	// Distinguish "this state was silent" from "nothing records state at all".
+	// The second means the run predates the per-message stamp or the consumer
+	// has not wired the resolver — a different bug, and one that would
+	// otherwise look like an ordinary assertion failure.
+	explanation := fmt.Sprintf("no assistant message with text was produced in state %q", expected)
+	if !anyStamped {
+		explanation = "no assistant message carries a workflow state: the run produced no " +
+			"per-message state stamps, so the workflow resolver is probably not wired"
+	}
+
+	return &evals.EvalResult{
+		Type:        h.Type(),
+		Score:       boolScore(false),
+		Value:       map[string]any{keyState: expected},
+		Explanation: explanation,
+		Details: map[string]any{
+			keyExpected:         expected,
+			keyStatesThatSpoke:  spoke,
+			"any_state_stamped": anyStamped,
+		},
+	}, nil
+}
+
+// statesThatSpoke returns the states that produced assistant text, in order of
+// first appearance and de-duplicated, plus whether any assistant message
+// carried a state stamp at all.
+//
+// Whitespace does not count as speech: a state that emits only blank content
+// has said nothing, which is the case this check exists to catch.
+func statesThatSpoke(evalCtx *evals.EvalContext) (states []string, anyStamped bool) {
+	if evalCtx == nil {
+		return nil, false
+	}
+	seen := map[string]bool{}
+	for i := range evalCtx.Messages {
+		msg := &evalCtx.Messages[i]
+		if !strings.EqualFold(msg.Role, roleAssistant) {
+			continue
+		}
+		state, ok := stampedState(msg.Meta)
+		if !ok {
+			continue
+		}
+		anyStamped = true
+		if strings.TrimSpace(msg.GetContent()) == "" {
+			continue
+		}
+		if !seen[state] {
+			seen[state] = true
+			states = append(states, state)
+		}
+	}
+	return states, anyStamped
+}
+
+// stampedState reads the workflow state recorded on a message.
+func stampedState(meta map[string]any) (string, bool) {
+	if len(meta) == 0 {
+		return "", false
+	}
+	raw, ok := meta[workflowStateMetaKey].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	state, ok := raw["current_state"].(string)
+	if !ok || state == "" {
+		return "", false
+	}
+	return state, true
+}
+
+// ValidateParams checks that the required 'state' param is set to a non-empty
+// string.
+func (h *WorkflowSpokeInStateHandler) ValidateParams(params map[string]any) error {
+	state, _ := params[keyState].(string)
+	if state == "" {
+		return fmt.Errorf("%s requires a non-empty 'state' string param", h.Type())
+	}
+	return nil
+}

--- a/runtime/evals/handlers/workflow_spoke_in_state_test.go
+++ b/runtime/evals/handlers/workflow_spoke_in_state_test.go
@@ -1,0 +1,124 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// stamped builds an assistant message carrying the per-message workflow state
+// the runtime records (stage.workflowStateMetaKey).
+func stamped(content, state string) types.Message {
+	return types.Message{
+		Role:    "assistant",
+		Content: content,
+		Meta: map[string]any{
+			"current_workflow_state": map[string]any{"current_state": state},
+		},
+	}
+}
+
+func spokeCtx(msgs ...types.Message) *evals.EvalContext {
+	return &evals.EvalContext{Messages: msgs}
+}
+
+func evalSpoke(t *testing.T, ctx *evals.EvalContext, state string) *evals.EvalResult {
+	t.Helper()
+	h := &WorkflowSpokeInStateHandler{}
+	res, err := h.Eval(context.Background(), ctx, map[string]any{"state": state})
+	require.NoError(t, err)
+	return res
+}
+
+func TestSpokeInState_PassesWhenStateProducedText(t *testing.T) {
+	res := evalSpoke(t, spokeCtx(
+		stamped("How can I help?", "triage"),
+		stamped("I'm the escalations agent.", "handoff"),
+	), "handoff")
+
+	assert.Equal(t, 1.0, *res.Score)
+	assert.Contains(t, res.Explanation, "handoff")
+}
+
+// The whole point of the check: #1747's bug was a transition that advanced the
+// state machine while the destination said nothing. transitioned_to passes on
+// that; this must not.
+func TestSpokeInState_FailsWhenStateWasEnteredButSilent(t *testing.T) {
+	res := evalSpoke(t, spokeCtx(
+		stamped("How can I help?", "triage"),
+		stamped("", "handoff"), // entered the state, produced no text
+	), "handoff")
+
+	assert.Equal(t, 0.0, *res.Score)
+	assert.Contains(t, res.Explanation, "no assistant message")
+}
+
+// Whitespace is not speech.
+func TestSpokeInState_TreatsWhitespaceAsSilence(t *testing.T) {
+	res := evalSpoke(t, spokeCtx(stamped("   \n\t ", "handoff")), "handoff")
+
+	assert.Equal(t, 0.0, *res.Score)
+}
+
+// A user message tagged with the state is not the agent speaking.
+func TestSpokeInState_IgnoresNonAssistantMessages(t *testing.T) {
+	user := types.Message{
+		Role:    "user",
+		Content: "hello",
+		Meta:    map[string]any{"current_workflow_state": map[string]any{"current_state": "handoff"}},
+	}
+	res := evalSpoke(t, spokeCtx(user), "handoff")
+
+	assert.Equal(t, 0.0, *res.Score)
+}
+
+// Diagnosing a failure needs to distinguish "that state never spoke" from
+// "nothing is stamping states at all" — the latter means the run predates the
+// per-message stamp or the resolver is not wired, which is a different bug.
+func TestSpokeInState_DistinguishesUnstampedRun(t *testing.T) {
+	res := evalSpoke(t, spokeCtx(
+		types.Message{Role: "assistant", Content: "hello"},
+	), "handoff")
+
+	assert.Equal(t, 0.0, *res.Score)
+	assert.Contains(t, res.Explanation, "no assistant message carries a workflow state")
+}
+
+// The failure detail should name the states that did speak, so the author can
+// see what happened instead of guessing.
+func TestSpokeInState_ReportsStatesThatDidSpeak(t *testing.T) {
+	res := evalSpoke(t, spokeCtx(
+		stamped("hi", "triage"),
+		stamped("still here", "triage"),
+		stamped("done", "confirmation"),
+	), "handoff")
+
+	assert.Equal(t, 0.0, *res.Score)
+	require.NotNil(t, res.Details)
+	spoke, ok := res.Details["states_that_spoke"].([]string)
+	require.True(t, ok, "details = %v", res.Details)
+	assert.Equal(t, []string{"triage", "confirmation"}, spoke, "in order, de-duplicated")
+}
+
+func TestSpokeInState_RequiresStateParam(t *testing.T) {
+	h := &WorkflowSpokeInStateHandler{}
+	res, err := h.Eval(context.Background(), spokeCtx(stamped("hi", "a")), map[string]any{})
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, *res.Score)
+	assert.Contains(t, res.Explanation, "state")
+
+	assert.Error(t, h.ValidateParams(map[string]any{}))
+	assert.NoError(t, h.ValidateParams(map[string]any{"state": "handoff"}))
+}
+
+func TestSpokeInState_IsRegistered(t *testing.T) {
+	reg := evals.NewEvalTypeRegistry()
+	h, err := reg.Get("spoke_in_state")
+	require.NoError(t, err)
+	assert.Equal(t, "spoke_in_state", h.Type())
+}


### PR DESCRIPTION
Adds `spoke_in_state`, the assertion that closes the blind spot which let the in-turn handoff bug ship. Part of #1748 — its remaining items are arena-side and now live in AltairaLabs/promptarena#109.

## Why the existing checks could not catch it

`state_is`, `transitioned_to`, `workflow_complete` and `workflow_transition_order` all read the state machine's transition history. **A transition that produces no output at all satisfies every one of them** — the state was entered, and that is the only question they ask.

That is precisely what #1747 fixed: the machine advanced and the destination state never spoke. Arena validated the broken behaviour for months because nothing asserted on the conversation.

`spoke_in_state` reads the conversation instead, using the per-message `current_workflow_state` stamp #1747 added. It passes only when an assistant message with non-empty text was produced while the workflow was in the named state.

```yaml
assertions:
  - type: workflow_transitioned_to
    params: {state: handoff}   # the machine advanced
  - type: spoke_in_state
    params: {state: handoff}   # ...and the destination agent actually replied
```

## Three deliberate behaviours

- **Whitespace is not speech.** A state emitting only blank content has said nothing, which is the case this exists to catch.
- **A user message tagged with the state does not count.** Only the agent speaking does.
- **A run with no per-message stamps at all says so explicitly**, rather than reporting a silent state. No stamps means the resolver is not wired — arena today, or a pre-#1747 runtime — which is a *different* bug from a state that stayed quiet. The explanation tells you which one you have, instead of looking like an ordinary assertion failure.

On failure, `Details` carries `states_that_spoke` in order and de-duplicated, so an author can see what actually happened rather than guessing.

## Schema

`AssertionConfig.type` is `anyOf[enum, {type: string}]`, so the enum is advisory and this validates today without waiting on promptarena to regenerate schemas. Adding it to the enum for editor completion is promptarena's call, since it owns generation.

## Testing

Eight tests covering: the passing case, entered-but-silent, whitespace-only, non-assistant messages, the unstamped run, the reported state list, param validation, and registration.

**Mutation-verified:** making silence count as speech fails both the entered-but-silent and whitespace tests — those two are the entire point of the check.

Registry-count guard in `handlers_test.go` updated (95 → 96), and `docs/reference/checks.md` documents it with the paired-assertion pattern.
