### PR TITLE
test(openai): skip Azure embedding tests where no embedding model is deployed

### DIFF
--- a/runtime/providers/openai/embedding_azure_integration_test.go
+++ b/runtime/providers/openai/embedding_azure_integration_test.go
@@ -11,7 +11,7 @@
 // Run locally against the demo resource:
 //
 //	az login --scope https://cognitiveservices.azure.com/.default
-//	export AZURE_OPENAI_ENDPOINT=https://aoai-omnia-demo-33eebkdcvsi4a.cognitiveservices.azure.com
+//	export AZURE_OPENAI_ENDPOINT=https://aoai-omnia-demo-2cbltt3edbpwa.cognitiveservices.azure.com
 //	export AZURE_OPENAI_EMBEDDING_DEPLOYMENT=text-embedding-3-small
 //	go test -tags=integration ./runtime/providers/openai/... -run AzureEmbedding -v
 //
@@ -23,11 +23,31 @@ package openai
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/AltairaLabs/PromptKit/runtime/credentials"
 	"github.com/AltairaLabs/PromptKit/runtime/providers"
 )
+
+// skipIfDeploymentMissing turns Azure's DeploymentNotFound into a skip.
+//
+// An Azure OpenAI account only serves the models actually deployed on it, and
+// an embedding model is not present on every resource — the chat-only Foundry
+// resource used elsewhere in this package has no text-embedding deployment at
+// all. That is a property of the target account, not a defect, and it is the
+// same reason skipIfNoAzure exists: these tests are gated on what the
+// environment provides.
+//
+// Only DeploymentNotFound is treated this way. Any other failure against a
+// deployment that does exist is a real one and still fails the test.
+func skipIfDeploymentMissing(t *testing.T, err error) {
+	t.Helper()
+	if err != nil && strings.Contains(err.Error(), "DeploymentNotFound") {
+		t.Skipf("embedding deployment %q is not provisioned on %s — set AZURE_OPENAI_EMBEDDING_DEPLOYMENT to one that is",
+			azureEmbeddingDeployment(), azureEndpoint())
+	}
+}
 
 // azureEmbeddingDeployment returns the embedding deployment to address. Azure
 // routes by deployment name, not model name. Defaults to the demo resource's
@@ -98,6 +118,7 @@ func TestAzureEmbedding_Embed(t *testing.T) {
 		Texts: []string{"PromptKit keyless Azure embedding works."},
 	})
 	if err != nil {
+		skipIfDeploymentMissing(t, err)
 		t.Fatalf("Embed failed against live Azure: %v", err)
 	}
 
@@ -139,6 +160,7 @@ func TestAzureEmbedding_BatchEmbed(t *testing.T) {
 	texts := []string{"first document", "second document", "third document"}
 	resp, err := emb.Embed(ctx, providers.EmbeddingRequest{Texts: texts})
 	if err != nil {
+		skipIfDeploymentMissing(t, err)
 		t.Fatalf("batch Embed failed against live Azure: %v", err)
 	}
 


### PR DESCRIPTION
Running `go test -tags=integration ./runtime/providers/openai/... -run Azure` against a chat-only Azure resource failed two tests with a 404 `DeploymentNotFound` for `text-embedding-3-small`.

That is a property of the target account, not a defect. An Azure OpenAI account only serves the models actually deployed on it, and the Foundry resource this package's *chat* tests target has no embedding deployment at all — only `gpt-4-1-mini`, `gpt-4o-mini-tts`, `gpt-4o-mini-transcribe` and `whisper`. It is the same reason `skipIfNoAzure` already exists: these tests are gated on what the environment actually provides.

## The guard is deliberately narrow

Only `DeploymentNotFound` skips. Anything else against a deployment that *does* exist is a real failure and still fails the test.

I verified both directions against live resources rather than assuming:

| Resource | Has embedding model? | Result |
|---|---|---|
| `aif-promptkit-fbe46f` (Foundry, chat-only) | no | **SKIP** — names the deployment and endpoint |
| `aoai-omnia-demo-2cbltt3edbpwa` | yes (`text-embedding-3-small`) | **did NOT skip** — ran and failed |

The second case is the important one: it proves this isn't a blanket skip. It ran, and surfaced a genuine problem that would otherwise have been masked.

## ⚠️ What the second run found

Against the resource that *does* have the deployment, both tests fail with **401 PermissionDenied**:

```
The principal `<user>` lacks the required data action
`Microsoft.CognitiveServices/accounts/OpenAI/deployments/embeddings/action`
```

That's an RBAC gap on `aoai-omnia-demo-2cbltt3edbpwa`, not a code problem — the signed-in principal can call chat but not embeddings. Granting `Cognitive Services OpenAI User` on that account would let this suite actually exercise the keyless embedding path end-to-end. Left as-is deliberately: a permissions failure should stay visible, and changing cloud IAM isn't something to slip into a test PR.

## Also

Corrected the endpoint in the run instructions — it named `aoai-omnia-demo-33eebkdcvsi4a`, which no longer exists.

## Verification

- `gofmt` clean, `golangci-lint --new-from-rev --build-tags=integration` — 0 issues
- Pre-commit hook passed in full
- Test-only change; no shipped code touched
