### PR TITLE
fix(skills): resolve git to an absolute path before running it

### DIFF
--- a/runtime/skills/installer_integration.go
+++ b/runtime/skills/installer_integration.go
@@ -2,16 +2,58 @@ package skills
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
+
+// ErrGitNotFound reports that no usable git executable could be resolved.
+// Callers can match it with errors.Is to tell "git is missing or untrustworthy"
+// apart from "the git command ran and failed".
+var ErrGitNotFound = errors.New("git executable not found")
+
+// gitPath resolves the git executable to an absolute path.
+//
+// Passing the bare name "git" to exec leaves the lookup to the runtime, which
+// re-searches PATH on each call and runs whatever it matches first. Resolving
+// here instead means every invocation below names one fixed executable, and the
+// two failure modes worth separating are handled explicitly:
+//
+//   - git is not installed. Left to exec, that surfaces as an opaque failure
+//     from Run() after the caller has already committed to an install; here it
+//     is a named error before anything happens.
+//   - PATH contains a directory relative to the working directory, so the match
+//     resolves against wherever the process happens to be running rather than a
+//     fixed location. exec.LookPath reports that case as ErrDot, which the
+//     error check below treats as fatal.
+//
+// The IsAbs check behind it is not redundant: GODEBUG=execerrdot=0 switches the
+// ErrDot reporting back off, and a relative match still must not be executed
+// when it does.
+func gitPath() (string, error) {
+	found, err := exec.LookPath("git")
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrGitNotFound, err)
+	}
+	if !filepath.IsAbs(found) {
+		return "", fmt.Errorf("%w: %q resolved through a relative PATH entry", ErrGitNotFound, found)
+	}
+	return found, nil
+}
 
 // defaultGitClone runs "git clone" to clone a repository.
 // The URL is constructed from a validated SkillRef, not user input.
 func defaultGitClone(url, dest string) error {
+	git, err := gitPath()
+	if err != nil {
+		return err
+	}
+
 	cmd := exec.CommandContext(
 		context.Background(),
-		"git", "clone", "--depth", "1", url, dest,
+		git, "clone", "--depth", "1", url, dest,
 	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -21,10 +63,15 @@ func defaultGitClone(url, dest string) error {
 // defaultGitCheckout runs "git checkout" in the given directory.
 // The ref is a version tag from a validated SkillRef, not user input.
 func defaultGitCheckout(dir, ref string) error {
+	git, err := gitPath()
+	if err != nil {
+		return err
+	}
+
 	// For shallow clones with a specific tag/version, we need to fetch it first.
 	fetchCmd := exec.CommandContext(
 		context.Background(),
-		"git", "fetch", "--depth", "1", "origin", ref,
+		git, "fetch", "--depth", "1", "origin", ref,
 	)
 	fetchCmd.Dir = dir
 	fetchCmd.Stdout = os.Stdout
@@ -35,7 +82,7 @@ func defaultGitCheckout(dir, ref string) error {
 
 	cmd := exec.CommandContext(
 		context.Background(),
-		"git", "checkout", ref,
+		git, "checkout", ref,
 	)
 	cmd.Dir = dir
 	cmd.Stdout = os.Stdout

--- a/runtime/skills/installer_integration_test.go
+++ b/runtime/skills/installer_integration_test.go
@@ -1,0 +1,184 @@
+package skills
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// fakeGitScript records the arguments it was called with, one invocation per
+// line, in the file named by FAKE_GIT_LOG. That lets the tests below assert
+// which git commands were issued without a real git being involved. Setting
+// FAKE_GIT_FAIL_ON to a subcommand makes that one subcommand exit non-zero.
+const fakeGitScript = `#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_GIT_LOG"
+if [ -n "$FAKE_GIT_FAIL_ON" ] && [ "$1" = "$FAKE_GIT_FAIL_ON" ]; then
+  exit 1
+fi
+exit 0
+`
+
+// writeFakeGit puts an executable named "git" inside dir so PATH lookups match
+// it. It returns the path of the log the fake appends its arguments to.
+func writeFakeGit(t *testing.T, dir string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake git relies on a /bin/sh shebang")
+	}
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("creating %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(fakeGitScript), 0o500); err != nil {
+		t.Fatalf("writing fake git: %v", err)
+	}
+
+	logPath := filepath.Join(t.TempDir(), "git-invocations.log")
+	t.Setenv("FAKE_GIT_LOG", logPath)
+	return logPath
+}
+
+// gitInvocations returns one entry per call the fake git recorded.
+func gitInvocations(t *testing.T, logPath string) []string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Clean(logPath))
+	if err != nil {
+		t.Fatalf("reading %s: %v", logPath, err)
+	}
+	return strings.Split(strings.TrimSpace(string(data)), "\n")
+}
+
+func TestGitPathReturnsAbsolutePath(t *testing.T) {
+	got, err := gitPath()
+	if err != nil {
+		t.Skipf("no git on PATH in this environment: %v", err)
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("gitPath() = %q, want an absolute path", got)
+	}
+}
+
+func TestGitPathReportsErrGitNotFoundWhenMissing(t *testing.T) {
+	// An empty directory as the entire PATH: nothing to match.
+	t.Setenv("PATH", t.TempDir())
+
+	_, err := gitPath()
+	if !errors.Is(err, ErrGitNotFound) {
+		t.Fatalf("gitPath() error = %v, want it to wrap ErrGitNotFound", err)
+	}
+}
+
+// A PATH entry relative to the working directory resolves against wherever the
+// process happens to be running, which is the case this guard exists for. It
+// must be refused even though a matching executable is genuinely there.
+func TestGitPathRejectsRelativePATHEntry(t *testing.T) {
+	root := t.TempDir()
+	writeFakeGit(t, filepath.Join(root, "fakebin"))
+
+	t.Chdir(root)
+	t.Setenv("PATH", "fakebin")
+
+	got, err := gitPath()
+	if !errors.Is(err, ErrGitNotFound) {
+		t.Fatalf("gitPath() = %q, error = %v; want it to wrap ErrGitNotFound", got, err)
+	}
+	if got != "" {
+		t.Errorf("gitPath() = %q, want no path returned alongside the error", got)
+	}
+}
+
+// The absolute-path guard must hold even where the runtime's own ErrDot
+// reporting is switched off, which is what GODEBUG=execerrdot=0 does. Without
+// the IsAbs check this case would resolve and run the relative match.
+func TestGitPathRejectsRelativePATHEntryWithoutErrDot(t *testing.T) {
+	root := t.TempDir()
+	writeFakeGit(t, filepath.Join(root, "fakebin"))
+
+	t.Chdir(root)
+	t.Setenv("PATH", "fakebin")
+	t.Setenv("GODEBUG", "execerrdot=0")
+
+	if got, err := gitPath(); !errors.Is(err, ErrGitNotFound) {
+		t.Fatalf("gitPath() = %q, error = %v; want it to wrap ErrGitNotFound", got, err)
+	}
+}
+
+func TestDefaultGitCloneRunsResolvedGit(t *testing.T) {
+	bin := t.TempDir()
+	logPath := writeFakeGit(t, bin)
+	t.Setenv("PATH", bin)
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	if err := defaultGitClone("https://example.invalid/org/skill.git", dest); err != nil {
+		t.Fatalf("defaultGitClone() = %v, want nil", err)
+	}
+
+	got := gitInvocations(t, logPath)
+	want := "clone --depth 1 https://example.invalid/org/skill.git " + dest
+	if len(got) != 1 || got[0] != want {
+		t.Errorf("git invocations = %q, want exactly [%q]", got, want)
+	}
+}
+
+func TestDefaultGitCloneReportsErrGitNotFound(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	err := defaultGitClone("https://example.invalid/org/skill.git", filepath.Join(t.TempDir(), "dest"))
+	if !errors.Is(err, ErrGitNotFound) {
+		t.Fatalf("defaultGitClone() error = %v, want it to wrap ErrGitNotFound", err)
+	}
+	if !strings.Contains(err.Error(), "git executable not found") {
+		t.Errorf("error %q does not name the problem", err)
+	}
+}
+
+// A shallow clone has to fetch the ref before it can check it out, so both
+// commands must be issued, in that order.
+func TestDefaultGitCheckoutFetchesThenChecksOut(t *testing.T) {
+	bin := t.TempDir()
+	logPath := writeFakeGit(t, bin)
+	t.Setenv("PATH", bin)
+
+	if err := defaultGitCheckout(t.TempDir(), "v1.0.0"); err != nil {
+		t.Fatalf("defaultGitCheckout() = %v, want nil", err)
+	}
+
+	got := gitInvocations(t, logPath)
+	want := []string{"fetch --depth 1 origin v1.0.0", "checkout v1.0.0"}
+	if len(got) != len(want) {
+		t.Fatalf("git invocations = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("invocation %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// If the fetch fails there is nothing to check out, so the checkout must not
+// be attempted and the fetch's error must reach the caller.
+func TestDefaultGitCheckoutStopsWhenFetchFails(t *testing.T) {
+	bin := t.TempDir()
+	logPath := writeFakeGit(t, bin)
+	t.Setenv("PATH", bin)
+	t.Setenv("FAKE_GIT_FAIL_ON", "fetch")
+
+	if err := defaultGitCheckout(t.TempDir(), "v1.0.0"); err == nil {
+		t.Fatal("defaultGitCheckout() = nil, want the fetch failure")
+	}
+
+	if got := gitInvocations(t, logPath); len(got) != 1 {
+		t.Errorf("git invocations = %q, want the fetch alone with no checkout after it", got)
+	}
+}
+
+func TestDefaultGitCheckoutReportsErrGitNotFound(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	err := defaultGitCheckout(t.TempDir(), "v1.0.0")
+	if !errors.Is(err, ErrGitNotFound) {
+		t.Fatalf("defaultGitCheckout() error = %v, want it to wrap ErrGitNotFound", err)
+	}
+}


### PR DESCRIPTION
Closes the three open `go:S4036` vulnerabilities on SonarCloud — `runtime/skills/installer_integration.go` lines 12, 25 and 36. These are the **only** open security issues on the PromptKit project, so this should take `security_rating` to A.

## The finding

All three call sites passed the bare name `"git"` to `exec.CommandContext`:

```go
cmd := exec.CommandContext(context.Background(), "git", "clone", "--depth", "1", url, dest)
```

That leaves the lookup to the runtime, which re-searches `PATH` on every call and runs whatever it matches first.

## The change

Resolve `git` explicitly, and refuse two cases outright:

| Case | Before | After |
|---|---|---|
| git not installed | opaque failure from `Run()`, after the caller has committed to an install | named `ErrGitNotFound`, before anything happens |
| `PATH` holds a **relative** directory | match resolves against wherever the process happens to be running | fatal — `exec.LookPath` reports it as `ErrDot` |

The relative-`PATH` case is the concrete risk the rule describes, and it's the one worth having a guard for.

**The `IsAbs` check behind the `ErrDot` check is not redundant.** `GODEBUG=execerrdot=0` switches the `ErrDot` reporting back off, and a relative match still must not be executed when it does. `TestGitPathRejectsRelativePATHEntryWithoutErrDot` covers exactly that configuration — and coverage confirms the `IsAbs` branch is genuinely reached there, not shadowed by the `ErrDot` return.

## On gosec G204

`golangci-lint` reports `G204: Subprocess launched with variable` on these three sites. **That is pre-existing, not introduced here** — G204 flags the variable `url`/`dest`/`ref` arguments, not the command name. Verified by stashing the change and re-linting:

| | G204 count in `runtime/skills` |
|---|---|
| baseline (`main`) | 3 |
| with this change | 3 |

`golangci-lint run --new-from-rev=HEAD ./runtime/skills/...` reports **0 issues**, and the pre-commit hook passed clean.

Worth noting the two rules pull in opposite directions here: S4036 wants the command name resolved rather than a bare literal; G204 wants literals rather than variables. Satisfying S4036 without regressing G204's count is the reachable outcome.

## Tests

New file, all three functions at **100%**:

- both success paths assert the **exact git argv** issued, via a fake `git` on `PATH` that logs its arguments — so this verifies the resolved absolute path is actually what gets executed, not just that the code compiles
- `defaultGitCheckout` asserts `fetch` precedes `checkout`, and that a failing `fetch` stops before `checkout` is attempted
- three resolution failures (missing, relative `PATH`, relative `PATH` with `ErrDot` disabled) assert `ErrGitNotFound`

## Verification

- `golangci-lint run --new-from-rev=HEAD ./runtime/skills/...` — 0 issues
- `go test ./... -count=1` in `runtime/` — 0 failures across the module
- `runtime/skills` package coverage 91.6%; the three changed functions at 100%
- Pre-commit hook passed in full (lint, build, tests, DCO)
