### PR TITLE
ci(docs): pin setup-node to the commit v7.0.0 actually tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
       - name: Setup Node.js
-        uses: actions/setup-node@e51e5fe84fc33b4c73ebe40526b2694712b5b858 # v6.1.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
Closes #1798.

`docs.yml` pinned `actions/setup-node@e51e5fe` with the comment `# v6.1.0`. **That comment was wrong.**

| | Commit | Date | What it is |
|---|---|---|---|
| Real `v6.1.0` tag | `395ad32` | Dec 2025 | the actual release |
| **Was pinned** | `e51e5fe` | Jul 2026 | 33 commits past v6.1.0 — untagged main |
| Dependabot proposed | `3d7870f` | Aug 2026 | 10 commits past **v7.0.0** — also untagged |
| **Now pinned** | `8207627` | Jul 2026 | ✅ the commit `v7.0.0` tags |

So the workflow claimed a released version while running development code, and #1798 would have moved it to *different* development code while keeping the same misleading `# v6.1.0` label.

Pinning a SHA is only worth doing if the SHA is one somebody chose deliberately. This pins the commit `v7.0.0` genuinely tags, and labels it accordingly.

## Is v7.0.0 safe here?

Yes. Its release notes list no breaking changes to inputs, and the three this workflow uses — `node-version`, `cache`, `cache-dependency-path` — are unchanged. The "Migrate to ESM" item is internal to the action. This is the **only** `setup-node` usage in the repo.

## The other seven pins are fine

Checked every pinned action against the tag its comment names:

```
OK  actions/checkout               v7.0.1
OK  actions/configure-pages        v6.0.0
OK  actions/deploy-pages           v5.0.0
OK  actions/download-artifact      v7.0.0
OK  actions/setup-go               v7.0.0
OK  actions/upload-artifact        v7.0.1
OK  actions/upload-pages-artifact  v5.0.0
```

`setup-node` was the only one that had drifted. All eight now match.
