### PR TITLE
test(events): join the playback goroutine before sampling the counter

### DIFF
--- a/runtime/events/player_test.go
+++ b/runtime/events/player_test.go
@@ -192,6 +192,13 @@ func TestSessionPlayer_PauseResume(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	player.Pause()
 
+	// Pause cancels the playback context but does not join the playback
+	// goroutine — that is what Wait is for. A goroutine already past the
+	// context check in playbackLoop still delivers its event, so sampling the
+	// counter straight after Pause races with that last delivery and reads one
+	// too few. Join first, then sample.
+	player.Wait()
+
 	mu.Lock()
 	countAtPause := eventCount
 	mu.Unlock()


### PR DESCRIPTION
Fixes the intermittent `-race` failure that turned #1813's CI red — `TestSessionPlayer_PauseResume` asserting at `player_test.go:206` and reading `2` where it expected `3`.

## Mechanism

`playbackLoop` checks the context and *then* delivers:

```go
select {
case <-ctx.Done():
    return          // ← Pause's cancel is observed here...
default:
}

if !p.deliverEvent(info) {   // ← ...but a loop already past it still delivers
```

`Pause()` cancels that context and returns immediately — it never joins the goroutine. The test sampled `eventCount` on the very next line, racing with that last in-flight delivery. `-race` slows everything and widens the window, which is why it showed up in CI and not locally.

## Why this is a test fix, not a code fix

The two doc comments settle it:

- `// Pause pauses playback.` — promises nothing about in-flight callbacks
- `// Wait blocks until playback completes or is stopped.` — **this** is the documented join

The test was asserting a property the API does not offer. It now calls `Wait()` before sampling. **No shipped code changes.**

## Evidence

Same 10× parallel `-race` load, 30 runs each:

| | failures |
|---|---|
| unfixed | **1/30** |
| fixed | **0/30** |

That margin alone is not conclusive — I'm not claiming it is. The mechanism above is the real evidence; these numbers corroborate it. (Quiet single-threaded runs pass either way, 0/25, which is why the isolated re-run I tried first was a useless check.)

## The API question this leaves open

Should `Pause()` be synchronous with in-flight callbacks? Reasonable people would say yes. But it **cannot** simply wait on `p.done`, because `playbackLoop` itself calls `Stop()` on delivery failure (`player.go:429`) — giving `Stop` the same treatment would deadlock a goroutine against itself, and the two methods should behave consistently.

So it needs a different mechanism (a generation counter, or a state re-check under `p.mu` immediately before invoking the callback). That is a real change to concurrency semantics in shipped code, and doing it while a 31-commit release is being prepared is exactly the risk I'd argue against — same reasoning as deferring the S3776 refactors in #1815. Happy to open an issue for it to be decided after v1.6.0.
