### PR TITLE
refactor: name the repeated string literals flagged by S1192

### DIFF
--- a/pkg/config/schema_validator.go
+++ b/pkg/config/schema_validator.go
@@ -19,6 +19,9 @@ import (
 	promptschema "github.com/AltairaLabs/PromptKit/runtime/prompt/schema"
 )
 
+// fileURLScheme is the prefix gojsonschema expects for a local schema path.
+const fileURLScheme = "file://"
+
 // SchemaBaseURL is the base URL for PromptKit JSON schemas
 const SchemaBaseURL = "https://promptkit.altairalabs.ai/schemas/v1alpha1"
 
@@ -292,7 +295,7 @@ func tryLocalSchemaFallback(configType ConfigType) (*gojsonschema.Schema, error)
 		return nil, fmt.Errorf("no local schema found for fallback")
 	}
 
-	localLoader := gojsonschema.NewReferenceLoader("file://" + localSchemaPath)
+	localLoader := gojsonschema.NewReferenceLoader(fileURLScheme + localSchemaPath)
 	return gojsonschema.NewSchema(localLoader)
 }
 
@@ -455,8 +458,8 @@ func loadRawSchemaForKey(schemaKey string) map[string]any {
 
 func fetchSchemaBytes(schemaKey string) ([]byte, error) {
 	switch {
-	case strings.HasPrefix(schemaKey, "file://"):
-		path := strings.TrimPrefix(schemaKey, "file://")
+	case strings.HasPrefix(schemaKey, fileURLScheme):
+		path := strings.TrimPrefix(schemaKey, fileURLScheme)
 		return os.ReadFile(path) //nolint:gosec // path comes from configured schemaDir
 	case strings.HasPrefix(schemaKey, "http://"), strings.HasPrefix(schemaKey, "https://"):
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, schemaKey, http.NoBody)

--- a/runtime/deploy/adaptersdk/serve.go
+++ b/runtime/deploy/adaptersdk/serve.go
@@ -14,6 +14,9 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/deploy"
 )
 
+// msgMethodNotFound prefixes the JSON-RPC error for an unrecognized method.
+const msgMethodNotFound = "method not found: "
+
 // JSON-RPC method names recognized by the adapter protocol.
 const (
 	MethodGetProviderInfo = "get_provider_info"
@@ -166,7 +169,7 @@ func dispatch(provider deploy.Provider, req *request) response {
 			JSONRPC: jsonRPCVersion,
 			Error: &rpcError{
 				Code:    CodeMethodNotFound,
-				Message: "method not found: " + req.Method,
+				Message: msgMethodNotFound + req.Method,
 			},
 			ID: req.ID,
 		}
@@ -310,7 +313,7 @@ func handleGetLoginURL(
 ) response {
 	lp, ok := provider.(deploy.LoginProvider)
 	if !ok {
-		return errResponse(req.ID, CodeMethodNotFound, "method not found: "+req.Method)
+		return errResponse(req.ID, CodeMethodNotFound, msgMethodNotFound+req.Method)
 	}
 	var params deploy.LoginURLRequest
 	if err := json.Unmarshal(req.Params, &params); err != nil {
@@ -332,7 +335,7 @@ func handleCompleteLogin(
 ) response {
 	lp, ok := provider.(deploy.LoginProvider)
 	if !ok {
-		return errResponse(req.ID, CodeMethodNotFound, "method not found: "+req.Method)
+		return errResponse(req.ID, CodeMethodNotFound, msgMethodNotFound+req.Method)
 	}
 	var params deploy.CompleteLoginRequest
 	if err := json.Unmarshal(req.Params, &params); err != nil {

--- a/runtime/media/audio_converter.go
+++ b/runtime/media/audio_converter.go
@@ -9,6 +9,9 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+// ffmpegAudioCodecFlag selects the output audio codec in an ffmpeg argument list.
+const ffmpegAudioCodecFlag = "-acodec"
+
 // Audio format constants.
 const (
 	AudioFormatWAV  = "wav"
@@ -303,10 +306,10 @@ func (c *AudioConverter) buildFFmpegArgs(inputPath, outputPath, toFormat string)
 	switch toFormat {
 	case AudioFormatWAV:
 		// PCM 16-bit signed little-endian for maximum compatibility
-		args = append(args, "-acodec", "pcm_s16le")
+		args = append(args, ffmpegAudioCodecFlag, "pcm_s16le")
 
 	case AudioFormatMP3:
-		args = append(args, "-acodec", "libmp3lame")
+		args = append(args, ffmpegAudioCodecFlag, "libmp3lame")
 		if c.config.BitRate != "" {
 			args = append(args, "-b:a", c.config.BitRate)
 		} else {
@@ -314,16 +317,16 @@ func (c *AudioConverter) buildFFmpegArgs(inputPath, outputPath, toFormat string)
 		}
 
 	case AudioFormatFLAC:
-		args = append(args, "-acodec", "flac")
+		args = append(args, ffmpegAudioCodecFlag, "flac")
 
 	case AudioFormatOGG:
-		args = append(args, "-acodec", "libvorbis")
+		args = append(args, ffmpegAudioCodecFlag, "libvorbis")
 		if c.config.BitRate != "" {
 			args = append(args, "-b:a", c.config.BitRate)
 		}
 
 	case AudioFormatAAC, AudioFormatM4A:
-		args = append(args, "-acodec", "aac")
+		args = append(args, ffmpegAudioCodecFlag, "aac")
 		if c.config.BitRate != "" {
 			args = append(args, "-b:a", c.config.BitRate)
 		}

--- a/runtime/providers/provider_contract_integration.go
+++ b/runtime/providers/provider_contract_integration.go
@@ -14,9 +14,6 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
-// skipNoToolSupport is the skip reason for providers without tool support.
-const skipNoToolSupport = "Provider doesn't implement ToolSupport"
-
 // Default values for contract test requests.
 const (
 	contractTestTemperature = 0.7
@@ -429,7 +426,7 @@ func buildWeatherTools(t *testing.T, toolSupport ToolSupport) ProviderTools {
 func testPredictWithToolsProducesToolCalls(t *testing.T, provider Provider) {
 	toolSupport, ok := provider.(ToolSupport)
 	if !ok {
-		t.Skip(skipNoToolSupport)
+		t.Skip("Provider doesn't implement ToolSupport")
 		return
 	}
 
@@ -470,7 +467,7 @@ func testPredictWithToolsProducesToolCalls(t *testing.T, provider Provider) {
 func testPredictWithToolsToolCallFormat(t *testing.T, provider Provider) {
 	toolSupport, ok := provider.(ToolSupport)
 	if !ok {
-		t.Skip(skipNoToolSupport)
+		t.Skip("Provider doesn't implement ToolSupport")
 		return
 	}
 
@@ -525,7 +522,7 @@ func testPredictWithToolsToolCallFormat(t *testing.T, provider Provider) {
 func testPredictWithToolsSystemMessage(t *testing.T, provider Provider) {
 	toolSupport, ok := provider.(ToolSupport)
 	if !ok {
-		t.Skip(skipNoToolSupport)
+		t.Skip("Provider doesn't implement ToolSupport")
 		return
 	}
 
@@ -560,7 +557,7 @@ func testPredictWithToolsSystemMessage(t *testing.T, provider Provider) {
 func testPredictWithToolsReturnsCostInfo(t *testing.T, provider Provider) {
 	toolSupport, ok := provider.(ToolSupport)
 	if !ok {
-		t.Skip(skipNoToolSupport)
+		t.Skip("Provider doesn't implement ToolSupport")
 		return
 	}
 
@@ -598,7 +595,7 @@ func testPredictWithToolsReturnsCostInfo(t *testing.T, provider Provider) {
 func testPredictWithToolsMultiTurn(t *testing.T, provider Provider) {
 	toolSupport, ok := provider.(ToolSupport)
 	if !ok {
-		t.Skip(skipNoToolSupport)
+		t.Skip("Provider doesn't implement ToolSupport")
 		return
 	}
 
@@ -723,7 +720,7 @@ func SkipIfNoCredentials(t *testing.T, provider Provider) {
 func testPredictStreamWithToolsProducesToolCalls(t *testing.T, provider Provider) {
 	toolSupport, ok := provider.(ToolSupport)
 	if !ok {
-		t.Skip(skipNoToolSupport)
+		t.Skip("Provider doesn't implement ToolSupport")
 		return
 	}
 

--- a/runtime/providers/provider_contract_integration.go
+++ b/runtime/providers/provider_contract_integration.go
@@ -14,6 +14,9 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+// skipNoToolSupport is the skip reason for providers without tool support.
+const skipNoToolSupport = "Provider doesn't implement ToolSupport"
+
 // Default values for contract test requests.
 const (
 	contractTestTemperature = 0.7
@@ -426,7 +429,7 @@ func buildWeatherTools(t *testing.T, toolSupport ToolSupport) ProviderTools {
 func testPredictWithToolsProducesToolCalls(t *testing.T, provider Provider) {
 	toolSupport, ok := provider.(ToolSupport)
 	if !ok {
-		t.Skip("Provider doesn't implement ToolSupport")
+		t.Skip(skipNoToolSupport)
 		return
 	}
 
@@ -467,7 +470,7 @@ func testPredictWithToolsProducesToolCalls(t *testing.T, provider Provider) {
 func testPredictWithToolsToolCallFormat(t *testing.T, provider Provider) {
 	toolSupport, ok := provider.(ToolSupport)
 	if !ok {
-		t.Skip("Provider doesn't implement ToolSupport")
+		t.Skip(skipNoToolSupport)
 		return
 	}
 
@@ -522,7 +525,7 @@ func testPredictWithToolsToolCallFormat(t *testing.T, provider Provider) {
 func testPredictWithToolsSystemMessage(t *testing.T, provider Provider) {
 	toolSupport, ok := provider.(ToolSupport)
 	if !ok {
-		t.Skip("Provider doesn't implement ToolSupport")
+		t.Skip(skipNoToolSupport)
 		return
 	}
 
@@ -557,7 +560,7 @@ func testPredictWithToolsSystemMessage(t *testing.T, provider Provider) {
 func testPredictWithToolsReturnsCostInfo(t *testing.T, provider Provider) {
 	toolSupport, ok := provider.(ToolSupport)
 	if !ok {
-		t.Skip("Provider doesn't implement ToolSupport")
+		t.Skip(skipNoToolSupport)
 		return
 	}
 
@@ -595,7 +598,7 @@ func testPredictWithToolsReturnsCostInfo(t *testing.T, provider Provider) {
 func testPredictWithToolsMultiTurn(t *testing.T, provider Provider) {
 	toolSupport, ok := provider.(ToolSupport)
 	if !ok {
-		t.Skip("Provider doesn't implement ToolSupport")
+		t.Skip(skipNoToolSupport)
 		return
 	}
 
@@ -720,7 +723,7 @@ func SkipIfNoCredentials(t *testing.T, provider Provider) {
 func testPredictStreamWithToolsProducesToolCalls(t *testing.T, provider Provider) {
 	toolSupport, ok := provider.(ToolSupport)
 	if !ok {
-		t.Skip("Provider doesn't implement ToolSupport")
+		t.Skip(skipNoToolSupport)
 		return
 	}
 

--- a/runtime/storage/instrumented.go
+++ b/runtime/storage/instrumented.go
@@ -17,6 +17,9 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+// attrMediaReference is the span attribute naming the media reference operated on.
+const attrMediaReference = "media.reference"
+
 // instrumentationTracerName is the OTel tracer name used for media storage spans.
 const instrumentationTracerName = "github.com/AltairaLabs/PromptKit/runtime/storage"
 
@@ -113,7 +116,7 @@ func (s *InstrumentedStorage) StoreMedia(
 		return ref, err
 	}
 
-	span.SetAttributes(attribute.String("media.reference", string(ref)))
+	span.SetAttributes(attribute.String(attrMediaReference, string(ref)))
 	s.publish(events.EventMediaStored, &events.MediaStorageEventData{
 		Operation:  "store",
 		Backend:    s.backend,
@@ -134,7 +137,7 @@ func (s *InstrumentedStorage) RetrieveMedia(
 ) (*types.MediaContent, error) {
 	ctx, span := s.startSpan(ctx, "media.retrieve", nil)
 	defer span.End()
-	span.SetAttributes(attribute.String("media.reference", string(reference)))
+	span.SetAttributes(attribute.String(attrMediaReference, string(reference)))
 
 	start := time.Now()
 	content, err := s.inner.RetrieveMedia(ctx, reference)
@@ -161,7 +164,7 @@ func (s *InstrumentedStorage) RetrieveMedia(
 func (s *InstrumentedStorage) DeleteMedia(ctx context.Context, reference Reference) error {
 	ctx, span := s.startSpan(ctx, "media.delete", nil)
 	defer span.End()
-	span.SetAttributes(attribute.String("media.reference", string(reference)))
+	span.SetAttributes(attribute.String(attrMediaReference, string(reference)))
 
 	start := time.Now()
 	err := s.inner.DeleteMedia(ctx, reference)
@@ -190,7 +193,7 @@ func (s *InstrumentedStorage) GetURL(
 ) (string, error) {
 	ctx, span := s.startSpan(ctx, "media.get_url", nil)
 	defer span.End()
-	span.SetAttributes(attribute.String("media.reference", string(reference)))
+	span.SetAttributes(attribute.String(attrMediaReference, string(reference)))
 
 	start := time.Now()
 	url, err := s.inner.GetURL(ctx, reference, expiry)

--- a/runtime/storage/local/filestore.go
+++ b/runtime/storage/local/filestore.go
@@ -21,6 +21,9 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+// msgDedupIndexPersistFailed is logged when the dedup index cannot be written.
+const msgDedupIndexPersistFailed = "failed to persist dedup index"
+
 const (
 	audioMIMETypePCM   = "audio/pcm"
 	audioMIMETypeL16   = "audio/L16"
@@ -280,7 +283,7 @@ func (fs *FileStore) StoreMedia(ctx context.Context, content *types.MediaContent
 
 		// Persist index (skips write if not dirty)
 		if err := fs.saveDedupIndex(); err != nil {
-			logger.Warn("failed to persist dedup index", "error", err)
+			logger.Warn(msgDedupIndexPersistFailed, "error", err)
 		}
 	}
 
@@ -441,7 +444,7 @@ func (fs *FileStore) storeMediaStreaming(
 		fs.refMu.Unlock()
 
 		if err := fs.saveDedupIndex(); err != nil {
-			logger.Warn("failed to persist dedup index", "error", err)
+			logger.Warn(msgDedupIndexPersistFailed, "error", err)
 		}
 	}
 
@@ -568,7 +571,7 @@ func (fs *FileStore) DeleteMedia(ctx context.Context, reference storage.Referenc
 
 		// Persist index (skips write if not dirty)
 		if err := fs.saveDedupIndex(); err != nil {
-			logger.Warn("failed to persist dedup index", "error", err)
+			logger.Warn(msgDedupIndexPersistFailed, "error", err)
 		}
 	}
 

--- a/server/a2a/server.go
+++ b/server/a2a/server.go
@@ -61,6 +61,27 @@ const (
 	evictionInterval = 1 * time.Minute
 )
 
+// HTTP header names and values used across the JSON-RPC and SSE handlers.
+const (
+	headerContentType  = "Content-Type"
+	headerCacheControl = "Cache-Control"
+	headerConnection   = "Connection"
+
+	contentTypeJSON = "application/json"
+	contentTypeSSE  = "text/event-stream"
+
+	cacheControlNoCache = "no-cache"
+	connectionKeepAlive = "keep-alive"
+)
+
+// Error messages returned to clients. Kept here so the same wording is used
+// everywhere a given condition is reported.
+const (
+	msgInternalServerError = "internal server error"
+	msgInvalidParams       = "Invalid params"
+	msgStreamingNotSupport = "Streaming not supported"
+)
+
 // Authenticator validates incoming requests. Return a non-nil error to reject.
 type Authenticator interface {
 	Authenticate(r *http.Request) error
@@ -363,7 +384,7 @@ func (s *Server) Serve(ln net.Listener) error {
 // handleHealthz is a liveness probe: it returns 200 whenever the HTTP server
 // is accepting connections.
 func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, contentTypeJSON)
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
@@ -371,7 +392,7 @@ func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
 // to accept traffic and 503 otherwise. It checks the isReady flag and all
 // registered health checkers.
 func (s *Server) handleReadyz(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, contentTypeJSON)
 
 	if !s.isReady.Load() {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -418,7 +439,7 @@ func (s *Server) handleReadyz(w http.ResponseWriter, r *http.Request) {
 // handleAgentCard serves the agent card as JSON.
 func (s *Server) handleAgentCard(w http.ResponseWriter, r *http.Request) {
 	if s.cardProvider == nil {
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(headerContentType, contentTypeJSON)
 		_ = json.NewEncoder(w).Encode(a2a.AgentCard{})
 		return
 	}
@@ -428,7 +449,7 @@ func (s *Server) handleAgentCard(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, contentTypeJSON)
 	_ = json.NewEncoder(w).Encode(card)
 }
 
@@ -473,7 +494,7 @@ func (s *Server) handleRPC(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request, req *a2a.JSONRPCRequest) {
 	var params a2a.SendMessageRequest
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		writeRPCError(w, req.ID, -32602, "Invalid params")
+		writeRPCError(w, req.ID, -32602, msgInvalidParams)
 		return
 	}
 
@@ -485,7 +506,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request, req *
 	conv, err := s.getOrCreateConversation(contextID)
 	if err != nil {
 		log.Printf("a2a: failed to open conversation for context %s: %v", contextID, err)
-		writeRPCError(w, req.ID, -32000, "internal server error")
+		writeRPCError(w, req.ID, -32000, msgInternalServerError)
 		return
 	}
 
@@ -505,7 +526,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request, req *
 	taskID := generateID()
 	if _, createErr := s.taskStore.Create(taskID, contextID); createErr != nil {
 		log.Printf("a2a: failed to create task for context %s: %v", contextID, createErr)
-		writeRPCError(w, req.ID, -32000, "internal server error")
+		writeRPCError(w, req.ID, -32000, msgInternalServerError)
 		return
 	}
 
@@ -528,7 +549,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request, req *
 	task, err := s.taskStore.Get(taskID)
 	if err != nil {
 		log.Printf("a2a: failed to retrieve task %s after processing: %v", taskID, err)
-		writeRPCError(w, req.ID, -32000, "internal server error")
+		writeRPCError(w, req.ID, -32000, msgInternalServerError)
 		return
 	}
 	writeRPCResult(w, req.ID, task)
@@ -582,7 +603,7 @@ func (s *Server) handleToolResultMessage(
 		} else {
 			if err := resumable.SendToolResult(tr.CallID, tr.Result); err != nil {
 				log.Printf("a2a: failed to submit tool result %s: %v", tr.CallID, err)
-				writeRPCError(w, req.ID, -32000, "internal server error")
+				writeRPCError(w, req.ID, -32000, msgInternalServerError)
 				return
 			}
 		}
@@ -591,7 +612,7 @@ func (s *Server) handleToolResultMessage(
 	taskID := generateID()
 	if _, err := s.taskStore.Create(taskID, contextID); err != nil {
 		log.Printf("a2a: failed to create task for context %s: %v", contextID, err)
-		writeRPCError(w, req.ID, -32000, "internal server error")
+		writeRPCError(w, req.ID, -32000, msgInternalServerError)
 		return
 	}
 
@@ -613,7 +634,7 @@ func (s *Server) handleToolResultMessage(
 	task, err := s.taskStore.Get(taskID)
 	if err != nil {
 		log.Printf("a2a: failed to retrieve task %s after processing: %v", taskID, err)
-		writeRPCError(w, req.ID, -32000, "internal server error")
+		writeRPCError(w, req.ID, -32000, msgInternalServerError)
 		return
 	}
 	writeRPCResult(w, req.ID, task)
@@ -769,7 +790,7 @@ func buildPendingToolsMessage(resp SendResult) *a2a.Message {
 func (s *Server) handleGetTask(w http.ResponseWriter, req *a2a.JSONRPCRequest) {
 	var params a2a.GetTaskRequest
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		writeRPCError(w, req.ID, -32602, "Invalid params")
+		writeRPCError(w, req.ID, -32602, msgInvalidParams)
 		return
 	}
 
@@ -787,7 +808,7 @@ func (s *Server) handleGetTask(w http.ResponseWriter, req *a2a.JSONRPCRequest) {
 func (s *Server) handleCancelTask(w http.ResponseWriter, req *a2a.JSONRPCRequest) {
 	var params a2a.CancelTaskRequest
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		writeRPCError(w, req.ID, -32602, "Invalid params")
+		writeRPCError(w, req.ID, -32602, msgInvalidParams)
 		return
 	}
 
@@ -808,7 +829,7 @@ func (s *Server) handleCancelTask(w http.ResponseWriter, req *a2a.JSONRPCRequest
 	task, err := s.taskStore.Get(params.ID)
 	if err != nil {
 		log.Printf("a2a: failed to retrieve task %s after cancel: %v", params.ID, err)
-		writeRPCError(w, req.ID, -32000, "internal server error")
+		writeRPCError(w, req.ID, -32000, msgInternalServerError)
 		return
 	}
 	writeRPCResult(w, req.ID, task)
@@ -818,7 +839,7 @@ func (s *Server) handleCancelTask(w http.ResponseWriter, req *a2a.JSONRPCRequest
 func (s *Server) handleListTasks(w http.ResponseWriter, req *a2a.JSONRPCRequest) {
 	var params a2a.ListTasksRequest
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		writeRPCError(w, req.ID, -32602, "Invalid params")
+		writeRPCError(w, req.ID, -32602, msgInvalidParams)
 		return
 	}
 
@@ -884,7 +905,7 @@ func writeRPCResult(w http.ResponseWriter, id, result any) {
 		writeRPCError(w, id, -32603, "Internal error: failed to encode result")
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, contentTypeJSON)
 	_ = json.NewEncoder(w).Encode(a2a.JSONRPCResponse{
 		JSONRPC: "2.0",
 		ID:      id,
@@ -894,7 +915,7 @@ func writeRPCResult(w http.ResponseWriter, id, result any) {
 
 // writeRPCError writes a JSON-RPC 2.0 error response.
 func writeRPCError(w http.ResponseWriter, id any, code int, msg string) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, contentTypeJSON)
 	_ = json.NewEncoder(w).Encode(a2a.JSONRPCResponse{
 		JSONRPC: "2.0",
 		ID:      id,
@@ -904,7 +925,7 @@ func writeRPCError(w http.ResponseWriter, id any, code int, msg string) {
 
 // writeRPCErrorWithStatus writes a JSON-RPC 2.0 error response with a specific HTTP status code.
 func writeRPCErrorWithStatus(w http.ResponseWriter, status int, id any, code int, msg string) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, contentTypeJSON)
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(a2a.JSONRPCResponse{
 		JSONRPC: "2.0",

--- a/server/a2a/server_stream.go
+++ b/server/a2a/server_stream.go
@@ -227,7 +227,7 @@ func (s *Server) handleStreamMessage(
 ) {
 	var params a2a.SendMessageRequest
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		writeRPCError(w, req.ID, -32602, "Invalid params")
+		writeRPCError(w, req.ID, -32602, msgInvalidParams)
 		return
 	}
 
@@ -272,14 +272,14 @@ func (s *Server) handleStreamMessage(
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		writeRPCError(w, req.ID, -32000, "Streaming not supported")
+		writeRPCError(w, req.ID, -32000, msgStreamingNotSupport)
 		return
 	}
 
 	// Set SSE headers.
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set(headerContentType, contentTypeSSE)
+	w.Header().Set(headerCacheControl, cacheControlNoCache)
+	w.Header().Set(headerConnection, connectionKeepAlive)
 
 	sc := &streamCtx{
 		srv:       s,
@@ -345,13 +345,13 @@ func (s *Server) handleStreamToolResultMessage(
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		writeRPCError(w, req.ID, -32000, "Streaming not supported")
+		writeRPCError(w, req.ID, -32000, msgStreamingNotSupport)
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set(headerContentType, contentTypeSSE)
+	w.Header().Set(headerCacheControl, cacheControlNoCache)
+	w.Header().Set(headerConnection, connectionKeepAlive)
 
 	sc := &streamCtx{
 		srv:       s,
@@ -509,7 +509,7 @@ func (sc *streamCtx) emitArtifact(idx int, parts []a2a.Part) {
 func (s *Server) handleTaskSubscribe(w http.ResponseWriter, r *http.Request, req *a2a.JSONRPCRequest) {
 	var params a2a.SubscribeTaskRequest
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		writeRPCError(w, req.ID, -32602, "Invalid params")
+		writeRPCError(w, req.ID, -32602, msgInvalidParams)
 		return
 	}
 
@@ -528,14 +528,14 @@ func (s *Server) handleTaskSubscribe(w http.ResponseWriter, r *http.Request, req
 
 		flusher, ok := w.(http.Flusher)
 		if !ok {
-			writeRPCError(w, req.ID, -32000, "Streaming not supported")
+			writeRPCError(w, req.ID, -32000, msgStreamingNotSupport)
 			return
 		}
 
 		// Task exists but no active stream. Send its current status.
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.Header().Set("Cache-Control", "no-cache")
-		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set(headerContentType, contentTypeSSE)
+		w.Header().Set(headerCacheControl, cacheControlNoCache)
+		w.Header().Set(headerConnection, connectionKeepAlive)
 
 		writeSSE(w, flusher, req.ID, a2a.TaskStatusUpdateEvent{
 			TaskID:    task.ID,
@@ -547,13 +547,13 @@ func (s *Server) handleTaskSubscribe(w http.ResponseWriter, r *http.Request, req
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		writeRPCError(w, req.ID, -32000, "Streaming not supported")
+		writeRPCError(w, req.ID, -32000, msgStreamingNotSupport)
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set(headerContentType, contentTypeSSE)
+	w.Header().Set(headerCacheControl, cacheControlNoCache)
+	w.Header().Set(headerConnection, connectionKeepAlive)
 
 	ch, subID, subErr := broadcaster.subscribe()
 	if subErr != nil {

--- a/server/a2a/server_stream.go
+++ b/server/a2a/server_stream.go
@@ -12,6 +12,15 @@ import (
 	"github.com/AltairaLabs/PromptKit/runtime/types"
 )
 
+// setSSEHeaders writes the header set every SSE response needs. The four
+// streaming handlers all opened with the same three Set calls; naming the
+// sequence once keeps them from drifting apart.
+func setSSEHeaders(w http.ResponseWriter) {
+	w.Header().Set(headerContentType, contentTypeSSE)
+	w.Header().Set(headerCacheControl, cacheControlNoCache)
+	w.Header().Set(headerConnection, connectionKeepAlive)
+}
+
 // subscriberBuffer is the channel buffer size for broadcast subscribers.
 const subscriberBuffer = 64
 
@@ -277,9 +286,7 @@ func (s *Server) handleStreamMessage(
 	}
 
 	// Set SSE headers.
-	w.Header().Set(headerContentType, contentTypeSSE)
-	w.Header().Set(headerCacheControl, cacheControlNoCache)
-	w.Header().Set(headerConnection, connectionKeepAlive)
+	setSSEHeaders(w)
 
 	sc := &streamCtx{
 		srv:       s,
@@ -349,9 +356,7 @@ func (s *Server) handleStreamToolResultMessage(
 		return
 	}
 
-	w.Header().Set(headerContentType, contentTypeSSE)
-	w.Header().Set(headerCacheControl, cacheControlNoCache)
-	w.Header().Set(headerConnection, connectionKeepAlive)
+	setSSEHeaders(w)
 
 	sc := &streamCtx{
 		srv:       s,
@@ -533,9 +538,7 @@ func (s *Server) handleTaskSubscribe(w http.ResponseWriter, r *http.Request, req
 		}
 
 		// Task exists but no active stream. Send its current status.
-		w.Header().Set(headerContentType, contentTypeSSE)
-		w.Header().Set(headerCacheControl, cacheControlNoCache)
-		w.Header().Set(headerConnection, connectionKeepAlive)
+		setSSEHeaders(w)
 
 		writeSSE(w, flusher, req.ID, a2a.TaskStatusUpdateEvent{
 			TaskID:    task.ID,
@@ -551,9 +554,7 @@ func (s *Server) handleTaskSubscribe(w http.ResponseWriter, r *http.Request, req
 		return
 	}
 
-	w.Header().Set(headerContentType, contentTypeSSE)
-	w.Header().Set(headerCacheControl, cacheControlNoCache)
-	w.Header().Set(headerConnection, connectionKeepAlive)
+	setSSEHeaders(w)
 
 	ch, subID, subErr := broadcaster.subscribe()
 	if subErr != nil {


### PR DESCRIPTION
Clears **all sixteen** open `go:S1192` findings — the duplicated-literal half of SonarCloud's 59 CRITICAL code smells, taking the count **59 → 43**.

Pure extraction. Every literal keeps its exact value, so nothing behavioural moves.

## server/a2a — ten of the sixteen

They were spread across `server.go` and `server_stream.go`, so they become two package-level const blocks rather than per-file ones:

| | |
|---|---|
| **Header names / values** | `Content-Type`, `application/json`, `text/event-stream`, `no-cache`, `Cache-Control`, `keep-alive` |
| **Client-facing errors** | `internal server error`, `Invalid params`, `Streaming not supported` |

**One addition beyond what Sonar flagged:** `"Connection"` is folded in with the other header names. Sonar hadn't flagged it only because it appears four times rather than five — leaving it as the single bare literal sitting between `headerContentType` and `headerCacheControl` would read worse than the problem being fixed.

## The remaining six — one const each

| File | Literal | × |
|---|---|---|
| `runtime/media/audio_converter.go` | `-acodec` | 5 |
| `runtime/deploy/adaptersdk/serve.go` | `method not found: ` | 3 |
| `pkg/config/schema_validator.go` | `file://` | 3 |
| `runtime/storage/local/filestore.go` | `failed to persist dedup index` | 3 |
| `runtime/storage/instrumented.go` | `media.reference` | 4 |
| `runtime/providers/provider_contract_integration.go` | `Provider doesn't implement ToolSupport` | 6 |

## What is deliberately NOT here

The **43 `go:S3776` cognitive-complexity findings.** Those want restructuring of the duplex pipeline stages (complexity 46), the provider streaming paths (`claude_streaming.go` 49, `vllm_tools.go` 42), the tool validator (46) and `sdk.go` (37). That is not work to do immediately before a 31-commit release — it is how a clean release becomes a bad one. They are all months old and are not getting worse by waiting.

One of them does deserve follow-up on its own merits: `runtime/providers/registry.go:320` (`CreateProviderFromSpec`, complexity 30) is the function whose skipped defaulting switch caused #1811. Its complexity is plausibly *why* that bug was possible — but for exactly that reason it wants a careful PR with tests, not a pre-release tidy.

## Verification

- `gofmt` clean on all eight changed files
- All four modules build; affected packages test green
- `golangci-lint run --new-from-rev=HEAD` — **0 issues** (it caught a British spelling in one of my new doc comments, now fixed)
- Pre-commit hook passed in full; changed-file coverage 80.5%–95.1%, all above the 80% gate
