### PR TITLE
chore(deps): @altairalabs/brand 0.7.2 — CodeGen-Sandbox rename

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@altairalabs/atlas-tokens": "^0.4.1",
-        "@altairalabs/brand": "^0.7.0",
+        "@altairalabs/brand": "^0.7.2",
         "@astrojs/mdx": "^7.0.3",
         "@astrojs/sitemap": "^3.7.3",
         "@astrojs/starlight": "~0.41.7",
@@ -30,9 +30,9 @@
       "license": "UNLICENSED"
     },
     "node_modules/@altairalabs/brand": {
-      "version": "0.7.0",
-      "resolved": "https://npm.pkg.github.com/download/@altairalabs/brand/0.7.0/718126bc35f34f57c286e149bdd5fce54803b98c",
-      "integrity": "sha512-ldUt8w/UwtAcsWgg5/q7ZldBZBvgOrP6k/8r/2p6AVJSXmuhLlYbhOdRnCU+bt2a2n20GmJfuqdmts+U5e2G5Q==",
+      "version": "0.7.2",
+      "resolved": "https://npm.pkg.github.com/download/@altairalabs/brand/0.7.2/90cc7b2d6d49760a9ebe7cb7ad887aaa9a6f77ab",
+      "integrity": "sha512-NN+UAD2fwWp1W7fG8veUGkTNWnXVn5POD4xLGyFVjNX/SUafOjlf4yhbN1D/XT4vuurU31O9QHJEeoakfGDTfw==",
       "license": "UNLICENSED"
     },
     "node_modules/@antfu/install-pkg": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@altairalabs/atlas-tokens": "^0.4.1",
-    "@altairalabs/brand": "^0.7.0",
+    "@altairalabs/brand": "^0.7.2",
     "@astrojs/mdx": "^7.0.3",
     "@astrojs/sitemap": "^3.7.3",
     "@astrojs/starlight": "~0.41.7",


### PR DESCRIPTION
Picks up `@altairalabs/brand@0.7.2`, which corrects the CodeGen product's name to **CodeGen-Sandbox** — its repo casing, per `strategy/site-heroes.md` §8.

The registry recorded `CodeGen` and the product's own site said `Codegen Sandbox`, so neither matched the spec or each other.

This site renders that name in the **family bar** and the footer's **Also from AltairaLabs** column, both derived from the registry — so picking up the release is all it needs. Nothing here is retyped.

Found auditing the three minor product sites for AltairaLabs/planning#41.
