### PR TITLE
docs(credentials): stop the Azure example URL rendering as a live link

### DIFF
--- a/runtime/credentials/azure.go
+++ b/runtime/credentials/azure.go
@@ -26,11 +26,15 @@ const azureDeploymentPath = "/openai/deployments/"
 // The returned URL does NOT include the API path (/chat/completions) or
 // api-version query param — the provider appends those per-request.
 //
-// endpoint is normally an account host (https://acct.openai.azure.com), which
-// gets the deployment path appended. An endpoint that already addresses a
-// deployment is returned as-is instead of having a second deployment path
-// stacked onto it, so a caller that passes a full deployment URL still ends up
-// with a usable base.
+// endpoint is normally an account host, which gets the deployment path
+// appended:
+//
+//	https://<resource>.openai.azure.com
+//	  -> https://<resource>.openai.azure.com/openai/deployments/<deployment>
+//
+// An endpoint that already addresses a deployment is returned as-is instead of
+// having a second deployment path stacked onto it, so a caller that passes a
+// full deployment URL still ends up with a usable base.
 func AzureOpenAIEndpoint(endpoint, deployment string) string {
 	trimmed := strings.TrimRight(endpoint, "/")
 	if strings.Contains(trimmed, azureDeploymentPath) {


### PR DESCRIPTION
Fixes a docs-site link failure I introduced in #1813.

That PR's doc comment wrote the example endpoint inline as `(https://acct.openai.azure.com)`. The reference generator escapes the closing paren, so the rendered href became `https://acct.openai.azure.com\` — percent-encoded to `%5C` — and the link checker failed it:

```
❌ Found 1 broken links (1 unique URLs)
🌐 EXTERNAL BROKEN LINKS (1):
  [404] https://acct.openai.azure.com%5C
      Found on: /api/runtime/
```

## Why it wasn't caught when #1813 merged

Two things had to line up:

1. The generated API reference is **gitignored** (`docs/.gitignore: src/content/docs/api/`) and rebuilt from Go source at deploy time — so the `Reference Drift` check, which compares *committed* pages, saw nothing.
2. `docs.yml` only runs for changes under `docs/`, and #1813 touched none.

It surfaced on #1814, the dependency batch, purely because that touches `docs/package-lock.json` and so triggered the docs workflow.

## The fix

Move the example into an indented block so it renders as a code sample rather than prose, and use `<resource>` instead of a concrete host so it reads as a placeholder:

```go
// endpoint is normally an account host, which gets the deployment path
// appended:
//
//	https://<resource>.openai.azure.com
//	  -> https://<resource>.openai.azure.com/openai/deployments/<deployment>
```

This is how the equivalent URL in `sdk/options.go` has always avoided the problem — it sits inside an indented `sdk.WithAzure(...)` example, so it is never linkified.

## Verification

Ran the CI sequence locally — `make docs-build`, then grepped the built output:

- `acct.openai.azure.com` no longer appears **anywhere** in `docs/dist/`
- The paragraph on `/api/runtime/` now renders with the URLs inside a code block

This unblocks the docs deploy on #1814.
