### PR TITLE
fix(sdk): build the Azure deployment path instead of the account host

### DIFF
--- a/runtime/credentials/azure.go
+++ b/runtime/credentials/azure.go
@@ -18,11 +18,25 @@ const tokenRefreshBuffer = 5 * time.Minute
 // platform.additional_config.api_version is not set.
 const DefaultAzureAPIVersion = "2024-12-01-preview"
 
+// azureDeploymentPath is the path segment under an Azure OpenAI account host
+// that addresses a single deployment.
+const azureDeploymentPath = "/openai/deployments/"
+
 // AzureOpenAIEndpoint returns the base URL for an Azure OpenAI deployment.
 // The returned URL does NOT include the API path (/chat/completions) or
 // api-version query param — the provider appends those per-request.
+//
+// endpoint is normally an account host (https://acct.openai.azure.com), which
+// gets the deployment path appended. An endpoint that already addresses a
+// deployment is returned as-is instead of having a second deployment path
+// stacked onto it, so a caller that passes a full deployment URL still ends up
+// with a usable base.
 func AzureOpenAIEndpoint(endpoint, deployment string) string {
-	return strings.TrimRight(endpoint, "/") + "/openai/deployments/" + deployment
+	trimmed := strings.TrimRight(endpoint, "/")
+	if strings.Contains(trimmed, azureDeploymentPath) {
+		return trimmed
+	}
+	return trimmed + azureDeploymentPath + deployment
 }
 
 // Apply adds the Azure AD token to the request.

--- a/runtime/credentials/azure_integration_test.go
+++ b/runtime/credentials/azure_integration_test.go
@@ -174,6 +174,22 @@ func TestAzureOpenAIEndpoint(t *testing.T) {
 			deployment: "gpt-4o",
 			expected:   "https://my-resource.openai.azure.com/openai/deployments/gpt-4o",
 		},
+		{
+			// A caller that already addressed a deployment must not get a
+			// second deployment path stacked underneath the first.
+			name:       "endpoint already names a deployment",
+			endpoint:   "https://my-resource.openai.azure.com/openai/deployments/gpt-4o",
+			deployment: "gpt-4o",
+			expected:   "https://my-resource.openai.azure.com/openai/deployments/gpt-4o",
+		},
+		{
+			// The deployment already in the endpoint wins: it is the more
+			// specific statement of intent.
+			name:       "existing deployment differs from the model",
+			endpoint:   "https://my-resource.openai.azure.com/openai/deployments/gpt-4o/",
+			deployment: "gpt-4-1-mini",
+			expected:   "https://my-resource.openai.azure.com/openai/deployments/gpt-4o",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/runtime/providers/azure_deployment_path_test.go
+++ b/runtime/providers/azure_deployment_path_test.go
@@ -1,0 +1,87 @@
+package providers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/openai"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// azureFakeCredential stands in for a real Azure AD credential. It has to be
+// non-nil: openai's CredentialFactory takes a no-credential branch that does not
+// forward Platform/PlatformConfig at all, which would mask what these tests
+// check.
+type azureFakeCredential struct{}
+
+func (azureFakeCredential) Apply(context.Context, *http.Request) error { return nil }
+func (azureFakeCredential) Type() string                               { return "azure" }
+
+// azureRequestPath builds a provider from spec, issues one prediction against a
+// local server, and reports the request path that server actually received.
+//
+// Asserting the path is the point: the failure this guards against is one where
+// provider construction succeeds and only the request URL is wrong, so a test
+// that stops at "a provider was returned" would pass while every call 404s.
+func azureRequestPath(t *testing.T, spec providers.ProviderSpec) string {
+	t.Helper()
+
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+	}))
+	defer srv.Close()
+
+	if spec.BaseURL != "" {
+		spec.BaseURL = srv.URL
+	}
+	spec.PlatformConfig.Endpoint = srv.URL
+
+	p, err := providers.CreateProviderFromSpec(spec)
+	if err != nil {
+		t.Fatalf("CreateProviderFromSpec: %v", err)
+	}
+	_, _ = p.Predict(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	return got
+}
+
+func azureSpec(baseURL string) providers.ProviderSpec {
+	return providers.ProviderSpec{
+		ID:             "openai",
+		Type:           "openai",
+		Model:          "gpt-4-1-mini",
+		BaseURL:        baseURL,
+		Credential:     azureFakeCredential{},
+		Platform:       "azure",
+		PlatformConfig: &providers.PlatformConfig{Type: "azure", Endpoint: "https://placeholder"},
+	}
+}
+
+// This is the shape sdk.WithAzure now produces: an empty BaseURL, with the
+// account host carried on PlatformConfig.Endpoint. The factory must turn that
+// into the per-deployment path, because Azure has no route at /chat/completions.
+func TestAzureEmptyBaseURLUsesDeploymentPath(t *testing.T) {
+	got := azureRequestPath(t, azureSpec(""))
+
+	want := "/openai/deployments/gpt-4-1-mini/chat/completions"
+	if got != want {
+		t.Errorf("request path = %q, want %q", got, want)
+	}
+}
+
+// A BaseURL that is set still wins, so an operator pointing at a gateway or a
+// recorded fixture is not overridden.
+func TestAzureExplicitBaseURLIsRespected(t *testing.T) {
+	got := azureRequestPath(t, azureSpec("https://placeholder"))
+
+	if got != "/chat/completions" {
+		t.Errorf("request path = %q, want an explicit BaseURL to be used verbatim", got)
+	}
+}

--- a/sdk/azure_platform_integration_test.go
+++ b/sdk/azure_platform_integration_test.go
@@ -1,0 +1,110 @@
+//go:build integration
+
+// Azure platform integration test for the WithAzure provider path.
+//
+// The unit tests either side of this seam each cover half of the guarantee —
+// that platformBaseURL defers for Azure, and that the openai factory turns a
+// deferred base URL into a deployment path. Neither proves the halves meet, and
+// #1811 was exactly a break between them: both sides were individually
+// defensible and every call still 404d. Only a real request settles it.
+//
+// Run locally:
+//
+//	az login --scope https://cognitiveservices.azure.com/.default
+//	export AZURE_OPENAI_ENDPOINT=https://<resource>.openai.azure.com
+//	export AZURE_OPENAI_DEPLOYMENT=<deployment-name>
+//	go test -tags=integration ./sdk/... -run Azure -v
+package sdk
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/openai"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// azurePlatformConfig builds the platformConfig WithAzure produces, or skips
+// when the environment does not name a live deployment.
+func azurePlatformConfig(t *testing.T) *platformConfig {
+	t.Helper()
+
+	endpoint := os.Getenv("AZURE_OPENAI_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("AZURE_OPENAI_ENDPOINT not set")
+	}
+	deployment := os.Getenv("AZURE_OPENAI_DEPLOYMENT")
+	if deployment == "" {
+		deployment = "gpt-4o-mini"
+	}
+
+	return &platformConfig{
+		platformType: platformTypeAzure,
+		providerType: "openai",
+		model:        deployment,
+		endpoint:     endpoint,
+	}
+}
+
+// The regression test for #1811. Before the fix this reached
+// {endpoint}/chat/completions and Azure answered 404 for every call; the
+// provider still constructed cleanly, so nothing short of a real request
+// caught it.
+func TestAzurePlatformProviderReachesDeployment(t *testing.T) {
+	pc := azurePlatformConfig(t)
+
+	prov, err := resolvePlatformProvider(&config{platform: pc})
+	if err != nil {
+		t.Fatalf("resolvePlatformProvider: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resp, err := prov.Predict(ctx, providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "Reply with the single word: ok"}},
+	})
+	if err != nil {
+		// A 404 here is the original bug resurfacing, so name it rather than
+		// letting it read as a generic provider failure.
+		if strings.Contains(err.Error(), "404") {
+			t.Fatalf("Predict returned 404 — the deployment path is not being built (#1811): %v", err)
+		}
+		t.Fatalf("Predict: %v", err)
+	}
+	if strings.TrimSpace(resp.Content) == "" {
+		t.Error("Predict returned empty content")
+	}
+	t.Logf("Azure responded: %q", strings.TrimSpace(resp.Content))
+}
+
+// WithAzure and WithPlatformEndpoint write the same field, so a caller who
+// worked around #1811 by passing a full deployment URL must keep working rather
+// than having a second deployment path stacked onto the first.
+func TestAzurePlatformProviderAcceptsFullDeploymentURL(t *testing.T) {
+	pc := azurePlatformConfig(t)
+	pc.endpoint = strings.TrimRight(pc.endpoint, "/") + "/openai/deployments/" + pc.model
+
+	prov, err := resolvePlatformProvider(&config{platform: pc})
+	if err != nil {
+		t.Fatalf("resolvePlatformProvider: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resp, err := prov.Predict(ctx, providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "Reply with the single word: ok"}},
+	})
+	if err != nil {
+		t.Fatalf("Predict with a full deployment URL: %v", err)
+	}
+	if strings.TrimSpace(resp.Content) == "" {
+		t.Error("Predict returned empty content")
+	}
+	t.Logf("Azure responded: %q", strings.TrimSpace(resp.Content))
+}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -578,9 +578,23 @@ func resolvePlatformCredential(ctx context.Context, pc *platformConfig) (provide
 	}
 }
 
-// platformBaseURL returns the base URL for a platform + provider combination.
-// The endpoint can be overridden via WithPlatformEndpoint.
+// platformBaseURL returns the base URL for a platform + provider combination,
+// or "" to leave the base URL for the provider factory to derive from
+// PlatformConfig. The endpoint can be overridden via WithPlatformEndpoint.
+//
+// Bedrock and Vertex endpoints are base URLs, so an endpoint set for either is
+// returned as-is. Azure's is not: it is an account host, and the base URL is a
+// per-deployment path underneath it. Returning the account host as a base URL
+// points every request at {host}/chat/completions, which Azure does not route,
+// so Azure defers to the openai factory — it builds the deployment path from
+// PlatformConfig.Endpoint, which sdk.go populates with the same value.
 func platformBaseURL(pc *platformConfig, provType string) string {
+	// Azure's endpoint is an account host rather than a base URL, so it must not
+	// short-circuit the factory the way Bedrock's and Vertex's can.
+	if pc.platformType == platformTypeAzure {
+		return ""
+	}
+
 	if pc.endpoint != "" {
 		return pc.endpoint
 	}
@@ -590,11 +604,6 @@ func platformBaseURL(pc *platformConfig, provType string) string {
 		return credentials.BedrockEndpoint(pc.region)
 	case platformTypeVertex:
 		return vertexBaseURL(pc, provType)
-	case platformTypeAzure:
-		// Azure always requires an explicit endpoint via WithPlatformEndpoint.
-		// When none is set, pc.endpoint is empty and provider creation will fail
-		// with a clear error from the Azure credential/provider layer.
-		return pc.endpoint
 	default:
 		return ""
 	}

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -701,10 +701,20 @@ func TestPlatformBaseURL(t *testing.T) {
 		assert.Equal(t, "https://custom.vertex", url)
 	})
 
-	t.Run("azure returns endpoint directly", func(t *testing.T) {
+	// Azure's endpoint is an account host, not a base URL — the base URL is the
+	// per-deployment path under it. Returning the host here would send requests
+	// to {host}/chat/completions, which Azure does not route, so the openai
+	// factory builds the deployment path from PlatformConfig.Endpoint instead.
+	t.Run("azure defers to the provider factory", func(t *testing.T) {
 		pc := &platformConfig{platformType: "azure", endpoint: "https://my-resource.openai.azure.com"}
 		url := platformBaseURL(pc, "openai")
-		assert.Equal(t, "https://my-resource.openai.azure.com", url)
+		assert.Empty(t, url)
+	})
+
+	t.Run("azure defers even with an endpoint override", func(t *testing.T) {
+		pc := &platformConfig{platformType: "azure", endpoint: "https://custom.openai.azure.com"}
+		url := platformBaseURL(pc, "openai")
+		assert.Empty(t, url)
 	})
 
 	t.Run("unknown platform returns empty", func(t *testing.T) {


### PR DESCRIPTION
Closes #1811.

`sdk.WithAzure` produced a provider requesting `{endpoint}/chat/completions` instead of `{endpoint}/openai/deployments/{model}/chat/completions`. Azure has no route at `/chat/completions`, so **every LLM call through `WithAzure` 404d** — including the doc-comment example on `options.go:749`. The provider constructed without error; only the first inference failed.

## Root cause

`platformBaseURL` returned `pc.endpoint` whenever it was non-empty. For Azure that is *always* — the endpoint is `WithAzure`'s required first argument — so `spec.BaseURL` arrived at the registry already populated. The registry's defaulting switch only runs when `baseURL == ""`, so it was skipped entirely, taking the #1010 guard inside it with it, which left openai's `azurePlatform` branch unreachable for anything built through `WithAzure`. `credentials.AzureOpenAIEndpoint` was never called on the chat path.

## The fix

The distinction that makes it correct:

| Platform | What the endpoint *is* | Right behaviour |
|---|---|---|
| Bedrock | a base URL | return it |
| Vertex | a base URL | return it |
| **Azure** | an **account host** — the base URL is a per-deployment path *underneath* it | defer to the factory |

Treating an account host as a base URL is a category error, so `platformBaseURL` now returns `""` for Azure and lets the openai factory build the deployment path from `PlatformConfig.Endpoint`, which `sdk.go:554` already populates with the same value. Bedrock and Vertex are untouched, and `runtime` needed no change.

This also drops the switch's `azure` case, which was **already dead** — the `pc.endpoint != ""` check above it returned first on every reachable path.

## The override caveat

The issue flagged this and it is real: `WithAzure` and `WithPlatformEndpoint` write the same `pc.endpoint` field, so there is no way to distinguish "account host" from "full base URL override". Anyone who worked around this bug by passing a full deployment URL to `WithAzure` would, after this change, get a *second* deployment path appended.

So `AzureOpenAIEndpoint` now leaves an endpoint that already addresses a deployment alone. That preserves the workaround and makes the function correct for either shape rather than only the documented one.

## The test that should have caught this

`TestPlatformBaseURL` had a subtest literally named **"azure returns endpoint directly"**, asserting the broken behaviour. That is a large part of why this survived — the bug was pinned in place by a passing test. It now asserts the deferral and says why.

## Tests

Per the issue's second point, these assert **the request path a server actually receives**, not that a provider was constructed — construction succeeding is the entire failure mode:

- `TestAzureEmptyBaseURLUsesDeploymentPath` — the shape `WithAzure` now produces resolves to `/openai/deployments/gpt-4-1-mini/chat/completions`
- `TestAzureExplicitBaseURLIsRespected` — an explicitly set `BaseURL` still wins, so gateways and recorded fixtures are not overridden
- `TestPlatformBaseURL` — Azure defers, with and without an endpoint override
- `TestAzureOpenAIEndpoint` — two cases for the already-a-deployment path, including one where the existing deployment differs from the model

**One honest gap:** no single test spans `sdk.WithAzure` → HTTP request. The guarantee is composed from the sdk-side test (Azure yields `""`) plus the runtime-side test (empty `BaseURL` + azure platform → deployment path). A true end-to-end test would need `resolveAzureCredential` to mint a token, which means a live call to `login.microsoftonline.com` — not something worth putting in CI.

## Verification

- `golangci-lint run --new-from-rev=HEAD ./sdk/... ./runtime/...` — 0 issues
- `go test ./... -count=1` — 0 failures in both `runtime` and `sdk`
- Coverage on changed files: `runtime/credentials/azure.go` 96.2%, `sdk/sdk.go` 87.3%
- Pre-commit hook passed in full (lint, build, reference drift, tests, coverage, DCO)

Embeddings were never affected — `buildPlatformEmbeddingClient` builds its URL from `pc.Endpoint` and never consults `spec.BaseURL`.
